### PR TITLE
Add blog infrastructure and first article

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,121 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowLeft, ArrowRight, CalendarDays, Clock3 } from 'lucide-react'
+import { siteConfig } from '../../site'
+import { BlogPostBody, getAllPosts, getPostBySlug } from '../posts'
+
+type BlogPostPageProps = {
+  params: Promise<{ slug: string }>
+}
+
+export function generateStaticParams() {
+  return getAllPosts().map((post) => ({
+    slug: post.slug,
+  }))
+}
+
+export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const post = getPostBySlug(slug)
+
+  if (!post) {
+    return {}
+  }
+
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: {
+      canonical: `/blog/${post.slug}`,
+    },
+    openGraph: {
+      title: post.title,
+      description: post.description,
+      url: `${siteConfig.url}/blog/${post.slug}`,
+      type: 'article',
+      publishedTime: post.date,
+      authors: [post.author],
+    },
+  }
+}
+
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+  const { slug } = await params
+  const post = getPostBySlug(slug)
+
+  if (!post) {
+    notFound()
+  }
+
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.description,
+    datePublished: post.date,
+    author: {
+      '@type': 'Organization',
+      name: post.author,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: siteConfig.name,
+      logo: `${siteConfig.url}/logo.png`,
+    },
+    mainEntityOfPage: `${siteConfig.url}/blog/${post.slug}`,
+  }
+
+  return (
+    <main className="min-h-screen pt-24">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <article className="container-custom max-w-4xl py-16 md:py-20">
+        <Link href="/blog" className="inline-flex items-center gap-2 text-sm font-medium text-primary-light hover:text-primary">
+          <ArrowLeft className="h-4 w-4" />
+          Back to blog
+        </Link>
+
+        <header className="mt-10 border-b border-border pb-10">
+          <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">{post.category}</p>
+          <h1 className="mt-5 font-heading text-4xl font-bold leading-tight md:text-6xl">{post.title}</h1>
+          <p className="mt-5 text-lg leading-8 text-slate-300">{post.description}</p>
+          <div className="mt-6 flex flex-wrap gap-4 text-sm text-slate-400">
+            <span>{post.author}</span>
+            <span className="inline-flex items-center gap-1.5">
+              <CalendarDays className="h-4 w-4" />
+              {post.date}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <Clock3 className="h-4 w-4" />
+              {post.readingTime}
+            </span>
+          </div>
+        </header>
+
+        <div className="mt-10">
+          <BlogPostBody content={post.content} />
+        </div>
+
+        <section className="mt-12 rounded-[30px] border border-primary/20 bg-primary/10 p-6 md:p-8">
+          <h2 className="font-heading text-2xl font-semibold text-white">Want to make AI safer for your team?</h2>
+          <p className="mt-3 text-sm leading-7 text-slate-300">
+            NeutralAI helps regulated teams mask sensitive prompt data before it reaches external model providers.
+          </p>
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+            <Link href={siteConfig.signupUrl} className="btn btn-cta justify-center px-8 py-4">
+              Try Free
+              <ArrowRight className="h-5 w-5" />
+            </Link>
+            <Link href="/contact" className="btn btn-secondary justify-center px-8 py-4">
+              Talk to Sales
+            </Link>
+          </div>
+        </section>
+      </article>
+    </main>
+  )
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,107 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, CalendarDays, Clock3, FileText } from 'lucide-react'
+import BackButton from '../components/BackButton'
+import { siteConfig } from '../site'
+import { getAllPosts } from './posts'
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description:
+    'NeutralAI articles on PII masking, AI governance, privacy engineering, and secure enterprise AI adoption.',
+  alternates: {
+    canonical: '/blog',
+  },
+  openGraph: {
+    title: 'NeutralAI Blog',
+    description:
+      'Practical guidance for PII-safe LLM adoption, privacy engineering, and AI governance.',
+    url: `${siteConfig.url}/blog`,
+  },
+}
+
+export default function BlogIndexPage() {
+  const posts = getAllPosts()
+  const featured = posts[0]
+
+  return (
+    <main className="min-h-screen pt-24">
+      <section className="relative overflow-hidden py-16 md:py-20">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_8%,rgba(34,211,238,0.16),transparent_26%),radial-gradient(circle_at_86%_16%,rgba(249,115,22,0.14),transparent_22%)]" />
+        <div className="container-custom relative z-10">
+          <BackButton />
+
+          <div className="grid gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-end">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">NeutralAI Blog</p>
+              <h1 className="mt-5 max-w-3xl font-heading text-4xl font-bold leading-[0.98] md:text-6xl">
+                Practical notes for secure enterprise AI adoption.
+              </h1>
+              <p className="mt-6 max-w-2xl text-lg leading-8 text-slate-300">
+                Guides on PII masking, AI governance, browser-based AI risk, and the controls regulated teams need before broad rollout.
+              </p>
+            </div>
+
+            {featured ? (
+              <Link
+                href={`/blog/${featured.slug}`}
+                className="rounded-[30px] border border-primary/25 bg-background-secondary/80 p-6 shadow-2xl shadow-cyan-950/20 transition hover:border-primary"
+              >
+                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-primary-light">
+                  <FileText className="h-4 w-4" />
+                  Featured
+                </div>
+                <h2 className="mt-5 font-heading text-3xl font-bold">{featured.title}</h2>
+                <p className="mt-4 text-sm leading-7 text-slate-400">{featured.description}</p>
+                <div className="mt-6 flex flex-wrap gap-3 text-xs text-slate-400">
+                  <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1">{featured.category}</span>
+                  <span className="inline-flex items-center gap-1">
+                    <CalendarDays className="h-3.5 w-3.5" />
+                    {featured.date}
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <Clock3 className="h-3.5 w-3.5" />
+                    {featured.readingTime}
+                  </span>
+                </div>
+                <span className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-primary-light">
+                  Read article
+                  <ArrowRight className="h-4 w-4" />
+                </span>
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <section className="section bg-background-secondary">
+        <div className="container-custom">
+          <div className="mb-8 max-w-3xl">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Latest Articles</p>
+            <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">Start with the controls that unblock AI.</h2>
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+            {posts.map((post) => (
+              <Link
+                key={post.slug}
+                href={`/blog/${post.slug}`}
+                className="rounded-[24px] border border-white/10 bg-background p-6 transition hover:border-primary/50 hover:-translate-y-1"
+              >
+                <span className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs text-primary-light">
+                  {post.category}
+                </span>
+                <h3 className="mt-5 font-heading text-2xl font-semibold text-white">{post.title}</h3>
+                <p className="mt-3 text-sm leading-6 text-slate-400">{post.description}</p>
+                <div className="mt-6 flex items-center justify-between gap-4 text-xs text-slate-500">
+                  <span>{post.date}</span>
+                  <span>{post.readingTime}</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/blog/posts.tsx
+++ b/app/blog/posts.tsx
@@ -1,0 +1,229 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import Link from 'next/link'
+
+export type BlogPostMeta = {
+  slug: string
+  title: string
+  description: string
+  date: string
+  author: string
+  category: string
+  readingTime: string
+}
+
+type BlogPost = BlogPostMeta & {
+  content: string
+}
+
+const blogDirectory = join(process.cwd(), 'content/blog')
+
+function parseFrontmatter(source: string): { metadata: Record<string, string>; content: string } {
+  const match = source.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/)
+
+  if (!match) {
+    throw new Error('Blog post is missing frontmatter')
+  }
+
+  const metadata = Object.fromEntries(
+    match[1]
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const [key, ...valueParts] = line.split(':')
+        return [key.trim(), valueParts.join(':').trim().replace(/^"|"$/g, '')]
+      })
+  )
+
+  return {
+    metadata,
+    content: match[2].trim(),
+  }
+}
+
+function calculateReadingTime(content: string) {
+  const words = content.split(/\s+/).filter(Boolean).length
+  return `${Math.max(1, Math.ceil(words / 220))} min read`
+}
+
+function readPostByFilename(filename: string): BlogPost {
+  const slug = filename.replace(/\.mdx$/, '')
+  const source = readFileSync(join(blogDirectory, filename), 'utf8')
+  const { metadata, content } = parseFrontmatter(source)
+
+  return {
+    slug,
+    title: metadata.title,
+    description: metadata.description,
+    date: metadata.date,
+    author: metadata.author,
+    category: metadata.category,
+    readingTime: calculateReadingTime(content),
+    content,
+  }
+}
+
+export function getAllPosts(): BlogPostMeta[] {
+  return readdirSync(blogDirectory)
+    .filter((filename) => filename.endsWith('.mdx'))
+    .map(readPostByFilename)
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .map(({ content: _content, ...meta }) => meta)
+}
+
+export function getPostBySlug(slug: string): BlogPost | undefined {
+  const filename = `${slug}.mdx`
+
+  if (!readdirSync(blogDirectory).includes(filename)) {
+    return undefined
+  }
+
+  return readPostByFilename(filename)
+}
+
+function parseInline(text: string) {
+  const segments = text.split(/(`[^`]+`|\[[^\]]+\]\([^)]+\)|\*\*[^*]+\*\*)/g)
+
+  return segments.map((segment, index) => {
+    if (segment.startsWith('`') && segment.endsWith('`')) {
+      return (
+        <code key={index} className="rounded-md border border-white/10 bg-white/[0.06] px-1.5 py-0.5 font-mono text-sm text-primary-light">
+          {segment.slice(1, -1)}
+        </code>
+      )
+    }
+
+    if (segment.startsWith('**') && segment.endsWith('**')) {
+      return <strong key={index} className="font-semibold text-white">{segment.slice(2, -2)}</strong>
+    }
+
+    const linkMatch = segment.match(/^\[([^\]]+)\]\(([^)]+)\)$/)
+    if (linkMatch) {
+      const href = linkMatch[2]
+      const isExternal = href.startsWith('http')
+
+      if (isExternal) {
+        return (
+          <a key={index} href={href} target="_blank" rel="noreferrer" className="text-primary-light hover:text-primary">
+            {linkMatch[1]}
+          </a>
+        )
+      }
+
+      return (
+        <Link key={index} href={href} className="text-primary-light hover:text-primary">
+          {linkMatch[1]}
+        </Link>
+      )
+    }
+
+    return segment
+  })
+}
+
+function flushParagraph(paragraph: string[], blocks: React.ReactNode[], keyPrefix: string) {
+  if (paragraph.length === 0) {
+    return
+  }
+
+  blocks.push(
+    <p key={`${keyPrefix}-${blocks.length}`} className="text-base leading-8 text-slate-300">
+      {parseInline(paragraph.join(' '))}
+    </p>
+  )
+  paragraph.length = 0
+}
+
+export function BlogPostBody({ content }: { content: string }) {
+  const lines = content.split('\n')
+  const blocks: React.ReactNode[] = []
+  const paragraph: string[] = []
+  let index = 0
+
+  while (index < lines.length) {
+    const line = lines[index]
+
+    if (line.trim() === '') {
+      flushParagraph(paragraph, blocks, 'paragraph')
+      index += 1
+      continue
+    }
+
+    if (line.startsWith('```')) {
+      flushParagraph(paragraph, blocks, 'paragraph')
+      const language = line.replace('```', '').trim() || 'text'
+      const codeLines: string[] = []
+      index += 1
+
+      while (index < lines.length && !lines[index].startsWith('```')) {
+        codeLines.push(lines[index])
+        index += 1
+      }
+
+      blocks.push(
+        <div key={`code-${blocks.length}`} className="overflow-hidden rounded-[24px] border border-white/10 bg-[#020617]">
+          <div className="border-b border-white/10 bg-white/[0.035] px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-primary-light">
+            {language}
+          </div>
+          <pre className="overflow-x-auto p-4 text-sm leading-6 text-slate-200">
+            <code>{codeLines.join('\n')}</code>
+          </pre>
+        </div>
+      )
+      index += 1
+      continue
+    }
+
+    if (line.startsWith('## ')) {
+      flushParagraph(paragraph, blocks, 'paragraph')
+      blocks.push(
+        <h2 key={`h2-${blocks.length}`} className="pt-4 font-heading text-3xl font-semibold text-white">
+          {parseInline(line.slice(3))}
+        </h2>
+      )
+      index += 1
+      continue
+    }
+
+    if (line.startsWith('### ')) {
+      flushParagraph(paragraph, blocks, 'paragraph')
+      blocks.push(
+        <h3 key={`h3-${blocks.length}`} className="pt-3 font-heading text-2xl font-semibold text-white">
+          {parseInline(line.slice(4))}
+        </h3>
+      )
+      index += 1
+      continue
+    }
+
+    if (line.startsWith('- ')) {
+      flushParagraph(paragraph, blocks, 'paragraph')
+      const items: string[] = []
+
+      while (index < lines.length && lines[index].startsWith('- ')) {
+        items.push(lines[index].slice(2))
+        index += 1
+      }
+
+      blocks.push(
+        <ul key={`ul-${blocks.length}`} className="space-y-3">
+          {items.map((item) => (
+            <li key={item} className="flex gap-3 text-base leading-7 text-slate-300">
+              <span className="mt-3 h-2 w-2 flex-shrink-0 rounded-full bg-primary" />
+              <span>{parseInline(item)}</span>
+            </li>
+          ))}
+        </ul>
+      )
+      continue
+    }
+
+    paragraph.push(line.trim())
+    index += 1
+  }
+
+  flushParagraph(paragraph, blocks, 'paragraph')
+
+  return <div className="space-y-7">{blocks}</div>
+}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -9,6 +9,7 @@ const productLinks = [
   { label: 'How It Works', href: homeSections.howItWorks },
   { label: 'Why Trust Us', href: homeSections.trust },
   { label: 'Compare', href: homeSections.compare },
+  { label: 'Blog', href: '/blog' },
   { label: 'Presidio Alternative', href: '/presidio-alternative' },
   { label: 'Pricing', href: homeSections.pricing },
 ] as const

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -12,6 +12,7 @@ const navLinks = [
   { name: 'How It Works', href: homeSections.howItWorks },
   { name: 'Why Trust Us', href: homeSections.trust },
   { name: 'Compare', href: homeSections.compare },
+  { name: 'Blog', href: '/blog' },
   { name: 'Trust Center', href: '/trust-center' },
   { name: 'Pricing', href: homeSections.pricing },
   { name: 'About', href: '/about' },

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,6 +6,8 @@ export const dynamic = 'force-static'
 const routes = [
   '',
   '/about',
+  '/blog',
+  '/blog/why-pii-masking-matters-for-enterprise-ai-adoption',
   '/compare',
   '/contact',
   '/insights/presidio-alone-regulated-industries',
@@ -21,7 +23,9 @@ const routes = [
 export default function sitemap(): MetadataRoute.Sitemap {
   return routes.map((route) => ({
     url: `${siteConfig.url}${route}`,
-    lastModified: route === '/trust-center' || route === '/presidio-alternative' || route.startsWith('/insights/')
+    lastModified: route.startsWith('/blog')
+      ? '2026-05-09'
+      : route === '/trust-center' || route === '/presidio-alternative' || route.startsWith('/insights/')
       ? '2026-05-08'
       : '2026-03-29',
     changeFrequency: route === '' ? 'weekly' : 'monthly',

--- a/content/blog/why-pii-masking-matters-for-enterprise-ai-adoption.mdx
+++ b/content/blog/why-pii-masking-matters-for-enterprise-ai-adoption.mdx
@@ -1,0 +1,68 @@
+---
+title: "Why PII Masking Matters for Enterprise AI Adoption"
+description: "A practical guide to why regulated teams need PII masking before prompts reach external AI providers."
+date: "2026-05-09"
+author: "NeutralAI Team"
+category: "AI Governance"
+---
+
+Enterprise teams want the productivity lift from AI, but they also need a defensible answer to a simple security question: what sensitive data leaves the organization when a prompt is sent?
+
+That question matters because AI adoption is no longer limited to one approved chatbot. Employees use browser tools, product teams embed model calls into applications, and support teams experiment with summarization workflows. Without a control layer, sensitive data can move into model providers through many small paths.
+
+## The risk is ordinary data, not exotic attacks
+
+Most prompt leaks are not dramatic. They look like normal work:
+
+- A support agent pastes a customer email and phone number into a summary prompt.
+- A finance analyst asks an AI tool to explain a payment record containing an IBAN.
+- A healthcare workflow includes a patient identifier in a draft note.
+- A legal team tests contract analysis with client names still present.
+
+The common pattern is that useful business context and sensitive identifiers are mixed together. PII masking separates those concerns before the prompt reaches the model.
+
+## What PII masking changes
+
+PII masking detects sensitive values and replaces them with safe placeholders or governed tokens. The model can still receive the task and surrounding context, but raw identifiers are removed from the request path.
+
+```text
+Original: Summarize Sarah Patel's claim. Email sarah@acme.example and phone +44 7123 456 789.
+Masked:   Summarize <PERSON>'s claim. Email <EMAIL> and phone <PHONE_NUMBER>.
+```
+
+For many AI workflows, that is enough to keep the work moving while reducing exposure. For workflows that need restoration later, reversible tokenization can keep a governed path back to the original value.
+
+## Why enterprises need this before broad rollout
+
+Security and compliance teams are not trying to slow AI adoption for its own sake. They need controls that can be explained, monitored, and reviewed. A practical masking layer helps with four jobs:
+
+- Reduce the chance that raw PII reaches external model providers.
+- Give teams a standard pattern instead of one-off prompt hygiene rules.
+- Create audit evidence about when masking and policy controls ran.
+- Let product teams adopt AI without rebuilding data protection from scratch.
+
+This is especially important in regulated environments where customer data, financial identifiers, health information, or employee records may appear in everyday workflows.
+
+## Detection is only one part of the system
+
+Open-source detection libraries can be useful foundations, but enterprise AI protection needs the operating model around detection: policy decisions, token handling, tenant controls, benchmark evidence, and clear failure behavior.
+
+That is why NeutralAI is built as a gateway pattern. Sensitive data is inspected and masked before the sanitized request moves downstream to a model provider.
+
+## A good first rollout pattern
+
+Teams usually do not need to solve every workflow on day one. A safer rollout starts with high-frequency, high-risk prompt paths:
+
+- support summaries
+- browser-based AI usage
+- internal assistants
+- claims or case notes
+- finance and compliance review workflows
+
+Start with masking, measure where false positives or missed entities appear, and tune policies before expanding to more teams.
+
+## The goal is not to ban AI
+
+The goal is to make AI adoption easier to approve. When security teams can see the control boundary, review evidence, and understand what data is masked, they can move from blanket objections to governed rollout.
+
+PII masking is not the whole AI governance program, but it is one of the first controls that makes enterprise AI adoption practical.

--- a/tests/content/blog.test.mjs
+++ b/tests/content/blog.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+
+function readSource(path) {
+  return readFileSync(join(root, path), 'utf8')
+}
+
+test('blog infrastructure renders index and MDX-backed post pages', () => {
+  const blogIndex = readSource('app/blog/page.tsx')
+  const blogPost = readSource('app/blog/[slug]/page.tsx')
+  const blogPosts = readSource('app/blog/posts.tsx')
+  const post = readSource('content/blog/why-pii-masking-matters-for-enterprise-ai-adoption.mdx')
+
+  assert.match(blogIndex, /NeutralAI Blog/)
+  assert.match(blogIndex, /getAllPosts/)
+  assert.match(blogPost, /generateStaticParams/)
+  assert.match(blogPost, /BlogPosting/)
+  assert.match(blogPosts, /content\/blog/)
+  assert.match(blogPosts, /\.mdx/)
+  assert.match(post, /Why PII Masking Matters for Enterprise AI Adoption/)
+  assert.match(post, /```text/)
+})
+
+test('blog route is discoverable from navigation, footer, and sitemap', () => {
+  const navbar = readSource('app/components/Navbar.tsx')
+  const footer = readSource('app/components/Footer.tsx')
+  const sitemap = readSource('app/sitemap.ts')
+
+  assert.match(navbar, /Blog/)
+  assert.ok(navbar.includes("href: '/blog'"))
+  assert.match(footer, /Blog/)
+  assert.ok(footer.includes("href: '/blog'"))
+  assert.ok(sitemap.includes("'/blog'"))
+  assert.ok(sitemap.includes("'/blog/why-pii-masking-matters-for-enterprise-ai-adoption'"))
+})
+
+test('blog post metadata has SEO-safe fields and canonical paths', () => {
+  const blogIndex = readSource('app/blog/page.tsx')
+  const blogPost = readSource('app/blog/[slug]/page.tsx')
+  const post = readSource('content/blog/why-pii-masking-matters-for-enterprise-ai-adoption.mdx')
+
+  assert.match(blogIndex, /canonical: '\/blog'/)
+  assert.match(blogPost, /canonical: `\/blog\/\$\{post\.slug\}`/)
+  assert.match(post, /description: "A practical guide/)
+  assert.match(post, /date: "2026-05-09"/)
+  assert.match(post, /author: "NeutralAI Team"/)
+})


### PR DESCRIPTION
## Summary
- Add file-backed blog infrastructure with `/blog` and `/blog/[slug]` routes.
- Publish the first NeutralAI blog article on PII masking for enterprise AI adoption.
- Add Blog discovery links in the navbar, footer, and sitemap.

## Validation
- `npm run test:content`
- `npm run lint`
- `npm run build`
- `npm run audit:prod`

Closes #13