### PR TITLE
Add finance and healthcare use-case pages

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -10,6 +10,8 @@ const productLinks = [
   { label: 'Why Trust Us', href: homeSections.trust },
   { label: 'Compare', href: homeSections.compare },
   { label: 'Playground', href: '/playground' },
+  { label: 'Finance Use Case', href: '/use-cases/finance' },
+  { label: 'Healthcare Use Case', href: '/use-cases/healthcare' },
   { label: 'Blog', href: '/blog' },
   { label: 'Presidio Alternative', href: '/presidio-alternative' },
   { label: 'Pricing', href: homeSections.pricing },

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -62,7 +62,7 @@ export default function Navbar() {
               Use Cases
               <ChevronDown className="h-4 w-4 transition-transform group-hover:rotate-180" />
             </button>
-            <div className="invisible absolute left-1/2 top-full z-50 mt-3 w-56 -translate-x-1/2 rounded-2xl border border-white/10 bg-background-secondary/95 p-2 opacity-0 shadow-[0_20px_60px_rgba(2,6,23,0.5)] backdrop-blur transition group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
+            <div className="invisible absolute left-1/2 top-full z-50 w-56 -translate-x-1/2 rounded-2xl border border-white/10 bg-background-secondary/95 p-2 opacity-0 shadow-[0_20px_60px_rgba(2,6,23,0.5)] backdrop-blur transition group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
               {useCaseLinks.map((link) => (
                 <Link
                   key={link.name}
@@ -97,7 +97,7 @@ export default function Navbar() {
         <motion.div 
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="xl:hidden absolute top-full left-0 right-0 glass border-t border-border p-4"
+          className="xl:hidden absolute top-full left-0 right-0 max-h-[calc(100vh-72px)] overflow-y-auto glass border-t border-border p-4"
         >
           {navLinks.map((link) => (
             <Link 

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { motion } from 'framer-motion'
-import { Menu, X } from 'lucide-react'
+import { ChevronDown, Menu, X } from 'lucide-react'
 import { homeSections, siteConfig } from '../site'
 
 const navLinks = [
@@ -18,6 +18,11 @@ const navLinks = [
   { name: 'Pricing', href: homeSections.pricing },
   { name: 'About', href: '/about' },
 ]
+
+const useCaseLinks = [
+  { name: 'Finance', href: '/use-cases/finance' },
+  { name: 'Healthcare', href: '/use-cases/healthcare' },
+] as const
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false)
@@ -49,6 +54,26 @@ export default function Navbar() {
               {link.name}
             </Link>
           ))}
+          <div className="group relative">
+            <button
+              type="button"
+              className="flex items-center gap-1 whitespace-nowrap text-sm text-slate-300 transition-colors hover:text-primary 2xl:text-base"
+            >
+              Use Cases
+              <ChevronDown className="h-4 w-4 transition-transform group-hover:rotate-180" />
+            </button>
+            <div className="invisible absolute left-1/2 top-full z-50 mt-3 w-56 -translate-x-1/2 rounded-2xl border border-white/10 bg-background-secondary/95 p-2 opacity-0 shadow-[0_20px_60px_rgba(2,6,23,0.5)] backdrop-blur transition group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
+              {useCaseLinks.map((link) => (
+                <Link
+                  key={link.name}
+                  href={link.href}
+                  className="block rounded-xl px-3 py-2 text-sm text-slate-300 transition hover:bg-white/[0.06] hover:text-primary"
+                >
+                  {link.name}
+                </Link>
+              ))}
+            </div>
+          </div>
         </div>
 
         <div className="hidden flex-shrink-0 items-center gap-4 xl:flex">
@@ -77,6 +102,17 @@ export default function Navbar() {
           {navLinks.map((link) => (
             <Link 
               key={link.name} 
+              href={link.href}
+              className="block py-3 text-slate-300 hover:text-primary transition-colors"
+              onClick={() => setIsOpen(false)}
+            >
+              {link.name}
+            </Link>
+          ))}
+          <div className="pt-2 font-mono text-xs uppercase tracking-[0.2em] text-slate-500">Use Cases</div>
+          {useCaseLinks.map((link) => (
+            <Link
+              key={link.name}
               href={link.href}
               className="block py-3 text-slate-300 hover:text-primary transition-colors"
               onClick={() => setIsOpen(false)}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -19,6 +19,8 @@ const routes = [
   '/support/browser-extension',
   '/terms',
   '/trust-center',
+  '/use-cases/finance',
+  '/use-cases/healthcare',
 ] as const
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/app/use-cases/UseCasePage.tsx
+++ b/app/use-cases/UseCasePage.tsx
@@ -1,0 +1,158 @@
+import Link from 'next/link'
+import type { LucideIcon } from 'lucide-react'
+import { ArrowRight, BadgeCheck, CheckCircle2, ShieldCheck } from 'lucide-react'
+import { siteConfig } from '../site'
+
+export type UseCasePageContent = {
+  eyebrow: string
+  title: string
+  description: string
+  primaryCta: string
+  secondaryCta: string
+  proofLabel: string
+  proofTitle: string
+  proofBody: string
+  painPoints: string[]
+  workflow: {
+    title: string
+    body: string
+  }[]
+  entities: string[]
+  trustSignals: {
+    icon: LucideIcon
+    title: string
+    body: string
+  }[]
+  disclaimer: string
+}
+
+export default function UseCasePage({ content }: { content: UseCasePageContent }) {
+  return (
+    <main className="min-h-screen pt-24">
+      <section className="relative overflow-hidden py-20 md:py-24">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_12%,rgba(6,182,212,0.18),transparent_28%),radial-gradient(circle_at_82%_18%,rgba(249,115,22,0.15),transparent_24%)]" />
+        <div className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
+
+        <div className="container-custom relative z-10 grid gap-10 lg:grid-cols-[1fr_0.88fr] lg:items-center">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              {content.eyebrow}
+            </div>
+            <h1 className="mt-5 max-w-4xl font-heading text-5xl font-bold md:text-7xl">
+              {content.title}
+            </h1>
+            <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
+              {content.description}
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Link href="/contact" className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto">
+                {content.primaryCta}
+                <ArrowRight className="h-5 w-5" />
+              </Link>
+              <Link href="/playground" className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto">
+                {content.secondaryCta}
+              </Link>
+            </div>
+          </div>
+
+          <div className="rounded-[28px] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.94),rgba(2,6,23,0.98))] p-6 shadow-[0_24px_80px_rgba(2,6,23,0.45)]">
+            <p className="font-mono text-xs uppercase tracking-[0.24em] text-[#fdba74]">{content.proofLabel}</p>
+            <h2 className="mt-3 font-heading text-3xl font-semibold">{content.proofTitle}</h2>
+            <p className="mt-4 text-sm leading-7 text-slate-300">{content.proofBody}</p>
+            <div className="mt-6 grid gap-3">
+              {content.painPoints.map((point) => (
+                <div key={point} className="flex gap-3 rounded-2xl border border-white/10 bg-white/[0.035] px-4 py-3 text-sm text-slate-200">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary-light" />
+                  <span>{point}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container-custom">
+          <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Protected workflow</p>
+              <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
+                Put masking before AI prompts leave the trusted path.
+              </h2>
+              <p className="mt-5 text-lg leading-8 text-slate-400">
+                NeutralAI is positioned between internal users, browser AI tools, application prompts, and external model providers so sensitive values can be removed or tokenized before egress.
+              </p>
+            </div>
+
+            <div className="grid gap-4">
+              {content.workflow.map((step, index) => (
+                <div key={step.title} className="grid gap-4 rounded-[24px] border border-white/10 bg-background-secondary p-5 sm:grid-cols-[auto_1fr]">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-primary/25 bg-primary/10 font-mono text-sm text-primary-light">
+                    0{index + 1}
+                  </div>
+                  <div>
+                    <h3 className="font-heading text-xl font-semibold">{step.title}</h3>
+                    <p className="mt-2 text-sm leading-6 text-slate-400">{step.body}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section bg-background-secondary">
+        <div className="container-custom">
+          <div className="grid gap-8 lg:grid-cols-[1fr_0.95fr] lg:items-start">
+            <div className="rounded-[28px] border border-white/10 bg-background/80 p-6 md:p-8">
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Entity coverage</p>
+              <h2 className="mt-4 font-heading text-3xl font-bold">Industry examples buyers recognize</h2>
+              <div className="mt-6 flex flex-wrap gap-3">
+                {content.entities.map((entity) => (
+                  <span key={entity} className="rounded-full border border-primary/25 bg-primary/10 px-4 py-2 font-mono text-xs uppercase tracking-[0.14em] text-primary-light">
+                    {entity}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid gap-4">
+              {content.trustSignals.map((signal) => (
+                <div key={signal.title} className="rounded-[24px] border border-white/10 bg-background/80 p-5">
+                  <signal.icon className="h-5 w-5 text-primary-light" />
+                  <h3 className="mt-4 font-heading text-xl font-semibold">{signal.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-400">{signal.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-8 rounded-[24px] border border-white/10 bg-white/[0.035] p-5 text-sm leading-7 text-slate-400">
+            <BadgeCheck className="mb-3 h-5 w-5 text-primary-light" />
+            {content.disclaimer}
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container-custom">
+          <div className="mx-auto max-w-4xl rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.95),rgba(2,6,23,0.97)),radial-gradient(circle_at_top_right,rgba(249,115,22,0.16),transparent_22%)] px-6 py-10 text-center md:px-10">
+            <h2 className="font-heading text-3xl font-bold md:text-5xl">Map NeutralAI to your AI rollout.</h2>
+            <p className="mx-auto mt-5 max-w-2xl text-lg text-slate-300">
+              Bring one workflow and one approval concern. We will show where masking, audit evidence, and deployment controls fit.
+            </p>
+            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+              <Link href="/contact" className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto">
+                Talk to Sales
+              </Link>
+              <Link href={siteConfig.signupUrl} className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto">
+                Try Free
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/use-cases/content.ts
+++ b/app/use-cases/content.ts
@@ -1,0 +1,106 @@
+import { ClipboardCheck, HeartPulse, Landmark, LockKeyhole, Scale, ShieldCheck } from 'lucide-react'
+import type { UseCasePageContent } from './UseCasePage'
+
+export const financeUseCase: UseCasePageContent = {
+  eyebrow: 'Finance use case',
+  title: 'Use AI on financial workflows without exposing customer data.',
+  description:
+    'NeutralAI helps financial services teams mask customer names, account identifiers, payment details, and claim references before prompts reach AI providers.',
+  primaryCta: 'See financial AI protection',
+  secondaryCta: 'Try a masking demo',
+  proofLabel: 'Regulated workflow',
+  proofTitle: 'Built for teams facing FCA, PRA, and GDPR review pressure.',
+  proofBody:
+    'The value is not a generic detector. NeutralAI gives security and compliance reviewers a gateway boundary, policy controls, and audit evidence for AI-assisted workflows.',
+  painPoints: [
+    'Claims summaries can include names, policy numbers, phone numbers, and bank details.',
+    'Shadow AI use can move regulated customer data into tools that procurement has not approved.',
+    'Audit teams need evidence of what was masked, when, and through which workflow.',
+  ],
+  workflow: [
+    {
+      title: 'Detect financial identifiers',
+      body: 'Find names, emails, phone numbers, IBANs, card-like values, claim references, and tenant-specific identifiers before prompt egress.',
+    },
+    {
+      title: 'Mask or tokenize before routing',
+      body: 'Send sanitized prompts onward while preserving enough context for useful AI assistance and governed audit review.',
+    },
+    {
+      title: 'Keep evidence for approval conversations',
+      body: 'Use policy events, health checks, and masked-output examples to support security, compliance, and procurement review.',
+    },
+  ],
+  entities: ['PERSON', 'EMAIL', 'PHONE', 'IBAN', 'CREDIT_CARD', 'POLICY_ID', 'CLAIM_REF'],
+  trustSignals: [
+    {
+      icon: Landmark,
+      title: 'Financial services language',
+      body: 'Pages and demos speak to claims, account servicing, customer support, and regulated AI review rather than generic productivity.',
+    },
+    {
+      icon: Scale,
+      title: 'Review-ready posture',
+      body: 'NeutralAI frames controls in terms compliance teams can evaluate: gateway boundary, masking policy, and audit evidence.',
+    },
+    {
+      icon: LockKeyhole,
+      title: 'Reversible where governance allows',
+      body: 'Sensitive values can become governed tokens so restore paths stay separate from normal model traffic.',
+    },
+  ],
+  disclaimer:
+    'NeutralAI supports regulated AI adoption workflows, but this page is not legal advice and does not claim automatic FCA, PRA, or GDPR approval for any customer deployment.',
+}
+
+export const healthcareUseCase: UseCasePageContent = {
+  eyebrow: 'Healthcare use case',
+  title: 'Protect PHI before healthcare prompts reach AI providers.',
+  description:
+    'NeutralAI helps healthcare and healthtech teams mask patient names, NHS numbers, medical record references, member IDs, and contact details before AI processing.',
+  primaryCta: 'Discuss healthcare deployment',
+  secondaryCta: 'Try a PHI demo',
+  proofLabel: 'PHI-aware controls',
+  proofTitle: 'Designed to support minimum-necessary AI workflows.',
+  proofBody:
+    'Healthcare buyers need careful language and careful controls. NeutralAI supports PHI-aware masking, audit-safe evidence, and BAA review conversations for eligible deployments.',
+  painPoints: [
+    'Clinical summaries and support tickets can contain PHI alongside useful operational context.',
+    'Teams need AI assistance without sending patient identifiers to external model providers.',
+    'Compliance reviewers need evidence without raw PHI appearing in standard reports.',
+  ],
+  workflow: [
+    {
+      title: 'Detect PHI-style identifiers',
+      body: 'Identify patient names, contact data, NHS numbers, medical record references, health plan IDs, and other sensitive values in prompts.',
+    },
+    {
+      title: 'Apply minimum-necessary masking',
+      body: 'Preserve useful clinical or operational context while removing direct identifiers before prompts are routed onward.',
+    },
+    {
+      title: 'Prepare for compliance review',
+      body: 'Use audit-safe metadata and deployment review materials to support healthcare security and BAA conversations.',
+    },
+  ],
+  entities: ['PERSON', 'EMAIL', 'PHONE', 'UK_NHS', 'MRN', 'HEALTH_PLAN_ID', 'DATE_TIME'],
+  trustSignals: [
+    {
+      icon: HeartPulse,
+      title: 'Healthcare-specific coverage',
+      body: 'The page speaks to PHI, clinical note summarization, patient support, and minimum-necessary handling instead of broad security claims.',
+    },
+    {
+      icon: ClipboardCheck,
+      title: 'BAA review support',
+      body: 'For eligible healthcare deployments, NeutralAI can support BAA review rather than implying a blanket signed agreement.',
+    },
+    {
+      icon: ShieldCheck,
+      title: 'Audit-safe evidence',
+      body: 'Standard evidence should describe findings and policy events without leaking raw patient identifiers into reports.',
+    },
+  ],
+  disclaimer:
+    'NeutralAI is not presenting this page as legal advice or a blanket HIPAA compliance claim. BAA terms, deployment model, and customer obligations require review.',
+}

--- a/app/use-cases/finance/page.tsx
+++ b/app/use-cases/finance/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import UseCasePage from '../UseCasePage'
+import { financeUseCase } from '../content'
+import { siteConfig } from '../../site'
+
+export const metadata: Metadata = {
+  title: 'AI Data Protection for Financial Services',
+  description:
+    'See how NeutralAI helps financial services teams mask IBANs, card data, customer names, and claim references before AI prompts reach model providers.',
+  alternates: {
+    canonical: '/use-cases/finance',
+  },
+  openGraph: {
+    title: 'AI Data Protection for Financial Services',
+    description:
+      'Mask customer and payment identifiers before financial services prompts reach external AI providers.',
+    url: `${siteConfig.url}/use-cases/finance`,
+  },
+}
+
+export default function FinanceUseCasePage() {
+  return <UseCasePage content={financeUseCase} />
+}

--- a/app/use-cases/healthcare/page.tsx
+++ b/app/use-cases/healthcare/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import UseCasePage from '../UseCasePage'
+import { healthcareUseCase } from '../content'
+import { siteConfig } from '../../site'
+
+export const metadata: Metadata = {
+  title: 'PHI-Aware AI Data Protection for Healthcare',
+  description:
+    'See how NeutralAI supports PHI-aware masking, minimum-necessary AI workflows, audit evidence, and BAA review conversations for healthcare deployments.',
+  alternates: {
+    canonical: '/use-cases/healthcare',
+  },
+  openGraph: {
+    title: 'PHI-Aware AI Data Protection for Healthcare',
+    description:
+      'Mask patient identifiers before healthcare prompts reach external AI providers, with BAA review support for eligible deployments.',
+    url: `${siteConfig.url}/use-cases/healthcare`,
+  },
+}
+
+export default function HealthcareUseCasePage() {
+  return <UseCasePage content={healthcareUseCase} />
+}

--- a/tests/content/use-cases.test.mjs
+++ b/tests/content/use-cases.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+
+function readSource(path) {
+  return readFileSync(join(root, path), 'utf8')
+}
+
+test('vertical use-case pages exist for finance and healthcare', () => {
+  const finance = readSource('app/use-cases/finance/page.tsx')
+  const healthcare = readSource('app/use-cases/healthcare/page.tsx')
+  const content = readSource('app/use-cases/content.ts')
+
+  assert.match(finance, /AI Data Protection for Financial Services/)
+  assert.match(finance, /canonical: '\/use-cases\/finance'/)
+  assert.match(healthcare, /PHI-Aware AI Data Protection for Healthcare/)
+  assert.match(healthcare, /canonical: '\/use-cases\/healthcare'/)
+  assert.match(content, /IBAN/)
+  assert.match(content, /CREDIT_CARD/)
+  assert.match(content, /UK_NHS/)
+  assert.match(content, /MRN/)
+})
+
+test('healthcare copy avoids blanket HIPAA claims while supporting BAA review language', () => {
+  const content = readSource('app/use-cases/content.ts')
+
+  assert.match(content, /PHI-aware masking/)
+  assert.match(content, /BAA review/)
+  assert.match(content, /not presenting this page as legal advice or a blanket HIPAA compliance claim/)
+  assert.doesNotMatch(content, /is HIPAA compliant/)
+  assert.doesNotMatch(content, /BAA included/)
+})
+
+test('use-case routes are discoverable from navigation, footer, and sitemap', () => {
+  const navbar = readSource('app/components/Navbar.tsx')
+  const footer = readSource('app/components/Footer.tsx')
+  const sitemap = readSource('app/sitemap.ts')
+
+  for (const route of ["'/use-cases/finance'", "'/use-cases/healthcare'"]) {
+    assert.ok(navbar.includes(route))
+    assert.ok(footer.includes(route))
+    assert.ok(sitemap.includes(route))
+  }
+
+  assert.match(navbar, /Use Cases/)
+  assert.match(footer, /Finance Use Case/)
+  assert.match(footer, /Healthcare Use Case/)
+})


### PR DESCRIPTION
## Problem

Generic website messaging does not give finance or healthcare buyers enough industry-specific confidence. WEB-12 asks for vertical pages that speak directly to regulated buyer concerns and are discoverable from navigation and sitemap.

## What Changed

- Added `/use-cases/finance` with financial-services pain points, entity examples, and regulated workflow positioning.
- Added `/use-cases/healthcare` with PHI-aware masking, minimum-necessary workflow, and careful BAA review language.
- Added a shared use-case page component and shared content model for consistent layout.
- Added Use Cases navigation, footer links, sitemap entries, and content coverage tests.

## Validation

- [x] `npm run test:content` passed, 36 tests.
- [x] `npm run lint` passed.
- [x] `npm run build` passed and generated `/use-cases/finance` plus `/use-cases/healthcare`.
- [x] `npm run audit:prod` completed; existing `next/postcss` moderate advisory remains and the suggested forced fix is breaking.
- [x] Browser checked finance desktop and healthcare mobile layouts locally.

## Risks / Follow-ups

- Healthcare copy avoids blanket HIPAA compliance claims and frames BAA as review support for eligible deployments.
- Future deeper vertical pages may need gateway evidence links once healthcare/document proof tickets are merged.

Closes #15
