### PR TITLE
Improve homepage primary CTA clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ next-env.d.ts
 
 # Local automation artifacts
 .playwright-cli/
+.playwright-mcp/

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -54,7 +54,7 @@ export default function Navbar() {
             Contact
           </Link>
           <Link href={siteConfig.signupUrl} className="btn btn-cta">
-            Try Free
+            Get Started Free
           </Link>
         </div>
 
@@ -94,7 +94,7 @@ export default function Navbar() {
             className="btn btn-cta w-full mt-4"
             onClick={() => setIsOpen(false)}
           >
-            Try Free
+            Get Started Free
           </Link>
         </motion.div>
       )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -494,7 +494,7 @@ function Hero() {
                 <ArrowRight className="h-5 w-5" />
               </a>
               <a href="/contact" className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto">
-                Talk to Sales
+                Book Demo
               </a>
             </div>
             <div className="mt-4 flex flex-col gap-3 text-sm text-slate-400 sm:flex-row sm:flex-wrap sm:items-center">
@@ -647,11 +647,11 @@ function ProductSurface() {
                   NeutralAI can protect browser-based AI usage in the flow people already know, which is exactly why adoption can move faster.
                 </p>
                 <div className="mt-5 flex flex-col gap-3 sm:flex-row">
-                  <a href="/install-extension" className="btn btn-cta w-full sm:w-auto">
-                    Install Extension
+                  <a href={siteConfig.signupUrl} className="btn btn-cta w-full sm:w-auto">
+                    Try Free
                   </a>
-                  <a href="/contact" className="btn btn-secondary w-full sm:w-auto">
-                    Enterprise Rollout
+                  <a href="/install-extension" className="btn btn-secondary w-full sm:w-auto">
+                    Install Browser Extension
                   </a>
                 </div>
               </div>

--- a/app/site.ts
+++ b/app/site.ts
@@ -8,7 +8,8 @@ export const siteConfig = {
   apiHealthUrl: 'https://api.neutralai.co.uk/health',
   apiReadyUrl: 'https://api.neutralai.co.uk/ready',
   appBaseUrl: 'https://app.neutralai.co.uk',
-  signupUrl: 'https://app.neutralai.co.uk/auth/signin?callbackUrl=%2Fchat',
+  signupUrl:
+    'https://app.neutralai.co.uk/auth/signin?intent=signup&plan=starter&src=website_start_free_trial&callbackUrl=%2Fchat',
   contactEmail: 'hello@neutralai.co.uk',
   privacyEmail: 'privacy@neutralai.co.uk',
   securityEmail: 'security@neutralai.co.uk',

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev -p 3200",
     "build": "next build",
     "start": "next start",
+    "test:content": "node --test tests/content/*.test.mjs",
     "lint": "eslint .",
     "audit:prod": "npm audit --omit=dev --audit-level=critical"
   },

--- a/tests/content/primary-cta.test.mjs
+++ b/tests/content/primary-cta.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+
+function readSource(path) {
+  return readFileSync(join(root, path), 'utf8')
+}
+
+test('site config exposes a working app signup/sandbox destination instead of a mailto fallback', () => {
+  const siteSource = readSource('app/site.ts')
+
+  assert.match(
+    siteSource,
+    /signupUrl:\s*'https:\/\/app\.neutralai\.co\.uk\/auth\/signin\?intent=signup&plan=starter&src=website_start_free_trial&callbackUrl=%2Fchat'/
+  )
+  assert.doesNotMatch(siteSource, /signupUrl:\s*'mailto:/)
+  assert.doesNotMatch(siteSource, /signupUrl:\s*'https:\/\/app\.neutralai\.co\.uk\/auth\/signup/)
+})
+
+test('navbar primary CTA invites users to get started free', () => {
+  const navbarSource = readSource('app/components/Navbar.tsx')
+
+  assert.match(navbarSource, /Get Started Free/)
+  assert.doesNotMatch(navbarSource, />\s*Try Free\s*</)
+})
+
+test('homepage hero uses Try Free, Book Demo, and a demoted extension install link', () => {
+  const homeSource = readSource('app/page.tsx')
+
+  assert.match(homeSource, /href=\{siteConfig\.signupUrl\}[\s\S]{0,180}>\s*Try Free/)
+  assert.match(homeSource, /href="\/contact"[\s\S]{0,180}>\s*Book Demo/)
+  assert.match(homeSource, /className="text-primary-light[^"]*"[\s\S]{0,80}>\s*Install browser extension/)
+  assert.doesNotMatch(homeSource, /className="btn btn-cta[^"]*"[\s\S]{0,120}>\s*Install Extension/)
+})
+
+test('extension-focused homepage card keeps Try Free primary and install secondary', () => {
+  const homeSource = readSource('app/page.tsx')
+
+  assert.match(
+    homeSource,
+    /Same tab\.[\s\S]*href=\{siteConfig\.signupUrl\}[\s\S]{0,180}>\s*Try Free/
+  )
+  assert.match(
+    homeSource,
+    /Same tab\.[\s\S]*href="\/install-extension" className="btn btn-secondary[^"]*"[\s\S]{0,120}>\s*Install Browser Extension/
+  )
+  assert.doesNotMatch(homeSource, /Plan Enterprise Rollout/)
+})
+
+test('final CTA keeps Try Free as the primary action and sales as secondary', () => {
+  const homeSource = readSource('app/page.tsx')
+
+  assert.match(homeSource, /function FinalCta\(\)[\s\S]*href=\{siteConfig\.signupUrl\}[\s\S]{0,180}>\s*Try Free/)
+  assert.match(homeSource, /function FinalCta\(\)[\s\S]*href="\/contact"[\s\S]{0,180}>\s*Talk to Sales/)
+})


### PR DESCRIPTION
## Problem

The homepage and navbar CTAs needed a clearer working signup/trial path instead of making the browser extension feel like the primary conversion path.

## What Changed

- Updated the shared signup URL to use the working app handoff with signup intent.
- Changed the navbar CTA to "Get Started Free".
- Updated the homepage hero secondary CTA to "Book Demo".
- Kept the browser extension accessible as a secondary action.
- Added content tests for primary CTA labels and destinations.
- Ignored generated Playwright MCP artifacts.

## Validation

- [x] npm run test:content
- [x] npm run lint
- [x] npm run build
- [x] npm run audit:prod (exit 0; reports 2 moderate Next/PostCSS advisories)
- [x] Manual Playwright browser check on homepage CTA rendering

## Risks / Follow-ups

- Assumption: `src=website_start_free_trial` is the desired analytics source for homepage signup handoffs.
- Consider a dedicated Playwright smoke script in a future PR.
