### PR TITLE
Add technical trust signals

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,12 +8,15 @@ import {
   Building2,
   CheckCircle2,
   ClipboardCheck,
+  FileText,
   Gauge,
   Globe,
   KeyRound,
+  Languages,
   Lock,
   Monitor,
   Network,
+  ScanSearch,
   Server,
   ShieldCheck,
   Timer,
@@ -222,10 +225,46 @@ const pricingFaqs = [
 const trustBadges = [
   'AES-256-GCM vault',
   'SOC2 readiness',
-  'GDPR aligned',
+  'GDPR-aligned controls',
   'Cyber Essentials evidence',
   '20+ PII entity types',
   '5+ language benchmark',
+] as const
+
+const technicalTrustDetails = [
+  {
+    icon: ScanSearch,
+    title: 'Two-stage detection',
+    detail: 'Presidio NER and pattern matching with semantic validation using Qdrant.',
+  },
+  {
+    icon: Lock,
+    title: 'Encrypted token vault',
+    detail: 'AES-256-GCM-backed reversible tokenization for governed restore paths.',
+  },
+  {
+    icon: FileText,
+    title: 'Entity coverage',
+    detail: 'EMAIL, PHONE, PERSON, CREDIT_CARD, IBAN, SSN, TR_ID, UK_NHS, and custom rules.',
+  },
+  {
+    icon: Languages,
+    title: 'Policy tuning',
+    detail: 'Configurable confidence thresholds per entity type and multilingual detection coverage.',
+  },
+] as const
+
+const entityTypes = [
+  'EMAIL',
+  'PHONE',
+  'PERSON',
+  'CREDIT_CARD',
+  'IBAN',
+  'SSN',
+  'TR_ID',
+  'UK_NHS',
+  'IP_ADDRESS',
+  'Custom rules',
 ] as const
 
 const complianceProofs = [
@@ -866,6 +905,40 @@ function HowItWorks() {
                 <div className={`mt-6 h-1 w-16 rounded-full ${index === 1 ? 'bg-[linear-gradient(90deg,#f97316,#fdba74)]' : 'bg-[linear-gradient(90deg,#22d3ee,#7dd3fc)]'}`} />
               </motion.div>
             ))}
+          </div>
+
+          <div className="mt-8 grid gap-6 lg:grid-cols-[1.05fr_0.95fr]">
+            <div className="rounded-[24px] border border-white/10 bg-background/85 p-5 md:p-6">
+              <p className="font-mono text-xs uppercase tracking-[0.24em] text-primary-light">Under the hood</p>
+              <h3 className="mt-3 font-heading text-2xl font-semibold">Detection, tokenization, and policy controls</h3>
+              <div className="mt-5 grid gap-4 sm:grid-cols-2">
+                {technicalTrustDetails.map((item) => (
+                  <div key={item.title} className="rounded-2xl border border-white/10 bg-white/[0.035] p-4">
+                    <item.icon className="h-5 w-5 text-primary-light" />
+                    <h4 className="mt-3 font-heading text-lg font-semibold text-slate-100">{item.title}</h4>
+                    <p className="mt-2 text-sm leading-6 text-slate-300">{item.detail}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[24px] border border-primary/15 bg-primary/10 p-5 md:p-6">
+              <p className="font-mono text-xs uppercase tracking-[0.24em] text-primary-light">Entity types</p>
+              <h3 className="mt-3 font-heading text-2xl font-semibold">20+ sensitive data classes</h3>
+              <p className="mt-3 text-sm leading-6 text-slate-300">
+                Core recognizers cover common personal, financial, network, and regional identifiers, with tenant-specific rules available for regulated workflows.
+              </p>
+              <div className="mt-5 flex flex-wrap gap-2">
+                {entityTypes.map((entity) => (
+                  <span
+                    key={entity}
+                    className="rounded-full border border-white/10 bg-background/80 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.16em] text-slate-200"
+                  >
+                    {entity}
+                  </span>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -2,9 +2,13 @@
 
 import { motion } from 'framer-motion'
 import {
+  ArrowRight,
   Database,
   ExternalLink,
+  FileText,
+  KeyRound,
   Lock,
+  Network,
   Scale,
   ServerCog,
   Shield,
@@ -42,8 +46,41 @@ const securitySections = [
 const readinessItems = [
   'Public endpoints are live behind TLS on api.neutralai.co.uk.',
   'Docker-based deployment and reverse proxy setup are already in place.',
-  'The current public website intentionally avoids presenting the product as unrestricted production-ready.',
+  'The current public website describes production controls without implying unsupported certification status.',
   'Production go-live discussions should include the immutable storage roadmap and security review scope.',
+] as const
+
+const securitySpecs = [
+  {
+    icon: Lock,
+    title: 'Encryption and token vault',
+    description:
+      'Sensitive values can be replaced with reversible tokens backed by an AES-256-GCM vault, then restored only through governed paths.',
+  },
+  {
+    icon: Network,
+    title: 'Detection pipeline',
+    description:
+      'Detection combines Presidio NER, pattern matching, semantic validation with Qdrant, and configurable confidence thresholds.',
+  },
+  {
+    icon: FileText,
+    title: 'Entity coverage',
+    description:
+      'Coverage includes EMAIL, PHONE, PERSON, CREDIT_CARD, IBAN, SSN, TR_ID, UK_NHS, IP_ADDRESS, and tenant-specific rules.',
+  },
+  {
+    icon: KeyRound,
+    title: 'Governed restore path',
+    description:
+      'Reversible masking is separated from normal model traffic so restored values can remain behind explicit authorization and audit controls.',
+  },
+] as const
+
+const architectureSteps = [
+  'Client app or browser extension',
+  'NeutralAI policy and masking gateway',
+  'Sanitized request to external LLM provider',
 ] as const
 
 export default function SecurityPage() {
@@ -91,6 +128,42 @@ export default function SecurityPage() {
                 <p className="mt-3 text-sm leading-6 text-slate-400">{section.description}</p>
               </motion.div>
             ))}
+          </div>
+
+          <div className="mt-10 rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.96),rgba(2,6,23,0.96)),radial-gradient(circle_at_top_left,rgba(34,211,238,0.12),transparent_24%)] p-6 md:p-8">
+            <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+              <div>
+                <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Technical controls</p>
+                <h2 className="mt-4 font-heading text-3xl font-bold">Mask first, then route the sanitized request</h2>
+                <p className="mt-4 text-slate-400">
+                  NeutralAI adds a policy gateway before external model providers so sensitive values can be detected, tokenized, and audited before prompt egress.
+                </p>
+
+                <div className="mt-6 grid gap-3">
+                  {architectureSteps.map((step, index) => (
+                    <div key={step} className="flex items-center gap-3">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full border border-primary/25 bg-primary/10 font-mono text-sm text-primary-light">
+                        0{index + 1}
+                      </div>
+                      <div className="min-w-0 flex-1 rounded-2xl border border-white/10 bg-background/80 px-4 py-3 text-sm text-slate-200">
+                        {step}
+                      </div>
+                      {index < architectureSteps.length - 1 ? <ArrowRight className="hidden h-5 w-5 text-primary-light sm:block" /> : null}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                {securitySpecs.map((spec) => (
+                  <div key={spec.title} className="rounded-[22px] border border-white/10 bg-white/[0.035] p-5">
+                    <spec.icon className="h-5 w-5 text-primary-light" />
+                    <h3 className="mt-4 font-heading text-xl font-semibold">{spec.title}</h3>
+                    <p className="mt-3 text-sm leading-6 text-slate-400">{spec.description}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       </section>
@@ -142,6 +215,15 @@ export default function SecurityPage() {
                   className="flex items-center justify-between rounded-2xl border border-border bg-background px-4 py-4 text-slate-200 transition-colors hover:border-primary"
                 >
                   <span>Public readiness endpoint</span>
+                  <ExternalLink className="h-4 w-4 text-primary" />
+                </a>
+                <a
+                  href={`${siteConfig.url}${siteConfig.securityTxtPath}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center justify-between rounded-2xl border border-border bg-background px-4 py-4 text-slate-200 transition-colors hover:border-primary"
+                >
+                  <span>Public security.txt</span>
                   <ExternalLink className="h-4 w-4 text-primary" />
                 </a>
                 <a

--- a/tests/content/trust-signals.test.mjs
+++ b/tests/content/trust-signals.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+
+function readSource(path) {
+  return readFileSync(join(root, path), 'utf8')
+}
+
+test('homepage exposes concrete trust badges and detection details', () => {
+  const homeSource = readSource('app/page.tsx')
+
+  assert.match(homeSource, /AES-256-GCM vault/)
+  assert.match(homeSource, /SOC2 readiness/)
+  assert.match(homeSource, /GDPR-aligned controls/)
+  assert.match(homeSource, /Cyber Essentials evidence/)
+  assert.match(homeSource, /20\+ PII entity types/)
+  assert.match(homeSource, /5\+ language benchmark/)
+  assert.match(homeSource, /Presidio NER and pattern matching with semantic validation using Qdrant/)
+  assert.match(homeSource, /Configurable confidence thresholds per entity type/)
+  assert.match(homeSource, /EMAIL/)
+  assert.match(homeSource, /CREDIT_CARD/)
+  assert.match(homeSource, /UK_NHS/)
+})
+
+test('security page describes architecture, encryption, and public trust links', () => {
+  const securitySource = readSource('app/security/page.tsx')
+
+  assert.match(securitySource, /AES-256-GCM vault/)
+  assert.match(securitySource, /Presidio NER/)
+  assert.match(securitySource, /semantic validation with Qdrant/)
+  assert.match(securitySource, /Client app or browser extension/)
+  assert.match(securitySource, /NeutralAI policy and masking gateway/)
+  assert.match(securitySource, /Sanitized request to external LLM provider/)
+  assert.match(securitySource, /siteConfig\.securityTxtPath/)
+  assert.match(securitySource, /siteConfig\.apiHealthUrl/)
+  assert.match(securitySource, /siteConfig\.apiReadyUrl/)
+})


### PR DESCRIPTION
## Problem

The public website needed stronger technical trust signals for security-conscious buyers evaluating NeutralAI as an AI data protection gateway.

## What Changed

- Added concrete homepage trust badges for AES-256-GCM, SOC2 readiness, GDPR-aligned controls, Cyber Essentials evidence, entity coverage, and language benchmark coverage.
- Enhanced the homepage How It Works section with Presidio/Qdrant detection details, token vault copy, entity examples, and confidence-threshold language.
- Expanded the Security page with a client → NeutralAI gateway → sanitized LLM request architecture flow, encryption/tokenization details, entity coverage, and security.txt link.
- Added content tests that pin the new technical trust signals and security-page details.

## Validation

- [x] `npm run test:content`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual browser smoke check on desktop `/#how-it-works` and mobile `/security`

## Risks / Follow-ups

- Copy avoids unsupported certification claims; broader compliance/customer proof claims remain tracked in later roadmap items.
- `npm install` reported existing dependency audit warnings: 2 moderate / 1 high. No dependency changes were made in this ticket.

Closes #7