### PR TITLE
Revise website positioning for launch

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -33,7 +33,7 @@ const principles = [
 
 const focusAreas = [
   'Helping teams place a security gateway in front of external model providers',
-  'Making pilot deployments easier to validate with health and readiness checks',
+  'Making production rollouts easier to validate with health and readiness checks',
   'Building toward stronger production controls, including immutable evidence paths',
 ] as const
 
@@ -81,7 +81,7 @@ export default function AboutPage() {
                   NeutralAI is being shaped as a gateway layer that stands between customer applications, browser-based AI usage, and external model providers. The goal is straightforward: let teams adopt AI while applying policy before sensitive data moves beyond the trusted boundary.
                 </p>
                 <p>
-                  That means the product story has to stay credible. We prefer explicit launch posture, beta-oriented onboarding, and visible hardening milestones over generic enterprise promises.
+                  That means the product story has to stay credible. We prefer clear operating posture, guided onboarding, and visible hardening milestones over generic enterprise promises.
                 </p>
               </div>
             </motion.div>
@@ -148,7 +148,7 @@ export default function AboutPage() {
           >
             <h2 className="font-heading text-3xl font-bold md:text-4xl">Want to evaluate the gateway?</h2>
             <p className="mt-5 text-lg text-slate-400">
-              The best next step is a pilot conversation that matches your current deployment stage, browser-extension needs, and review requirements.
+              The best next step is a rollout conversation that matches your current deployment stage, browser-extension needs, and review requirements.
             </p>
             <a href="/contact" className="btn btn-cta mt-8 px-8 py-4 text-lg">
               Contact NeutralAI

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,0 +1,178 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import {
+  ArrowRight,
+  BadgeCheck,
+  CheckCircle2,
+  ClipboardCheck,
+  KeyRound,
+  Lock,
+  ShieldCheck,
+  XCircle,
+} from 'lucide-react'
+import BackButton from '../components/BackButton'
+import { siteConfig } from '../site'
+
+export const metadata: Metadata = {
+  title: 'Compare NeutralAI',
+  description:
+    'A feature-based comparison of NeutralAI against do-it-yourself PII masking for regulated AI workflows.',
+  alternates: {
+    canonical: '/compare',
+  },
+}
+
+const comparisonRows = [
+  {
+    capability: 'Prompt PII detection',
+    diy: 'Possible with open-source primitives, but calibration, testing, and maintenance stay with your team.',
+    neutralai: 'Built into the gateway with entity coverage, policy controls, and benchmark evidence.',
+  },
+  {
+    capability: 'Reversible tokenization',
+    diy: 'Requires a secure vault, cryptography choices, authorization checks, and audit trails.',
+    neutralai: 'Encrypted token vault designed for governed restore paths and compliance review.',
+  },
+  {
+    capability: 'Compliance evidence',
+    diy: 'Usually assembled manually from logs, screenshots, and after-the-fact explanations.',
+    neutralai: 'Control events, health checks, and benchmark artifacts are designed to support audit conversations.',
+  },
+  {
+    capability: 'Browser AI protection',
+    diy: 'Needs extension engineering, store review, provider-specific DOM handling, and rollout support.',
+    neutralai: 'Chrome and Edge extension paths are part of the product surface.',
+  },
+  {
+    capability: 'Deployment model',
+    diy: 'You own every production hardening and hosting decision.',
+    neutralai: 'Managed SaaS, private cloud, and on-prem rollout paths are available for different risk postures.',
+  },
+] as const
+
+const proofPoints = [
+  {
+    icon: ShieldCheck,
+    title: 'Gateway boundary',
+    body: 'NeutralAI sits before the model provider so policy can run before sensitive values leave the workflow.',
+  },
+  {
+    icon: KeyRound,
+    title: 'Token vault',
+    body: 'Sensitive values can be transformed into governed references instead of being sent as raw text.',
+  },
+  {
+    icon: ClipboardCheck,
+    title: 'Audit story',
+    body: 'Operational evidence and benchmark artifacts give buyers something concrete to review.',
+  },
+] as const
+
+export default function ComparePage() {
+  return (
+    <main className="min-h-screen pt-24">
+      <section className="relative overflow-hidden py-20">
+        <div className="absolute inset-0 grid-bg opacity-30" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(6,182,212,0.18),transparent_30%),radial-gradient(circle_at_bottom_right,rgba(249,115,22,0.16),transparent_26%)]" />
+
+        <div className="container-custom relative z-10">
+          <BackButton />
+
+          <div className="mx-auto max-w-4xl text-center">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Build vs Buy</p>
+            <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
+              More than a PII detector. A control layer your buyers can approve.
+            </h1>
+            <p className="mt-6 text-xl leading-8 text-slate-400">
+              Open-source detection is a useful ingredient. Regulated AI adoption needs the rest of the operating model:
+              vaulting, policy enforcement, browser coverage, telemetry, and evidence.
+            </p>
+            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+              <Link href={siteConfig.signupUrl} className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto">
+                Try Free
+                <ArrowRight className="h-5 w-5" />
+              </Link>
+              <Link href="/contact" className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto">
+                Talk to Sales
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container-custom">
+          <div className="grid gap-6 lg:grid-cols-3">
+            {proofPoints.map((point) => (
+              <div key={point.title} className="accent-card rounded-[24px] p-6">
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10">
+                  <point.icon className="h-6 w-6 text-primary-light" />
+                </div>
+                <h2 className="mt-5 font-heading text-2xl font-semibold">{point.title}</h2>
+                <p className="mt-3 text-sm leading-6 text-slate-300">{point.body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="section bg-background-secondary">
+        <div className="container-custom">
+          <div className="mx-auto max-w-3xl text-center">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Feature Comparison</p>
+            <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
+              The hard part is not masking once. It is making it safe to operate.
+            </h2>
+          </div>
+
+          <div className="mt-10 overflow-hidden rounded-[28px] border border-white/10 bg-background/80">
+            <div className="grid border-b border-white/10 bg-white/[0.04] text-sm font-semibold text-slate-200 md:grid-cols-[0.8fr_1fr_1fr]">
+              <div className="px-5 py-4">Capability</div>
+              <div className="px-5 py-4">DIY detector path</div>
+              <div className="px-5 py-4">NeutralAI</div>
+            </div>
+            {comparisonRows.map((row) => (
+              <div key={row.capability} className="grid border-b border-white/10 last:border-b-0 md:grid-cols-[0.8fr_1fr_1fr]">
+                <div className="px-5 py-5 font-heading text-lg font-semibold text-white">{row.capability}</div>
+                <div className="flex gap-3 px-5 py-5 text-sm leading-6 text-slate-400">
+                  <XCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-[#fdba74]" />
+                  <span>{row.diy}</span>
+                </div>
+                <div className="flex gap-3 px-5 py-5 text-sm leading-6 text-slate-200">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 flex-shrink-0 text-primary-light" />
+                  <span>{row.neutralai}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-8 rounded-[24px] border border-primary/20 bg-primary/10 p-5 text-sm leading-7 text-slate-200">
+            <BadgeCheck className="mb-3 h-5 w-5 text-primary-light" />
+            NeutralAI uses proven detection primitives where they make sense, but the product value is the full compliance
+            gateway around them: policy, vaulting, evidence, deployment, and browser coverage.
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container-custom">
+          <div className="mx-auto max-w-4xl rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.95),rgba(2,6,23,0.97)),radial-gradient(circle_at_top_right,rgba(249,115,22,0.16),transparent_22%)] px-6 py-10 text-center md:px-10">
+            <Lock className="mx-auto h-9 w-9 text-primary-light" />
+            <h2 className="mt-5 font-heading text-3xl font-bold md:text-5xl">Give security a reason to say yes.</h2>
+            <p className="mx-auto mt-5 max-w-2xl text-lg text-slate-300">
+              Start with the managed product, then choose the deployment model that fits your governance needs.
+            </p>
+            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+              <Link href={siteConfig.signupUrl} className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto">
+                Try Free
+              </Link>
+              <Link href="/contact" className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto">
+                Plan Enterprise Rollout
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -8,12 +8,14 @@ const productLinks = [
   { label: 'Problem', href: homeSections.problem },
   { label: 'How It Works', href: homeSections.howItWorks },
   { label: 'Why Trust Us', href: homeSections.trust },
+  { label: 'Compare', href: homeSections.compare },
   { label: 'Pricing', href: homeSections.pricing },
 ] as const
 
 const launchLinks = [
   { label: 'API Health', href: siteConfig.apiHealthUrl },
   { label: 'Readiness Check', href: siteConfig.apiReadyUrl },
+  { label: 'Try Free', href: siteConfig.signupUrl },
   { label: 'Install Extension', href: '/install-extension' },
   { label: 'Extension Support', href: '/support/browser-extension' },
 ] as const
@@ -64,7 +66,7 @@ export default function Footer() {
             </p>
             <div className="mt-3 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[11px] text-primary-light">
               <span className="h-2 w-2 rounded-full bg-accent-success animate-pulse" />
-              Public beta with live health endpoints
+              Live and operational
             </div>
           </div>
 
@@ -107,8 +109,8 @@ export default function Footer() {
             © {new Date().getFullYear()} NeutralAI Ltd. Built for security-conscious AI adoption.
           </p>
           <div className="flex flex-col gap-2 text-sm text-slate-500 md:flex-row md:flex-wrap md:items-center md:justify-end md:gap-4">
-            <a href={contactLinks.betaAccessMailto} className="hover:text-primary transition-colors">
-              {siteConfig.contactEmail}
+            <a href={contactLinks.demoMailto} className="hover:text-primary transition-colors">
+              {siteConfig.salesEmail}
             </a>
             <a href={contactLinks.supportMailto} className="hover:text-primary transition-colors">
               {siteConfig.supportEmail}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -5,12 +5,13 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { motion } from 'framer-motion'
 import { Menu, X } from 'lucide-react'
-import { homeSections } from '../site'
+import { homeSections, siteConfig } from '../site'
 
 const navLinks = [
   { name: 'Problem', href: homeSections.problem },
   { name: 'How It Works', href: homeSections.howItWorks },
   { name: 'Why Trust Us', href: homeSections.trust },
+  { name: 'Compare', href: homeSections.compare },
   { name: 'Pricing', href: homeSections.pricing },
   { name: 'About', href: '/about' },
 ]
@@ -51,8 +52,8 @@ export default function Navbar() {
           <Link href="/contact" className="text-slate-300 hover:text-white transition-colors">
             Contact
           </Link>
-          <Link href="/install-extension" className="btn btn-cta">
-            Install Extension
+          <Link href={siteConfig.signupUrl} className="btn btn-cta">
+            Try Free
           </Link>
         </div>
 
@@ -87,8 +88,12 @@ export default function Navbar() {
           >
             Contact
           </Link>
-          <Link href="/install-extension" className="btn btn-cta w-full mt-4" onClick={() => setIsOpen(false)}>
-            Install Extension
+          <Link
+            href={siteConfig.signupUrl}
+            className="btn btn-cta w-full mt-4"
+            onClick={() => setIsOpen(false)}
+          >
+            Try Free
           </Link>
         </motion.div>
       )}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -9,9 +9,9 @@ const contactCards = [
   {
     icon: Mail,
     title: 'General enquiries',
-    description: 'Use this route for pilot requests, rollout questions, browser extension pilots, and early commercial conversations.',
-    label: siteConfig.contactEmail,
-    href: contactLinks.betaAccessMailto,
+    description: 'Use this route for demo requests, rollout questions, browser extension planning, and commercial conversations.',
+    label: siteConfig.salesEmail,
+    href: contactLinks.demoMailto,
   },
   {
     icon: ShieldCheck,
@@ -23,7 +23,7 @@ const contactCards = [
   {
     icon: Waypoints,
     title: 'Live endpoint checks',
-    description: 'Validate the public beta runtime before reaching out, including simple health and readiness checks.',
+    description: 'Validate the live runtime before reaching out, including simple health and readiness checks.',
     label: 'api.neutralai.co.uk/health',
     href: siteConfig.apiHealthUrl,
   },
@@ -31,8 +31,8 @@ const contactCards = [
 
 const onboardingSteps = [
   'Share the models, applications, or workflows you want to protect.',
-  'We align on pilot scope, data handling expectations, and launch posture.',
-  'If the fit is right, we move into beta onboarding with the right deployment and review path.',
+  'We align on scope, data handling expectations, and rollout posture.',
+  'If the fit is right, we move into guided onboarding with the right deployment and review path.',
 ] as const
 
 export default function ContactPage() {
@@ -55,7 +55,7 @@ export default function ContactPage() {
               Start the conversation before you start the rollout
             </h1>
             <p className="mt-6 text-xl text-slate-400">
-              NeutralAI is currently onboarding pilots directly. Reach out with your target workflow, model usage, browser extension needs, and compliance expectations so we can scope the right starting point.
+              NeutralAI is ready for guided evaluation and team rollout conversations. Reach out with your target workflow, model usage, browser extension needs, and compliance expectations so we can scope the right starting point.
             </p>
           </motion.div>
         </div>
@@ -117,7 +117,7 @@ export default function ContactPage() {
                 </li>
                 <li className="flex items-start gap-3">
                   <span className="mt-1 h-2.5 w-2.5 rounded-full bg-primary" />
-                  <span>Whether you are validating a pilot, rolling out the extension, or planning a stricter production path</span>
+                  <span>Whether you are validating the product, rolling out the extension, or planning a stricter production path</span>
                 </li>
               </ul>
             </motion.div>
@@ -129,7 +129,7 @@ export default function ContactPage() {
               transition={{ delay: 0.08 }}
               className="card p-8"
             >
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Beta flow</p>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Evaluation flow</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">What happens next</h2>
               <ol className="mt-6 space-y-5">
                 {onboardingSteps.map((step, index) => (

--- a/app/install-extension/page.tsx
+++ b/app/install-extension/page.tsx
@@ -16,18 +16,18 @@ const installOptions = [
   {
     title: 'Install for Chrome',
     description:
-      'Use this route for Chrome Web Store rollout once the public listing is approved. Until then, we will route pilots through direct support.',
+      'Use this route for the Chrome Web Store listing and managed browser rollout conversations.',
     href: siteConfig.chromeExtensionUrl || extensionLinks.supportMailto,
-    label: siteConfig.chromeExtensionUrl ? 'Open Chrome listing' : 'Request Chrome pilot access',
+    label: siteConfig.chromeExtensionUrl ? 'Open Chrome listing' : 'Request Chrome rollout support',
     external: true,
     icon: Chrome,
   },
   {
     title: 'Install for Edge',
     description:
-      'Use this route for Microsoft Edge Add-ons rollout. If the public listing is not yet live, we will guide pilot installs directly.',
+      'Use this route for the Microsoft Edge Add-ons listing and managed browser rollout conversations.',
     href: siteConfig.edgeExtensionUrl || extensionLinks.supportMailto,
-    label: siteConfig.edgeExtensionUrl ? 'Open Edge listing' : 'Request Edge pilot access',
+    label: siteConfig.edgeExtensionUrl ? 'Open Edge listing' : 'Request Edge rollout support',
     external: true,
     icon: Download,
   },
@@ -62,7 +62,7 @@ export default function InstallExtensionPage() {
               Install the browser extension without guessing the rollout path
             </h1>
             <p className="mt-6 text-xl text-slate-400">
-              NeutralAI Interceptor masks sensitive prompt data before it leaves supported AI web applications. This page is the public install reference for pilots, browser store review, and managed enterprise rollout.
+              NeutralAI Interceptor masks sensitive prompt data before it leaves supported AI web applications. This page is the public install reference for browser store review and managed enterprise rollout.
             </p>
           </div>
         </div>
@@ -112,7 +112,7 @@ export default function InstallExtensionPage() {
               <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Self-serve sign-in</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">How unmanaged installs authenticate</h2>
               <p className="mt-4 text-slate-400">
-                The extension uses the NeutralAI app domain for sign-in, session checks, and short-lived auth context retrieval. During store review or pilot onboarding, these public URLs should be reachable and documented.
+                The extension uses the NeutralAI app domain for sign-in, session checks, and short-lived auth context retrieval. During store review or guided onboarding, these public URLs should be reachable and documented.
               </p>
               <ul className="mt-6 space-y-4">
                 {signInSteps.map((step) => (
@@ -131,7 +131,7 @@ export default function InstallExtensionPage() {
               </p>
               <div className="mt-8 rounded-2xl border border-primary/20 bg-primary/10 p-4 text-sm text-slate-200">
                 <ShieldCheck className="mb-3 h-5 w-5 text-primary-light" />
-                Need a managed rollout instead of a self-serve pilot? Use the enterprise route from the support page and we will help with policy-based deployment.
+                Need a managed rollout instead of self-serve install? Use the enterprise route from the support page and we will help with policy-based deployment.
               </div>
             </div>
           </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,6 +38,17 @@ export const metadata: Metadata = {
     'privacy gateway',
     'LLM security',
     'UK GDPR',
+    'presidio alternative',
+    'pii detection api',
+    'ai compliance gateway',
+    'llm data protection',
+    'sensitive data masking for ai',
+    'enterprise ai privacy',
+    'ai data loss prevention',
+    'pii redaction for llm',
+    'gdpr compliant ai',
+    'hipaa ai gateway',
+    'ai privacy gateway',
   ],
   alternates: {
     canonical: '/',
@@ -75,9 +86,28 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: siteConfig.name,
+    applicationCategory: 'SecurityApplication',
+    operatingSystem: 'Web',
+    url: siteConfig.url,
+    description: siteConfig.description,
+    offers: {
+      '@type': 'Offer',
+      category: 'SaaS',
+      url: siteConfig.signupUrl,
+    },
+  }
+
   return (
     <html lang="en" className="scroll-smooth">
       <body className={`${dmSans.variable} ${jetBrainsMono.variable} ${spaceGrotesk.variable} font-body bg-background text-slate-50 antialiased`}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
         <Navbar />
         <main className="min-h-screen">
           {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -477,15 +477,15 @@ function Hero() {
           <div>
             <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-sm text-primary-light">
               <span className="h-2 w-2 rounded-full bg-accent-success animate-pulse" />
-              AI security gateway - now available
+              Use AI. Stay compliant. Prove it.
             </div>
 
             <h1 className="mt-6 max-w-4xl font-heading text-4xl font-bold leading-tight md:text-6xl xl:text-7xl">
-              Use AI. Stay compliant. <span className="gradient-text-warm">Prove it.</span>
+              Mask sensitive prompt data <span className="gradient-text-warm">before it leaves AI apps.</span>
             </h1>
 
             <p className="mt-6 max-w-2xl text-lg text-slate-300 md:text-xl">
-              NeutralAI is the compliance-first AI privacy gateway that masks sensitive prompt data, keeps a governed token vault, and gives security teams proof that AI usage is controlled.
+              NeutralAI adds a compliance-first control layer for browser AI and app traffic, with masking, encrypted tokenization, and audit-ready proof for regulated teams.
             </p>
 
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -786,10 +786,10 @@ function Trust() {
             <div>
               <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Why Trust NeutralAI</p>
               <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
-                Visible proof, not <span className="gradient-text-warm">security theatre.</span>
+                Proof your security team <span className="gradient-text-warm">can trust.</span>
               </h2>
               <p className="mt-5 max-w-2xl text-lg text-slate-300">
-                NeutralAI is not just a masking wrapper. It combines a policy boundary, encrypted tokenization, audit evidence, and deployment choices that match regulated teams.
+                NeutralAI goes beyond masking by combining policy enforcement, encrypted tokenization, audit-ready evidence, and deployment options built for regulated AI adoption.
               </p>
             </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import {
   ArrowRight,
   Building2,
   CheckCircle2,
-  FileCheck2,
+  ClipboardCheck,
   Gauge,
   Globe,
   KeyRound,
@@ -16,10 +16,10 @@ import {
   Network,
   Server,
   ShieldCheck,
-  Sparkles,
+  Timer,
   type LucideIcon,
 } from 'lucide-react'
-import { contactLinks, siteConfig } from './site'
+import { siteConfig } from './site'
 
 type Card = {
   icon: LucideIcon
@@ -69,44 +69,44 @@ const steps = [
 const trustCards: Card[] = [
   {
     icon: ShieldCheck,
-    title: 'A real boundary',
-    description: 'NeutralAI sits between user workflows and external model vendors.',
+    title: 'Compliance evidence automation',
+    description: 'NeutralAI gives teams a control point that can produce audit-ready proof instead of leaving AI usage invisible.',
   },
   {
-    icon: FileCheck2,
-    title: 'Live operational proof',
-    description: 'Public health and readiness endpoints say more than placeholder testimonials.',
+    icon: KeyRound,
+    title: 'Reversible vault tokenization',
+    description: 'Sensitive values can be replaced with encrypted tokens before model egress, then restored only through governed paths.',
   },
   {
-    icon: Sparkles,
-    title: 'Honest launch posture',
-    description: 'Pilot-ready now, with production hardening called out explicitly.',
+    icon: Building2,
+    title: 'Managed, private cloud, or on-prem',
+    description: 'Teams can start with managed SaaS and move toward stricter deployment models as governance demands increase.',
   },
 ] as const
 
 const pricingPlans = [
   {
-    name: 'Pilot',
-    summary: 'Best for a focused proof of value',
+    name: 'Free evaluation',
+    summary: 'Best for testing the product with a controlled trial',
     features: [
-      'Focused browser extension rollout',
-      'Shared beta guidance',
-      'Initial deployment fit review',
+      'Starter quota for hands-on evaluation',
+      'Chat and browser extension workflows',
+      'Clear upgrade path when limits are reached',
     ],
-    href: '/install-extension',
-    cta: 'Start Pilot Path',
+    href: siteConfig.signupUrl,
+    cta: 'Try Free',
     featured: false,
   },
   {
-    name: 'Team Rollout',
-    summary: 'Best for moving from pilot to internal approval',
+    name: 'Team rollout',
+    summary: 'Best for getting approved AI usage into a team',
     features: [
-      'Security and rollout planning',
+      'Usage controls and billing readiness',
       'App, extension, or mixed deployment support',
-      'Operational guidance before wider rollout',
+      'Security review and rollout guidance',
     ],
-    href: contactLinks.launchReviewMailto,
-    cta: 'Book Rollout Review',
+    href: '/contact',
+    cta: 'Talk to Sales',
     featured: true,
   },
   {
@@ -120,6 +120,33 @@ const pricingPlans = [
     href: '/contact',
     cta: 'Talk to Sales',
     featured: false,
+  },
+] as const
+
+const trustBadges = [
+  'AES-256-GCM vault',
+  'SOC2 readiness',
+  'GDPR aligned',
+  'Cyber Essentials evidence',
+  '20+ PII entity types',
+  '5+ language benchmark',
+] as const
+
+const complianceProofs = [
+  {
+    icon: ClipboardCheck,
+    label: 'Auto evidence',
+    value: 'SOC2 / ISO / CE',
+  },
+  {
+    icon: Lock,
+    label: 'Token vault',
+    value: 'AES-256-GCM',
+  },
+  {
+    icon: Timer,
+    label: 'Measured overhead',
+    value: '~41 ms',
   },
 ] as const
 
@@ -450,29 +477,29 @@ function Hero() {
           <div>
             <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-sm text-primary-light">
               <span className="h-2 w-2 rounded-full bg-accent-success animate-pulse" />
-              Browser extension and gateway beta
+              AI security gateway - now available
             </div>
 
             <h1 className="mt-6 max-w-4xl font-heading text-4xl font-bold leading-tight md:text-6xl xl:text-7xl">
-              Mask sensitive prompt data <span className="gradient-text-warm">before it leaves AI apps.</span>
+              Use AI. Stay compliant. <span className="gradient-text-warm">Prove it.</span>
             </h1>
 
             <p className="mt-6 max-w-2xl text-lg text-slate-300 md:text-xl">
-              NeutralAI adds a control layer for browser-based AI usage and application traffic so teams can keep moving without sending raw sensitive data straight to external models.
+              NeutralAI is the compliance-first AI privacy gateway that masks sensitive prompt data, keeps a governed token vault, and gives security teams proof that AI usage is controlled.
             </p>
 
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-              <a href="/install-extension" className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto">
-                Install Extension
+              <a href={siteConfig.signupUrl} className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto">
+                Try Free
                 <ArrowRight className="h-5 w-5" />
               </a>
               <a href="/contact" className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto">
-                Book Demo
+                Talk to Sales
               </a>
             </div>
             <div className="mt-4 flex flex-col gap-3 text-sm text-slate-400 sm:flex-row sm:flex-wrap sm:items-center">
-              <a href="/contact" className="text-primary-light transition-colors hover:text-primary">
-                Planning a broader rollout? Talk to NeutralAI
+              <a href="/install-extension" className="text-primary-light transition-colors hover:text-primary">
+                Install browser extension
               </a>
               <span className="hidden text-slate-600 sm:inline">•</span>
               <a
@@ -487,10 +514,10 @@ function Hero() {
 
             <div className="mt-10 space-y-3">
               {[
-                'Stops raw PII and business identifiers from reaching external models first',
-                'Browser extension supports familiar AI workflows without forcing a portal switch',
-                'Gives security and legal a visible control point for rollout decisions',
-                'Creates a clearer path from experimentation to approved internal use',
+                'Stops raw PII and business identifiers before they reach external models',
+                'Generates compliance evidence for AI usage instead of relying on manual screenshots',
+                'Supports browser extension, managed gateway, private cloud, and on-prem rollout paths',
+                'Helps legal and security approve AI adoption without blocking everyday workflows',
               ].map((item) => (
                 <div key={item} className="flex items-start gap-3 text-slate-300">
                   <CheckCircle2 className="mt-0.5 h-5 w-5 flex-shrink-0 text-primary-light" />
@@ -498,10 +525,34 @@ function Hero() {
                 </div>
               ))}
             </div>
+
+            <div className="mt-8 grid gap-3 sm:grid-cols-3">
+              {complianceProofs.map((proof) => (
+                <div key={proof.label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+                  <proof.icon className="h-5 w-5 text-primary-light" />
+                  <p className="mt-3 text-xs uppercase tracking-[0.2em] text-slate-500">{proof.label}</p>
+                  <p className="mt-1 font-heading text-lg font-semibold text-slate-100">{proof.value}</p>
+                </div>
+              ))}
+            </div>
           </div>
 
           <div className="lg:-mt-3 xl:-mt-4">
             <ProductVisual />
+          </div>
+        </div>
+      </div>
+      <div className="container-custom relative z-10 mt-12">
+        <div className="marquee rounded-full border border-white/10 bg-white/[0.04] px-4 py-3">
+          <div className="marquee-track gap-3">
+            {[...trustBadges, ...trustBadges].map((badge, index) => (
+              <span
+                key={`${badge}-${index}`}
+                className="inline-flex whitespace-nowrap rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-xs font-medium uppercase tracking-[0.18em] text-primary-light"
+              >
+                {badge}
+              </span>
+            ))}
           </div>
         </div>
       </div>
@@ -738,7 +789,7 @@ function Trust() {
                 Visible proof, not <span className="gradient-text-warm">security theatre.</span>
               </h2>
               <p className="mt-5 max-w-2xl text-lg text-slate-300">
-                The trust story should stay simple: a real product boundary, live operational proof, and a launch posture that says exactly what is ready now.
+                NeutralAI is not just a masking wrapper. It combines a policy boundary, encrypted tokenization, audit evidence, and deployment choices that match regulated teams.
               </p>
             </div>
 
@@ -770,10 +821,10 @@ function Trust() {
         <div className="mt-10 rounded-[28px] border border-accent-cta/20 bg-[linear-gradient(180deg,rgba(249,115,22,0.08),rgba(15,23,42,0.92))] p-6">
           <div className="grid gap-6 lg:grid-cols-[1fr_auto] lg:items-center">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Launch Signals</p>
-              <h3 className="mt-4 font-heading text-3xl font-semibold">Live beta runtime. Clear next step.</h3>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Operational Signals</p>
+              <h3 className="mt-4 font-heading text-3xl font-semibold">Live runtime. Measured product proof.</h3>
               <p className="mt-4 max-w-3xl text-slate-300">
-                The public signal is simple: the beta runtime is live on <span className="text-primary-light">api.neutralai.co.uk</span>, while production hardening is still being completed openly and deliberately.
+                The public signal is simple: the runtime is live on <span className="text-primary-light">api.neutralai.co.uk</span>, the benchmark pages are published, and the gateway overhead is measured separately from model generation time.
               </p>
             </div>
 
@@ -799,7 +850,7 @@ function Pricing() {
         <SectionIntro
           eyebrow="Engagement Paths"
           title="Pick the right starting point"
-          description="NeutralAI is still in a guided rollout phase. These options are designed to move the right conversation forward without pretending this is a finished self-serve security product."
+          description="Start with a free evaluation, move into a team rollout when the control model is clear, or bring NeutralAI into a stricter enterprise deployment path."
           centered
         />
 
@@ -858,12 +909,12 @@ function FinalCta() {
             NeutralAI is for teams that already know AI usage is happening and want a credible way to reduce prompt risk without slowing everyone down.
           </p>
           <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <a href="/install-extension" className="btn btn-cta w-full px-8 py-4 text-lg sm:w-auto">
-              Install Extension
+            <a href={siteConfig.signupUrl} className="btn btn-cta w-full px-8 py-4 text-lg sm:w-auto">
+              Try Free
               <ArrowRight className="h-5 w-5" />
             </a>
-            <a href={contactLinks.launchReviewMailto} className="btn btn-secondary w-full px-8 py-4 text-lg sm:w-auto">
-              Book Rollout Review
+            <a href="/contact" className="btn btn-secondary w-full px-8 py-4 text-lg sm:w-auto">
+              Talk to Sales
             </a>
           </div>
           <p className="mt-4 text-sm text-slate-400">

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -23,7 +23,7 @@ const securitySections = [
     icon: ServerCog,
     title: 'Operational checks',
     description:
-      'The public beta runtime exposes health and readiness endpoints to support smoke tests, deployment checks, and simple launch monitoring.',
+      'The live runtime exposes health and readiness endpoints to support smoke tests, deployment checks, and simple launch monitoring.',
   },
   {
     icon: Lock,
@@ -40,7 +40,7 @@ const securitySections = [
 ] as const
 
 const readinessItems = [
-  'Public beta endpoints are live behind TLS on api.neutralai.co.uk.',
+  'Public endpoints are live behind TLS on api.neutralai.co.uk.',
   'Docker-based deployment and reverse proxy setup are already in place.',
   'The current public website intentionally avoids presenting the product as unrestricted production-ready.',
   'Production go-live discussions should include the immutable storage roadmap and security review scope.',
@@ -66,7 +66,7 @@ export default function SecurityPage() {
               Launch trust starts with an accurate posture
             </h1>
             <p className="mt-6 text-xl text-slate-400">
-              This page summarizes the current public security story for NeutralAI: what is live, what is suitable for pilots, and what is still part of the production-hardening path.
+              This page summarizes the current public security story for NeutralAI: what is live, what is suitable for evaluation, and what is still part of the production-hardening path.
             </p>
           </motion.div>
         </div>

--- a/app/site.ts
+++ b/app/site.ts
@@ -8,18 +8,21 @@ export const siteConfig = {
   apiHealthUrl: 'https://api.neutralai.co.uk/health',
   apiReadyUrl: 'https://api.neutralai.co.uk/ready',
   appBaseUrl: 'https://app.neutralai.co.uk',
+  signupUrl: 'https://app.neutralai.co.uk/auth/signin?callbackUrl=%2Fchat',
   contactEmail: 'hello@neutralai.co.uk',
   privacyEmail: 'privacy@neutralai.co.uk',
   securityEmail: 'security@neutralai.co.uk',
   supportEmail: 'support@neutralai.co.uk',
   salesEmail: 'sales@neutralai.co.uk',
   securityTxtPath: '/.well-known/security.txt',
-  chromeExtensionUrl: '',
-  edgeExtensionUrl: '',
+  chromeExtensionUrl:
+    'https://chromewebstore.google.com/detail/neutralai-interceptor/gpdjigfhopjabaodmnombeoldieoobnh',
+  edgeExtensionUrl:
+    'https://microsoftedge.microsoft.com/addons/detail/neutralai-interceptor/agdhbinchoiapijeicfgdmkoekolefkg',
 } as const
 
 export const contactLinks = {
-  betaAccessMailto: `mailto:${siteConfig.contactEmail}?subject=NeutralAI%20beta%20access`,
+  demoMailto: `mailto:${siteConfig.salesEmail}?subject=NeutralAI%20demo%20request`,
   launchReviewMailto: `mailto:${siteConfig.contactEmail}?subject=NeutralAI%20launch%20readiness%20review`,
   securityMailto: `mailto:${siteConfig.securityEmail}?subject=Security%20enquiry%20for%20NeutralAI`,
   supportMailto: `mailto:${siteConfig.supportEmail}?subject=NeutralAI%20support`,
@@ -32,6 +35,7 @@ export const homeSections = {
   howItWorks: '/#how-it-works',
   trust: '/#trust',
   pricing: '/#pricing',
+  compare: '/compare',
 } as const
 
 export const extensionLinks = {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,6 +6,7 @@ export const dynamic = 'force-static'
 const routes = [
   '',
   '/about',
+  '/compare',
   '/contact',
   '/install-extension',
   '/privacy',

--- a/app/support/browser-extension/page.tsx
+++ b/app/support/browser-extension/page.tsx
@@ -68,7 +68,7 @@ export default function BrowserExtensionSupportPage() {
               Public support reference for NeutralAI Interceptor
             </h1>
             <p className="mt-6 text-xl text-slate-400">
-              This is the canonical support page for browser store review, pilot installs, and enterprise rollout conversations. It explains the extension’s limited purpose, requested permissions, and the NeutralAI-owned app and API surfaces it interacts with.
+              This is the canonical support page for browser store review, self-serve installs, and enterprise rollout conversations. It explains the extension’s limited purpose, requested permissions, and the NeutralAI-owned app and API surfaces it interacts with.
             </p>
           </div>
         </div>
@@ -157,7 +157,7 @@ export default function BrowserExtensionSupportPage() {
                   Enterprise customers can deploy NeutralAI Interceptor with managed browser policies so the extension is force-installed, pinned, and locked to organization-controlled NeutralAI endpoints.
                 </p>
                 <p>
-                  That rollout path is separate from self-serve sign-in and is the recommended approach for larger pilots, regulated teams, or centrally managed browser fleets.
+                  That rollout path is separate from self-serve sign-in and is the recommended approach for regulated teams or centrally managed browser fleets.
                 </p>
               </div>
               <Link

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -95,7 +95,7 @@ export default function TermsPage() {
               Terms of <span className="gradient-text">Service</span>
             </h1>
             <p className="text-xl text-slate-400 max-w-2xl mx-auto">
-              These Terms of Service govern access to NeutralAI beta services, including the gateway, browser extension support surfaces, and related onboarding conversations.
+              These Terms of Service govern access to NeutralAI services, including the gateway, browser extension support surfaces, and related onboarding conversations.
             </p>
           </motion.div>
         </div>


### PR DESCRIPTION
Closes nazifsohtaoglu/neutralai-gateway#749

## Summary
- reposition the homepage around “Use AI. Stay compliant. Prove it.” with working Try Free and Talk to Sales CTAs
- add trust badges, compliance proof points, measured overhead messaging, and real Chrome/Edge extension listing links
- add a feature-based /compare page for the build-vs-buy / Presidio-wrapper objection without naming competitors directly
- remove beta/pilot framing from the public marketing surfaces and add higher-intent SEO keywords plus SoftwareApplication structured data

## Validation
- npm run lint
- npm run build
- npm run audit:prod
- git diff --check
- Playwright smoke: / and /compare at desktop/mobile viewport via local dev server

## Notes
- `npm run audit:prod` exits successfully at the configured critical threshold; npm still reports a moderate advisory from Next’s transitive PostCSS dependency.
- This website PR closes the gateway roadmap issue because the gateway root is intentionally app-first; the marketing landing belongs in `neutralai-website`.