### PR TITLE
Add Presidio alternative website content

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -95,6 +95,9 @@ export default function ComparePage() {
               <Link href="/contact" className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto">
                 Talk to Sales
               </Link>
+              <Link href="/presidio-alternative" className="text-primary-light transition hover:text-primary">
+                Presidio alternative
+              </Link>
             </div>
           </div>
         </div>
@@ -150,6 +153,9 @@ export default function ComparePage() {
             <BadgeCheck className="mb-3 h-5 w-5 text-primary-light" />
             NeutralAI uses proven detection primitives where they make sense, but the product value is the full compliance
             gateway around them: policy, vaulting, evidence, deployment, and browser coverage.
+            <Link href="/presidio-alternative" className="ml-2 font-semibold text-primary-light hover:text-primary">
+              See the Presidio-specific build-vs-buy analysis.
+            </Link>
           </div>
         </div>
       </section>

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -9,6 +9,7 @@ const productLinks = [
   { label: 'How It Works', href: homeSections.howItWorks },
   { label: 'Why Trust Us', href: homeSections.trust },
   { label: 'Compare', href: homeSections.compare },
+  { label: 'Presidio Alternative', href: '/presidio-alternative' },
   { label: 'Pricing', href: homeSections.pricing },
 ] as const
 

--- a/app/insights/presidio-alone-regulated-industries/page.tsx
+++ b/app/insights/presidio-alone-regulated-industries/page.tsx
@@ -1,0 +1,135 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft, ArrowRight, ShieldCheck } from 'lucide-react'
+import { siteConfig } from '../../site'
+
+export const metadata: Metadata = {
+  title: 'Why Presidio Alone Is Not Enough for Regulated Industries',
+  description:
+    'A technical explanation of why regulated AI teams usually need more than Microsoft Presidio alone: policy, vaulting, audit evidence, tenancy, SSO, extension enforcement, and operations.',
+  keywords: [
+    'presidio alternative',
+    'pii masking for llm',
+    'ai compliance gateway',
+    'regulated AI PII masking',
+  ],
+  alternates: {
+    canonical: '/insights/presidio-alone-regulated-industries',
+  },
+}
+
+export default function PresidioRegulatedIndustriesPage() {
+  return (
+    <main className="min-h-screen pt-24">
+      <article className="container-custom max-w-4xl py-16 md:py-20">
+        <Link href="/presidio-alternative" className="inline-flex items-center gap-2 text-sm font-medium text-primary-light hover:text-primary">
+          <ArrowLeft className="h-4 w-4" />
+          Back to comparison
+        </Link>
+
+        <header className="mt-10 border-b border-border pb-10">
+          <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
+            <ShieldCheck className="h-3.5 w-3.5" />
+            Technical note
+          </div>
+          <h1 className="mt-5 font-heading text-4xl font-bold md:text-6xl">
+            Why Presidio alone is not enough for regulated industries
+          </h1>
+          <p className="mt-5 text-lg leading-8 text-slate-300">
+            Presidio is a capable open-source foundation for detecting and anonymizing PII. In regulated AI workflows,
+            the hard part is turning that foundation into a governed product boundary that users, auditors, and security
+            teams can trust every day.
+          </p>
+        </header>
+
+        <div className="mt-10 space-y-10 text-base leading-8 text-slate-300">
+          <section>
+            <h2 className="font-heading text-3xl font-semibold text-white">The build starts after detection</h2>
+            <p className="mt-4">
+              Presidio provides analyzer and anonymizer components, customizable recognizers, and anonymization
+              operators. That is useful engineering leverage. It is not the same thing as a full AI compliance gateway.
+              A regulated rollout still needs authentication, tenant boundaries, policy decisions, reversible token
+              handling, audit evidence, customer-facing controls, and operational ownership.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-3xl font-semibold text-white">Accuracy has to be product accuracy</h2>
+            <p className="mt-4">
+              NeutralAI publishes a gateway-owned benchmark page for the current product configuration and a
+              Presidio-vanilla baseline. The important point is not that Presidio is weak; it is that enterprise
+              deployments usually need tuned recognizers, contextual rules, regression packs, and product-level
+              enforcement around the library.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-3xl font-semibold text-white">Regulated teams need evidence</h2>
+            <p className="mt-4">
+              Security review usually asks what was masked, where policy was applied, which tenant and user path was in
+              scope, and what proof can be shown without leaking raw sensitive text. Those questions are outside a pure
+              recognizer library. They belong to the gateway, vault, audit, and deployment layers.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-3xl font-semibold text-white">Operations becomes the real cost center</h2>
+            <p className="mt-4">
+              A do-it-yourself Presidio deployment means owning dependency updates, NLP model drift, browser extension
+              support, scaling, incident response, benchmark maintenance, and customer-facing documentation. Those costs
+              are why a build-vs-buy decision should include the full operating surface, not just the license cost of an
+              open-source component.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-3xl font-semibold text-white">Where NeutralAI fits</h2>
+            <p className="mt-4">
+              NeutralAI uses proven open-source detection foundations and adds the policy boundary, encrypted
+              tokenization layer, audit evidence, multi-tenant controls, user-facing chat and extension flows, and
+              deployment choices that regulated teams need when AI usage moves from experiment to production.
+            </p>
+          </section>
+        </div>
+
+        <section className="mt-10 grid gap-4 border-t border-border pt-8 md:grid-cols-3">
+          <a
+            href="https://github.com/microsoft/presidio"
+            className="rounded-2xl border border-white/12 bg-white/5 p-5 text-sm leading-7 text-slate-300 transition hover:border-primary/40"
+          >
+            Microsoft Presidio GitHub
+          </a>
+          <a
+            href="https://microsoft.github.io/presidio/"
+            className="rounded-2xl border border-white/12 bg-white/5 p-5 text-sm leading-7 text-slate-300 transition hover:border-primary/40"
+          >
+            Microsoft Presidio docs
+          </a>
+          <a
+            href={`${siteConfig.appBaseUrl}/pii-benchmark`}
+            className="rounded-2xl border border-white/12 bg-white/5 p-5 text-sm leading-7 text-slate-300 transition hover:border-primary/40"
+          >
+            NeutralAI benchmark
+          </a>
+        </section>
+
+        <section className="mt-10 rounded-[32px] border border-primary/20 bg-primary/10 p-7">
+          <h2 className="font-heading text-2xl font-semibold text-white">For buyers evaluating a Presidio alternative</h2>
+          <p className="mt-3 text-sm leading-7 text-slate-300">
+            Ask whether the solution stops at PII detection, or whether it includes the gateway, vault, evidence, policy,
+            tenant, browser, and operational controls needed for live AI usage.
+          </p>
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+            <Link href="/presidio-alternative" className="btn btn-cta w-full justify-center px-8 py-4 text-base sm:w-auto">
+              Compare build vs buy
+              <ArrowRight className="h-5 w-5" />
+            </Link>
+            <Link href="/contact" className="btn btn-secondary w-full justify-center px-8 py-4 text-base sm:w-auto">
+              Talk to Sales
+            </Link>
+          </div>
+        </section>
+      </article>
+    </main>
+  )
+}

--- a/app/presidio-alternative/RoiCalculator.tsx
+++ b/app/presidio-alternative/RoiCalculator.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Calculator, CheckCircle2 } from 'lucide-react'
+
+const maintenanceItems = [
+  'SpaCy and NLP model updates',
+  'Recognizer tuning and regression packs',
+  'Security patches and dependency drift',
+  'Scaling, observability, and incident response',
+  'Compliance evidence and customer questionnaires',
+  'Browser store releases and extension support',
+] as const
+
+function formatUsd(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(Math.max(0, Math.round(value)))
+}
+
+export default function RoiCalculator() {
+  const [engineers, setEngineers] = useState(3)
+  const [months, setMonths] = useState(9)
+  const [monthlyCost, setMonthlyCost] = useState(18000)
+  const [complianceHours, setComplianceHours] = useState(140)
+  const [neutralaiMonthly, setNeutralaiMonthly] = useState(499)
+
+  const roi = useMemo(() => {
+    const engineeringCost = engineers * monthlyCost * months
+    const platformCost = 2500 * months
+    const complianceCost = complianceHours * 150
+    const internalBuildCost = engineeringCost + platformCost + complianceCost
+    const neutralaiCost = neutralaiMonthly * months
+    return {
+      engineeringCost,
+      platformCost,
+      complianceCost,
+      internalBuildCost,
+      neutralaiCost,
+      estimatedSavings: internalBuildCost - neutralaiCost,
+    }
+  }, [complianceHours, engineers, monthlyCost, months, neutralaiMonthly])
+
+  return (
+    <section id="roi-calculator" className="section border-y border-border/80 bg-background-secondary">
+      <div className="container-custom grid gap-8 lg:grid-cols-[0.95fr_1.05fr]">
+        <div>
+          <div className="inline-flex items-center gap-2 rounded-full border border-accent-success/25 bg-accent-success/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-accent-success">
+            <Calculator className="h-3.5 w-3.5" />
+            Build vs buy ROI calculator
+          </div>
+          <h2 className="mt-5 font-heading text-3xl font-bold md:text-5xl">
+            The hidden cost is not installing Presidio. It is productizing everything around it.
+          </h2>
+          <p className="mt-4 text-sm leading-7 text-slate-300 md:text-base">
+            Use conservative assumptions to estimate the internal build path. This calculator keeps the model simple:
+            engineering time, platform operations, and compliance evidence work.
+          </p>
+
+          <div className="mt-7 grid gap-3">
+            {maintenanceItems.map((item) => (
+              <div key={item} className="flex items-center gap-3 text-sm text-slate-300">
+                <CheckCircle2 className="h-4 w-4 text-primary-light" />
+                <span>{item}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-[28px] border border-white/12 bg-background/85 p-6 shadow-[0_24px_90px_rgba(2,6,23,0.45)]">
+          <div className="grid gap-5 md:grid-cols-2">
+            <label className="block">
+              <span className="text-sm font-medium text-white">Engineers assigned</span>
+              <input
+                type="range"
+                min="1"
+                max="8"
+                value={engineers}
+                onChange={(event) => setEngineers(Number(event.target.value))}
+                className="mt-3 w-full accent-primary"
+              />
+              <span className="mt-1 block text-sm text-slate-300">{engineers} engineers</span>
+            </label>
+            <label className="block">
+              <span className="text-sm font-medium text-white">Build timeline</span>
+              <input
+                type="range"
+                min="3"
+                max="18"
+                value={months}
+                onChange={(event) => setMonths(Number(event.target.value))}
+                className="mt-3 w-full accent-primary"
+              />
+              <span className="mt-1 block text-sm text-slate-300">{months} months</span>
+            </label>
+            <label className="block">
+              <span className="text-sm font-medium text-white">Loaded monthly cost per engineer</span>
+              <input
+                type="number"
+                min="8000"
+                step="1000"
+                value={monthlyCost}
+                onChange={(event) => setMonthlyCost(Number(event.target.value))}
+                className="mt-3 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none focus:border-primary"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-medium text-white">Compliance and review hours</span>
+              <input
+                type="number"
+                min="0"
+                step="10"
+                value={complianceHours}
+                onChange={(event) => setComplianceHours(Number(event.target.value))}
+                className="mt-3 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none focus:border-primary"
+              />
+            </label>
+            <label className="block md:col-span-2">
+              <span className="text-sm font-medium text-white">NeutralAI monthly subscription assumption</span>
+              <input
+                type="number"
+                min="0"
+                step="100"
+                value={neutralaiMonthly}
+                onChange={(event) => setNeutralaiMonthly(Number(event.target.value))}
+                className="mt-3 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none focus:border-primary"
+              />
+            </label>
+          </div>
+
+          <div className="mt-7 grid gap-4 md:grid-cols-3">
+            <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+              <p className="text-xs uppercase tracking-[0.14em] text-slate-400">DIY build</p>
+              <p className="mt-2 text-2xl font-semibold text-white">{formatUsd(roi.internalBuildCost)}</p>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+              <p className="text-xs uppercase tracking-[0.14em] text-slate-400">NeutralAI</p>
+              <p className="mt-2 text-2xl font-semibold text-white">{formatUsd(roi.neutralaiCost)}</p>
+            </div>
+            <div className="rounded-2xl border border-accent-success/25 bg-accent-success/10 p-4">
+              <p className="text-xs uppercase tracking-[0.14em] text-accent-success">Estimated savings</p>
+              <p className="mt-2 text-2xl font-semibold text-white">{formatUsd(roi.estimatedSavings)}</p>
+            </div>
+          </div>
+
+          <div className="mt-5 rounded-2xl border border-white/10 bg-white/[0.04] p-5 text-sm leading-7 text-slate-300">
+            <p>
+              Breakdown: {formatUsd(roi.engineeringCost)} engineering, {formatUsd(roi.platformCost)} platform
+              operations, and {formatUsd(roi.complianceCost)} compliance evidence work.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/presidio-alternative/RoiCalculator.tsx
+++ b/app/presidio-alternative/RoiCalculator.tsx
@@ -12,25 +12,25 @@ const maintenanceItems = [
   'Browser store releases and extension support',
 ] as const
 
-function formatUsd(value: number) {
-  return new Intl.NumberFormat('en-US', {
+function formatGbp(value: number) {
+  return new Intl.NumberFormat('en-GB', {
     style: 'currency',
-    currency: 'USD',
+    currency: 'GBP',
     maximumFractionDigits: 0,
   }).format(Math.max(0, Math.round(value)))
 }
 
 export default function RoiCalculator() {
-  const [engineers, setEngineers] = useState(3)
-  const [months, setMonths] = useState(9)
-  const [monthlyCost, setMonthlyCost] = useState(18000)
-  const [complianceHours, setComplianceHours] = useState(140)
-  const [neutralaiMonthly, setNeutralaiMonthly] = useState(499)
+  const [engineers, setEngineers] = useState(2)
+  const [months, setMonths] = useState(6)
+  const [monthlyCost, setMonthlyCost] = useState(8500)
+  const [complianceHours, setComplianceHours] = useState(60)
+  const [neutralaiMonthly, setNeutralaiMonthly] = useState(399)
 
   const roi = useMemo(() => {
     const engineeringCost = engineers * monthlyCost * months
-    const platformCost = 2500 * months
-    const complianceCost = complianceHours * 150
+    const platformCost = 900 * months
+    const complianceCost = complianceHours * 85
     const internalBuildCost = engineeringCost + platformCost + complianceCost
     const neutralaiCost = neutralaiMonthly * months
     return {
@@ -56,7 +56,8 @@ export default function RoiCalculator() {
           </h2>
           <p className="mt-4 text-sm leading-7 text-slate-300 md:text-base">
             Use conservative assumptions to estimate the internal build path. This calculator keeps the model simple:
-            engineering time, platform operations, and compliance evidence work.
+            UK engineering time, platform operations, and compliance evidence work. Defaults use a modest two-engineer
+            production build over six months, not a large transformation programme.
           </p>
 
           <div className="mt-7 grid gap-3">
@@ -96,11 +97,11 @@ export default function RoiCalculator() {
               <span className="mt-1 block text-sm text-slate-300">{months} months</span>
             </label>
             <label className="block">
-              <span className="text-sm font-medium text-white">Loaded monthly cost per engineer</span>
+              <span className="text-sm font-medium text-white">Loaded monthly cost per engineer, GBP</span>
               <input
                 type="number"
-                min="8000"
-                step="1000"
+                min="5500"
+                step="500"
                 value={monthlyCost}
                 onChange={(event) => setMonthlyCost(Number(event.target.value))}
                 className="mt-3 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none focus:border-primary"
@@ -118,11 +119,11 @@ export default function RoiCalculator() {
               />
             </label>
             <label className="block md:col-span-2">
-              <span className="text-sm font-medium text-white">NeutralAI monthly subscription assumption</span>
+              <span className="text-sm font-medium text-white">NeutralAI monthly subscription assumption, GBP</span>
               <input
                 type="number"
                 min="0"
-                step="100"
+                step="50"
                 value={neutralaiMonthly}
                 onChange={(event) => setNeutralaiMonthly(Number(event.target.value))}
                 className="mt-3 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none focus:border-primary"
@@ -133,22 +134,22 @@ export default function RoiCalculator() {
           <div className="mt-7 grid gap-4 md:grid-cols-3">
             <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
               <p className="text-xs uppercase tracking-[0.14em] text-slate-400">DIY build</p>
-              <p className="mt-2 text-2xl font-semibold text-white">{formatUsd(roi.internalBuildCost)}</p>
+              <p className="mt-2 text-2xl font-semibold text-white">{formatGbp(roi.internalBuildCost)}</p>
             </div>
             <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
               <p className="text-xs uppercase tracking-[0.14em] text-slate-400">NeutralAI</p>
-              <p className="mt-2 text-2xl font-semibold text-white">{formatUsd(roi.neutralaiCost)}</p>
+              <p className="mt-2 text-2xl font-semibold text-white">{formatGbp(roi.neutralaiCost)}</p>
             </div>
             <div className="rounded-2xl border border-accent-success/25 bg-accent-success/10 p-4">
               <p className="text-xs uppercase tracking-[0.14em] text-accent-success">Estimated savings</p>
-              <p className="mt-2 text-2xl font-semibold text-white">{formatUsd(roi.estimatedSavings)}</p>
+              <p className="mt-2 text-2xl font-semibold text-white">{formatGbp(roi.estimatedSavings)}</p>
             </div>
           </div>
 
           <div className="mt-5 rounded-2xl border border-white/10 bg-white/[0.04] p-5 text-sm leading-7 text-slate-300">
             <p>
-              Breakdown: {formatUsd(roi.engineeringCost)} engineering, {formatUsd(roi.platformCost)} platform
-              operations, and {formatUsd(roi.complianceCost)} compliance evidence work.
+              Breakdown: {formatGbp(roi.engineeringCost)} engineering, {formatGbp(roi.platformCost)} platform
+              operations, and {formatGbp(roi.complianceCost)} compliance evidence work.
             </p>
           </div>
         </div>

--- a/app/presidio-alternative/page.tsx
+++ b/app/presidio-alternative/page.tsx
@@ -1,0 +1,299 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import {
+  ArrowRight,
+  BadgeCheck,
+  CheckCircle2,
+  FileText,
+  ShieldCheck,
+  XCircle,
+} from 'lucide-react'
+import RoiCalculator from './RoiCalculator'
+import { siteConfig } from '../site'
+
+export const metadata: Metadata = {
+  title: 'Presidio Alternative for Regulated AI Teams',
+  description:
+    'Compare NeutralAI with building directly on Microsoft Presidio. See PII masking for LLM accuracy, compliance gateway features, TCO, and a build-vs-buy ROI calculator.',
+  keywords: [
+    'presidio alternative',
+    'pii masking for llm',
+    'ai compliance gateway',
+    'Microsoft Presidio alternative',
+    'PII redaction for AI',
+  ],
+  alternates: {
+    canonical: '/presidio-alternative',
+  },
+  openGraph: {
+    title: 'Presidio Alternative for Regulated AI Teams',
+    description:
+      'Presidio is a strong foundation. NeutralAI adds the policy, vault, audit, tenant, browser, and deployment layers around it.',
+    url: `${siteConfig.url}/presidio-alternative`,
+  },
+}
+
+const benchmark = {
+  generatedAt: '2026-05-08',
+  caseCount: 1000,
+  languages: ['DE', 'EN', 'ES', 'FR', 'TR'],
+  neutralaiF1: '99.2%',
+  presidioF1: '57.5%',
+  neutralaiRecall: '98.4%',
+  presidioRecall: '40.3%',
+  exactMatch: '98.4%',
+} as const
+
+const appBenchmarkUrl = `${siteConfig.appBaseUrl}/pii-benchmark`
+const latencyBenchmarkUrl = `${siteConfig.appBaseUrl}/latency-benchmark`
+
+const comparisonRows = [
+  {
+    capability: 'PII detection and anonymization',
+    presidio: 'Strong open-source analyzer and anonymizer building blocks for text, images, and structured data.',
+    neutralai: 'Uses proven detection foundations, then adds product calibration, policy enforcement, and gateway controls.',
+  },
+  {
+    capability: 'Vault and reversible tokenization',
+    presidio: 'Possible to build, but your team owns key handling, token lifecycle, storage, and restore paths.',
+    neutralai: 'Encrypted vault workflows, token boundaries, TTL controls, and product-level restore behavior are part of the platform.',
+  },
+  {
+    capability: 'Audit evidence',
+    presidio: 'You design the logging model, redaction policy, admin visibility, and evidence exports.',
+    neutralai: 'Audit-friendly events, compliance reports, benchmark artifacts, and operational proof are product surfaces.',
+  },
+  {
+    capability: 'Multi-tenant rollout',
+    presidio: 'You own tenant isolation, API keys, rate limits, policy scoping, and admin roles.',
+    neutralai: 'Tenant-aware controls, billing posture, API key lifecycle, admin surfaces, and rollout boundaries are built in.',
+  },
+  {
+    capability: 'Enterprise access controls',
+    presidio: 'SSO, MFA, BYOK posture, SIEM export, and procurement evidence are separate engineering projects.',
+    neutralai: 'SSO/MFA posture, BYOK-oriented deployment choices, SIEM-ready evidence, and security review assets are part of the product story.',
+  },
+  {
+    capability: 'Browser extension',
+    presidio: 'You build, submit, support, and monitor browser-specific enforcement yourself.',
+    neutralai: 'Chrome and Edge extension enforcement is a first-class user path with visible shield status and quota behavior.',
+  },
+] as const
+
+const proofCards = [
+  {
+    label: 'NeutralAI overall F1',
+    value: benchmark.neutralaiF1,
+    tone: 'primary',
+  },
+  {
+    label: 'Presidio-vanilla overall F1',
+    value: benchmark.presidioF1,
+    tone: 'muted',
+  },
+  {
+    label: 'NeutralAI exact-match accuracy',
+    value: benchmark.exactMatch,
+    tone: 'primary',
+  },
+] as const
+
+function MetricBar({ label, neutralai, presidio }: { label: string; neutralai: string; presidio: string }) {
+  const neutralaiWidth = Number(neutralai.replace('%', ''))
+  const presidioWidth = Number(presidio.replace('%', ''))
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-4 text-sm">
+        <span className="font-medium text-white">{label}</span>
+        <span className="text-slate-400">NeutralAI {neutralai} / Presidio {presidio}</span>
+      </div>
+      <div className="mt-3 grid gap-2">
+        <div className="h-3 rounded-full bg-white/10">
+          <div className="h-3 rounded-full bg-primary" style={{ width: `${Math.min(100, neutralaiWidth)}%` }} />
+        </div>
+        <div className="h-3 rounded-full bg-white/10">
+          <div className="h-3 rounded-full bg-slate-500" style={{ width: `${Math.min(100, presidioWidth)}%` }} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function PresidioAlternativePage() {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'NeutralAI',
+    applicationCategory: 'SecurityApplication',
+    description:
+      'NeutralAI is an AI compliance gateway for PII masking for LLM workflows, compared against building directly with Microsoft Presidio.',
+    url: `${siteConfig.url}/presidio-alternative`,
+    offers: {
+      '@type': 'Offer',
+      category: 'AI compliance gateway',
+      url: siteConfig.signupUrl,
+    },
+  }
+
+  return (
+    <main className="min-h-screen pt-24">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <section className="relative overflow-hidden py-20 md:py-24">
+        <div className="absolute inset-0 grid-bg opacity-30" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(6,182,212,0.18),transparent_30%),radial-gradient(circle_at_bottom_right,rgba(249,115,22,0.16),transparent_26%)]" />
+
+        <div className="container-custom relative z-10 grid gap-10 lg:grid-cols-[1fr_0.92fr] lg:items-center">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              Presidio alternative
+            </div>
+            <h1 className="mt-5 font-heading text-5xl font-bold md:text-7xl">
+              Presidio is a library. NeutralAI is the compliance gateway around it.
+            </h1>
+            <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-300">
+              Microsoft Presidio is a strong open-source foundation for PII detection and anonymization. The enterprise
+              question is what happens after detection: vaulting, policy boundaries, audit evidence, tenant controls,
+              SSO, browser enforcement, and maintenance.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <a href="#roi-calculator" className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto">
+                Calculate build vs buy
+                <ArrowRight className="h-5 w-5" />
+              </a>
+              <a href={appBenchmarkUrl} className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto">
+                View benchmark
+              </a>
+            </div>
+          </div>
+
+          <div className="rounded-[32px] border border-white/12 bg-background/85 p-6 shadow-[0_24px_90px_rgba(2,6,23,0.45)]">
+            <div className="flex items-center justify-between gap-4 border-b border-white/10 pb-5">
+              <div>
+                <p className="font-mono text-xs uppercase tracking-[0.22em] text-primary-light">Benchmark proof</p>
+                <h2 className="mt-2 font-heading text-2xl font-semibold">NeutralAI vs Presidio-vanilla</h2>
+              </div>
+              <span className="rounded-full border border-accent-success/25 bg-accent-success/10 px-3 py-1 text-xs font-semibold text-accent-success">
+                {benchmark.caseCount} cases
+              </span>
+            </div>
+
+            <div className="mt-6 grid gap-4 sm:grid-cols-3">
+              {proofCards.map((card) => (
+                <div
+                  key={card.label}
+                  className={`rounded-2xl border p-5 ${
+                    card.tone === 'primary'
+                      ? 'border-primary/20 bg-primary/10'
+                      : 'border-white/10 bg-white/5'
+                  }`}
+                >
+                  <p className="text-xs uppercase tracking-[0.14em] text-slate-400">{card.label}</p>
+                  <p className="mt-2 text-3xl font-semibold text-white">{card.value}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-6 space-y-5">
+              <MetricBar label="Overall F1" neutralai={benchmark.neutralaiF1} presidio={benchmark.presidioF1} />
+              <MetricBar label="Overall recall" neutralai={benchmark.neutralaiRecall} presidio={benchmark.presidioRecall} />
+            </div>
+
+            <div className="mt-6 rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+              <p className="text-sm leading-7 text-slate-300">
+                Public benchmark generated on <span className="font-medium text-white">{benchmark.generatedAt}</span>.
+                It covers {benchmark.languages.join(', ')} prompt samples and links back to the gateway-owned proof page.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container-custom">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Feature comparison</p>
+              <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
+                What you still need to build around Presidio
+              </h2>
+              <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-300 md:text-base">
+                Presidio gives teams an adaptable detection engine. Regulated AI teams also need the operational layer
+                that makes masking enforceable, explainable, and supportable in production.
+              </p>
+            </div>
+            <Link href="/insights/presidio-alone-regulated-industries" className="inline-flex items-center gap-2 text-sm font-semibold text-primary-light hover:text-primary">
+              Read the technical note
+              <FileText className="h-4 w-4" />
+            </Link>
+          </div>
+
+          <div className="mt-10 overflow-hidden rounded-[28px] border border-white/10 bg-background/80">
+            <div className="grid border-b border-white/10 bg-white/[0.04] text-sm font-semibold text-slate-200 md:grid-cols-[0.78fr_1fr_1fr]">
+              <div className="px-5 py-4">Capability</div>
+              <div className="px-5 py-4">Build with Presidio</div>
+              <div className="px-5 py-4">Buy NeutralAI</div>
+            </div>
+            {comparisonRows.map((row) => (
+              <div key={row.capability} className="grid border-b border-white/10 last:border-b-0 md:grid-cols-[0.78fr_1fr_1fr]">
+                <div className="px-5 py-5 font-heading text-lg font-semibold text-white">{row.capability}</div>
+                <div className="flex gap-3 px-5 py-5 text-sm leading-6 text-slate-400">
+                  <XCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-[#fdba74]" />
+                  <span>{row.presidio}</span>
+                </div>
+                <div className="flex gap-3 px-5 py-5 text-sm leading-6 text-slate-200">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 flex-shrink-0 text-primary-light" />
+                  <span>{row.neutralai}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-8 rounded-[24px] border border-primary/20 bg-primary/10 p-5 text-sm leading-7 text-slate-200">
+            <BadgeCheck className="mb-3 h-5 w-5 text-primary-light" />
+            NeutralAI is not positioned as a from-scratch recognizer model. It uses proven open-source detection
+            foundations and adds the gateway, policy, tokenization, audit, deployment, and UX layers regulated teams
+            usually have to build themselves.
+          </div>
+        </div>
+      </section>
+
+      <RoiCalculator />
+
+      <section className="section">
+        <div className="container-custom">
+          <div className="rounded-[32px] border border-primary/20 bg-[linear-gradient(180deg,rgba(15,23,42,0.95),rgba(2,6,23,0.97)),radial-gradient(circle_at_top_right,rgba(34,211,238,0.18),transparent_24%)] px-6 py-10 md:px-10">
+            <div className="grid gap-8 lg:grid-cols-[1fr_0.82fr] lg:items-center">
+              <div>
+                <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Customer-safe proof</p>
+                <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
+                  Use the website for the sales story. Use the gateway for the proof source.
+                </h2>
+                <p className="mt-5 max-w-2xl text-sm leading-7 text-slate-300 md:text-base">
+                  The comparison page keeps SEO and buyer education on the marketing site, then links to gateway-owned
+                  benchmark pages for reproducible accuracy and latency details.
+                </p>
+              </div>
+              <div className="grid gap-3">
+                <a href={appBenchmarkUrl} className="btn btn-cta justify-center px-8 py-4 text-base">
+                  Open accuracy benchmark
+                </a>
+                <a href={latencyBenchmarkUrl} className="btn btn-secondary justify-center px-8 py-4 text-base">
+                  Open latency benchmark
+                </a>
+                <Link href={siteConfig.signupUrl} className="btn btn-secondary justify-center px-8 py-4 text-base">
+                  Try Free
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,7 +8,9 @@ const routes = [
   '/about',
   '/compare',
   '/contact',
+  '/insights/presidio-alone-regulated-industries',
   '/install-extension',
+  '/presidio-alternative',
   '/privacy',
   '/security',
   '/support/browser-extension',
@@ -19,8 +21,10 @@ const routes = [
 export default function sitemap(): MetadataRoute.Sitemap {
   return routes.map((route) => ({
     url: `${siteConfig.url}${route}`,
-    lastModified: route === '/trust-center' ? '2026-05-08' : '2026-03-29',
+    lastModified: route === '/trust-center' || route === '/presidio-alternative' || route.startsWith('/insights/')
+      ? '2026-05-08'
+      : '2026-03-29',
     changeFrequency: route === '' ? 'weekly' : 'monthly',
-    priority: route === '' ? 1 : 0.7,
+    priority: route === '' ? 1 : route === '/presidio-alternative' ? 0.85 : 0.7,
   }))
 }

--- a/tests/content/presidio-comparison.test.mjs
+++ b/tests/content/presidio-comparison.test.mjs
@@ -27,8 +27,12 @@ test('roi calculator remains client-side and exposes expected controls', () => {
 
   assert.match(source, /'use client'/)
   assert.match(source, /Build vs buy ROI calculator/)
+  assert.match(source, /currency:\s*'GBP'/)
+  assert.match(source, /useState\(8500\)/)
+  assert.match(source, /useState\(399\)/)
   assert.match(source, /Engineers assigned/)
   assert.match(source, /Build timeline/)
+  assert.match(source, /Loaded monthly cost per engineer, GBP/)
   assert.match(source, /Estimated savings/)
   assert.match(source, /SpaCy and NLP model updates/)
 })

--- a/tests/content/presidio-comparison.test.mjs
+++ b/tests/content/presidio-comparison.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+
+function readSource(path) {
+  return readFileSync(join(root, path), 'utf8')
+}
+
+test('presidio alternative page carries SEO and build-vs-buy content', () => {
+  const source = readSource('app/presidio-alternative/page.tsx')
+
+  assert.match(source, /Presidio Alternative for Regulated AI Teams/)
+  assert.match(source, /presidio alternative/)
+  assert.match(source, /pii masking for llm/)
+  assert.match(source, /ai compliance gateway/)
+  assert.match(source, /Build with Presidio/)
+  assert.match(source, /Buy NeutralAI/)
+  assert.match(source, /Presidio is a library/)
+  assert.match(source, /not positioned as a from-scratch recognizer model/)
+})
+
+test('roi calculator remains client-side and exposes expected controls', () => {
+  const source = readSource('app/presidio-alternative/RoiCalculator.tsx')
+
+  assert.match(source, /'use client'/)
+  assert.match(source, /Build vs buy ROI calculator/)
+  assert.match(source, /Engineers assigned/)
+  assert.match(source, /Build timeline/)
+  assert.match(source, /Estimated savings/)
+  assert.match(source, /SpaCy and NLP model updates/)
+})
+
+test('presidio insight page links official sources and benchmark proof', () => {
+  const source = readSource('app/insights/presidio-alone-regulated-industries/page.tsx')
+
+  assert.match(source, /Why Presidio alone is not enough for regulated industries/)
+  assert.match(source, /https:\/\/github\.com\/microsoft\/presidio/)
+  assert.match(source, /https:\/\/microsoft\.github\.io\/presidio\//)
+  assert.match(source, /siteConfig\.appBaseUrl\}\/pii-benchmark/)
+  assert.match(source, /not the same thing as a full AI compliance gateway/)
+})
+
+test('new routes are discoverable from existing website surfaces', () => {
+  const compare = readSource('app/compare/page.tsx')
+  const footer = readSource('app/components/Footer.tsx')
+  const sitemap = readSource('app/sitemap.ts')
+
+  assert.match(compare, /\/presidio-alternative/)
+  assert.match(footer, /\/presidio-alternative/)
+  assert.match(sitemap, /\/presidio-alternative/)
+  assert.match(sitemap, /\/insights\/presidio-alone-regulated-industries/)
+})


### PR DESCRIPTION
Closes #22

## Summary
- Add a website-native Presidio alternative page with benchmark proof, feature comparison, SEO metadata, and an interactive build-vs-buy ROI calculator.
- Add a technical insight page explaining why Presidio alone is not enough for regulated AI workflows.
- Link the new pages from existing compare/footer surfaces and include both routes in the sitemap.

## Tests
- npm run test:content
- npm run build
- npm run lint
- npm run audit:prod
- git diff --check

## Notes
- Gateway issue nazifsohtaoglu/neutralai-gateway#754 was closed as transferred.
- Gateway PR nazifsohtaoglu/neutralai-gateway#776 was closed to avoid merging marketing content into the app repo.
- Benchmark proof links remain gateway-owned via app.neutralai.co.uk/pii-benchmark and app.neutralai.co.uk/latency-benchmark.