### PR TITLE
Remove beta-era product positioning

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -7,15 +7,15 @@ import BackButton from '../components/BackButton'
 const principles = [
   {
     icon: Shield,
-    title: 'Security before convenience',
+    title: 'Production readiness with transparency',
     description:
-      'We would rather explain a staged rollout honestly than present a product as more mature than it is.',
+      'We explain deployment posture, control coverage, and review expectations clearly so teams can approve AI usage with confidence.',
   },
   {
     icon: Lock,
     title: 'Sensitive data deserves boundaries',
     description:
-      'NeutralAI is being built around the idea that AI enablement should not require teams to surrender control of regulated data.',
+      'NeutralAI is designed around the idea that AI enablement should not require teams to surrender control of regulated data.',
   },
   {
     icon: Scale,
@@ -34,7 +34,7 @@ const principles = [
 const focusAreas = [
   'Helping teams place a security gateway in front of external model providers',
   'Making production rollouts easier to validate with health and readiness checks',
-  'Building toward stronger production controls, including immutable evidence paths',
+  'Operating stronger production controls, including evidence paths for governance review',
 ] as const
 
 export default function AboutPage() {
@@ -78,10 +78,10 @@ export default function AboutPage() {
               <h2 className="mt-5 font-heading text-3xl font-bold">What we are building</h2>
               <div className="mt-5 space-y-4 text-slate-400">
                 <p>
-                  NeutralAI is being shaped as a gateway layer that stands between customer applications, browser-based AI usage, and external model providers. The goal is straightforward: let teams adopt AI while applying policy before sensitive data moves beyond the trusted boundary.
+                  NeutralAI operates as a gateway layer that stands between customer applications, browser-based AI usage, and external model providers. The goal is straightforward: let teams adopt AI while applying policy before sensitive data moves beyond the trusted boundary.
                 </p>
                 <p>
-                  That means the product story has to stay credible. We prefer clear operating posture, guided onboarding, and visible hardening milestones over generic enterprise promises.
+                  That means the product story has to stay credible. We prefer clear operating posture, governed onboarding, and visible controls over generic enterprise promises.
                 </p>
               </div>
             </motion.div>
@@ -146,9 +146,9 @@ export default function AboutPage() {
             viewport={{ once: true }}
             className="mx-auto max-w-3xl text-center"
           >
-            <h2 className="font-heading text-3xl font-bold md:text-4xl">Want to evaluate the gateway?</h2>
+            <h2 className="font-heading text-3xl font-bold md:text-4xl">Ready to deploy the gateway?</h2>
             <p className="mt-5 text-lg text-slate-400">
-              The best next step is a rollout conversation that matches your current deployment stage, browser-extension needs, and review requirements.
+              The best next step is a deployment conversation that matches your current environment, browser-extension needs, and review requirements.
             </p>
             <a href="/contact" className="btn btn-cta mt-8 px-8 py-4 text-lg">
               Contact NeutralAI

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -32,7 +32,7 @@ const contactCards = [
 const onboardingSteps = [
   'Share the models, applications, or workflows you want to protect.',
   'We align on scope, data handling expectations, and rollout posture.',
-  'If the fit is right, we move into guided onboarding with the right deployment and review path.',
+  'If the fit is right, we move into governed onboarding with the right deployment and review path.',
 ] as const
 
 export default function ContactPage() {
@@ -52,10 +52,10 @@ export default function ContactPage() {
           >
             <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Contact NeutralAI</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
-              Start the conversation before you start the rollout
+              Schedule a demo for your AI security rollout
             </h1>
             <p className="mt-6 text-xl text-slate-400">
-              NeutralAI is ready for guided evaluation and team rollout conversations. Reach out with your target workflow, model usage, browser extension needs, and compliance expectations so we can scope the right starting point.
+              See NeutralAI in action with your target workflow, model usage, browser extension needs, and compliance expectations so we can scope the right deployment path.
             </p>
           </motion.div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -86,10 +86,10 @@ const trustCards: Card[] = [
 
 const pricingPlans = [
   {
-    name: 'Free evaluation',
-    summary: 'Best for testing the product with a controlled trial',
+    name: 'Free sandbox',
+    summary: 'Best for validating the gateway with a controlled workspace',
     features: [
-      'Starter quota for hands-on evaluation',
+      'Starter quota for hands-on validation',
       'Chat and browser extension workflows',
       'Clear upgrade path when limits are reached',
     ],
@@ -98,12 +98,12 @@ const pricingPlans = [
     featured: false,
   },
   {
-    name: 'Team rollout',
-    summary: 'Best for getting approved AI usage into a team',
+    name: 'Team deployment',
+    summary: 'Best for getting approved AI usage into daily workflows',
     features: [
       'Usage controls and billing readiness',
       'App, extension, or mixed deployment support',
-      'Security review and rollout guidance',
+      'Security review and deployment guidance',
     ],
     href: '/contact',
     cta: 'Talk to Sales',
@@ -477,7 +477,7 @@ function Hero() {
           <div>
             <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-sm text-primary-light">
               <span className="h-2 w-2 rounded-full bg-accent-success animate-pulse" />
-              Use AI. Stay compliant. Prove it.
+              AI Security Gateway - Now Available
             </div>
 
             <h1 className="mt-6 max-w-4xl font-heading text-4xl font-bold leading-tight md:text-6xl xl:text-7xl">
@@ -848,9 +848,9 @@ function Pricing() {
     <section id="pricing" className="section bg-background-secondary">
       <div className="container-custom">
         <SectionIntro
-          eyebrow="Engagement Paths"
-          title="Pick the right starting point"
-          description="Start with a free evaluation, move into a team rollout when the control model is clear, or bring NeutralAI into a stricter enterprise deployment path."
+          eyebrow="Deployment Paths"
+          title="Start small, expand with control"
+          description="Start with a free sandbox, expand into team deployment when the control model is clear, or bring NeutralAI into a stricter enterprise environment."
           centered
         />
 

--- a/tests/content/primary-cta.test.mjs
+++ b/tests/content/primary-cta.test.mjs
@@ -56,3 +56,27 @@ test('final CTA keeps Try Free as the primary action and sales as secondary', ()
   assert.match(homeSource, /function FinalCta\(\)[\s\S]*href=\{siteConfig\.signupUrl\}[\s\S]{0,180}>\s*Try Free/)
   assert.match(homeSource, /function FinalCta\(\)[\s\S]*href="\/contact"[\s\S]{0,180}>\s*Talk to Sales/)
 })
+
+test('public positioning avoids beta and pilot language', () => {
+  const publicPositioningSources = [
+    'app/page.tsx',
+    'app/about/page.tsx',
+    'app/contact/page.tsx',
+    'app/components/Footer.tsx',
+  ]
+
+  for (const path of publicPositioningSources) {
+    const source = readSource(path)
+
+    assert.doesNotMatch(source, /\b(beta|pilot|pilots)\b/i, `${path} should not use beta or pilot language`)
+  }
+})
+
+test('homepage uses confident availability and deployment framing', () => {
+  const homeSource = readSource('app/page.tsx')
+
+  assert.match(homeSource, /AI Security Gateway - Now Available/)
+  assert.match(homeSource, /eyebrow="Deployment Paths"/)
+  assert.doesNotMatch(homeSource, /Engagement Paths/)
+  assert.doesNotMatch(homeSource, /guided rollout phase/i)
+})


### PR DESCRIPTION
## Problem

The public website still had early-stage positioning that could make NeutralAI feel less ready for regulated teams evaluating production AI usage.

## What Changed

- Updated the homepage hero badge to present NeutralAI as an available AI security gateway.
- Reframed About page principles and focus copy around production readiness, governed onboarding, and transparent deployment posture.
- Updated Contact page copy to invite demo and deployment conversations instead of evaluation-era framing.
- Added content tests to prevent beta/pilot language from returning to public positioning surfaces.

## Validation

- [x] `npm run test:content`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual browser smoke check on desktop homepage and mobile contact page

## Risks / Follow-ups

- Product claims remain intentionally conservative; broader compliance/customer proof claims are still tracked separately in the open website roadmap.

Closes #6