### PR TITLE
Add benchmark proof block

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -342,6 +342,14 @@ const complianceProofs = [
   },
 ] as const
 
+// Source of truth: nazifsohtaoglu/neutralai-gateway benchmark artifacts listed in website issue #16.
+const benchmarkProof = {
+  publicOverallF1: '99.8%',
+  holdoutOverallF1: '98.4%',
+  personHoldoutF1: '92.7%',
+  appBenchmarkUrl: `${siteConfig.appBaseUrl}/pii-benchmark`,
+} as const
+
 type DeploymentCard = {
   icon: LucideIcon
   title: string
@@ -1132,6 +1140,44 @@ function Trust() {
                 </motion.div>
               ))}
             </div>
+          </div>
+        </div>
+
+        <div id="benchmark-proof" className="mt-10 scroll-mt-28 overflow-hidden rounded-[28px] border border-primary/20 bg-[linear-gradient(135deg,rgba(6,182,212,0.12),rgba(15,23,42,0.94)_42%,rgba(249,115,22,0.10))] p-6">
+          <div className="grid gap-7 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Benchmark proof</p>
+              <h3 className="mt-4 font-heading text-3xl font-semibold">Measured against a reproducible Presidio-vanilla baseline.</h3>
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300 md:text-base">
+                NeutralAI combines proven open-source detection primitives with multilingual calibration, masking, and enforcement layers. The gateway repo remains the measurement source of truth, while the website links buyers to the published methodology and benchmark surface.
+              </p>
+              <p className="mt-3 text-xs leading-6 text-slate-500">
+                Product benchmark, not a third-party independent evaluation.
+              </p>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-3">
+              {[
+                ['Public overall F1', benchmarkProof.publicOverallF1],
+                ['Holdout overall F1', benchmarkProof.holdoutOverallF1],
+                ['Holdout PERSON F1', benchmarkProof.personHoldoutF1],
+              ].map(([label, value]) => (
+                <div key={label} className="rounded-2xl border border-white/10 bg-background/80 p-5">
+                  <p className="text-xs uppercase tracking-[0.16em] text-slate-500">{label}</p>
+                  <p className="mt-2 font-heading text-3xl font-semibold text-white">{value}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+            <a href={benchmarkProof.appBenchmarkUrl} className="btn btn-cta justify-center px-6 py-3 text-sm">
+              Open benchmark
+              <ArrowRight className="h-4 w-4" />
+            </a>
+            <a href="/presidio-alternative" className="btn btn-secondary justify-center px-6 py-3 text-sm">
+              Read Presidio comparison
+            </a>
           </div>
         </div>
 

--- a/app/presidio-alternative/page.tsx
+++ b/app/presidio-alternative/page.tsx
@@ -37,7 +37,8 @@ const benchmark = {
   generatedAt: '2026-05-08',
   caseCount: 1000,
   languages: ['DE', 'EN', 'ES', 'FR', 'TR'],
-  neutralaiF1: '99.2%',
+  // Source of truth: nazifsohtaoglu/neutralai-gateway benchmark artifacts listed in website issue #16.
+  neutralaiF1: '99.8%',
   presidioF1: '57.5%',
   neutralaiRecall: '98.4%',
   presidioRecall: '40.3%',

--- a/tests/content/presidio-comparison.test.mjs
+++ b/tests/content/presidio-comparison.test.mjs
@@ -20,6 +20,8 @@ test('presidio alternative page carries SEO and build-vs-buy content', () => {
   assert.match(source, /Buy NeutralAI/)
   assert.match(source, /Presidio is a library/)
   assert.match(source, /not positioned as a from-scratch recognizer model/)
+  assert.match(source, /Source of truth: nazifsohtaoglu\/neutralai-gateway benchmark artifacts/)
+  assert.match(source, /neutralaiF1: '99\.8%'/)
 })
 
 test('roi calculator remains client-side and exposes expected controls', () => {

--- a/tests/content/trust-signals.test.mjs
+++ b/tests/content/trust-signals.test.mjs
@@ -66,6 +66,26 @@ test('homepage adds a scannable detection engine deep dive', () => {
   assert.match(homeSource, /encrypted vault/)
 })
 
+test('homepage carries benchmark proof without overclaiming independence', () => {
+  const homeSource = readSource('app/page.tsx')
+
+  assert.match(homeSource, /Source of truth: nazifsohtaoglu\/neutralai-gateway benchmark artifacts/)
+  assert.match(homeSource, /id="benchmark-proof"/)
+  assert.match(homeSource, /Benchmark proof/)
+  assert.match(homeSource, /reproducible Presidio-vanilla baseline/)
+  assert.match(homeSource, /multilingual calibration, masking, and enforcement layers/)
+  assert.match(homeSource, /Public overall F1/)
+  assert.match(homeSource, /99\.8%/)
+  assert.match(homeSource, /Holdout overall F1/)
+  assert.match(homeSource, /98\.4%/)
+  assert.match(homeSource, /Holdout PERSON F1/)
+  assert.match(homeSource, /92\.7%/)
+  assert.match(homeSource, /Product benchmark, not a third-party independent evaluation/)
+  assert.match(homeSource, /benchmarkProof\.appBenchmarkUrl/)
+  assert.match(homeSource, /\/presidio-alternative/)
+  assert.doesNotMatch(homeSource, /independent third-party evaluation/)
+})
+
 test('security page describes architecture, encryption, and public trust links', () => {
   const securitySource = readSource('app/security/page.tsx')
 


### PR DESCRIPTION
## Problem

The website needs a customer-safe benchmark proof block that references gateway-owned measurement artifacts without duplicating benchmark logic or implying a third-party independent evaluation.

## What Changed

- Added a concise homepage benchmark proof block in the Trust section.
- Included public and holdout benchmark metrics from the gateway source-of-truth issue context.
- Linked buyers to the app benchmark surface and the Presidio comparison page for deeper context.
- Added content coverage to guard the benchmark wording and overclaim boundary.

## Validation

- [x] `npm run test:content` passed, 37 tests.
- [x] `npm run lint` passed.
- [x] `npm run build` passed.
- [x] `npm run audit:prod` completed; existing `next/postcss` moderate advisory remains and the suggested forced fix is breaking.
- [x] Browser checked desktop and mobile benchmark block locally.

## Risks / Follow-ups

- Copy explicitly says this is a product benchmark, not a third-party independent evaluation.
- Gateway remains the measurement source of truth for future benchmark updates.

Closes #16
