### PR TITLE
Add AI workflow documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Problem
+
+What visitor, content, or maintenance problem does this solve?
+
+## What Changed
+
+- 
+
+## Validation
+
+- [ ] 
+
+## Risks / Follow-ups
+
+- 

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,11 @@ next-env.d.ts
 # Local automation artifacts
 .playwright-cli/
 .playwright-mcp/
+
+# Local Codex/workflow scratch artifacts
+/templates/
+/web-*.png
+/web-*.md
+/web[0-9]*-*.png
+/homepage-*.png
+/pricing-*.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+Short repository guide for Codex. Longer working context lives under `docs/ai/`.
+
+## Read First on Every Task
+
+1. `docs/ai/PROJECT_MAP.md`
+2. If the task is risky, `docs/ai/RISK_REGISTER.md`
+3. If flows or integrations matter, `docs/ai/FLOWS.md`
+4. For test selection, `docs/ai/TESTING_AND_COMMANDS.md`
+5. For ticket handling, `docs/ai/TICKET_WORKFLOW.md`
+6. For PR rules, `docs/ai/PR_RULES.md`
+7. For unresolved context, `docs/ai/OPEN_QUESTIONS.md`
+
+## Repository Rules
+
+- Before changing production code, read the existing local pattern for the relevant area.
+- Do not write secret, token, private key, credential, webhook secret, or client secret values into docs, tests, logs, or PR text.
+- If you make an assumption, label it explicitly with `Assumption:`.
+- Add unknown or unclear points to `docs/ai/OPEN_QUESTIONS.md`.
+- Do not revert unrelated user changes.
+- Keep changes small and focused.
+- When creating PRs, open ready-for-review PRs unless the user explicitly asks for draft. Do not prefix PR titles with `codex`.
+
+## Common Commands
+
+```bash
+npm install
+npm run dev
+npm run build
+npm run lint
+npm run test:content
+npm run audit:prod
+```
+
+`npm run dev` starts the local Next.js server on `http://localhost:3200`.
+
+## High-Level Architecture
+
+- Next.js App Router site for the NeutralAI marketing/product website.
+- Root layout: `app/layout.tsx`.
+- Homepage: `app/page.tsx`.
+- Route segments such as About, Privacy, and Terms live under `app/*/page.tsx`.
+- Shared components live under `app/components/`.
+- Global styles live in `app/globals.css`.
+- Product messaging is about NeutralAI Gateway: a PII gateway for regulated UK industries that masks sensitive data before it reaches LLMs.
+
+## Change Workflow
+
+1. Run `git status --short` and preserve existing user changes.
+2. Classify the ticket using `docs/ai/TICKET_WORKFLOW.md`.
+3. Read the relevant architecture/risk docs.
+4. Make the smallest focused change.
+5. Run targeted checks from `docs/ai/TESTING_AND_COMMANDS.md`.
+6. Summarize changed files, validation, risks, and follow-ups.
+
+## AI Repo Map Files
+
+- `docs/ai/PROJECT_MAP.md`: directories, entry points, runtime/framework map.
+- `docs/ai/ARCHITECTURE.md`: layers, route surface, content model, invariants.
+- `docs/ai/DEPENDENCY_GRAPH.md`: important dependencies and Mermaid graphs.
+- `docs/ai/FLOWS.md`: critical runtime/editorial flows.
+- `docs/ai/TESTING_AND_COMMANDS.md`: commands and test decision table.
+- `docs/ai/RISK_REGISTER.md`: sensitive-area checklist.
+- `docs/ai/OPEN_QUESTIONS.md`: unresolved questions.
+- `docs/ai/TICKET_WORKFLOW.md`: ticket triage and execution workflow.
+- `docs/ai/PR_RULES.md`: PR title/body/validation rules.

--- a/docs/ai/ARCHITECTURE.md
+++ b/docs/ai/ARCHITECTURE.md
@@ -1,0 +1,55 @@
+# Architecture
+
+## Short Summary
+
+This is a Next.js App Router marketing website for NeutralAI Gateway. It is mostly static/content-driven, with shared layout/components and build-time validation through Next, ESLint, content tests, and dependency audit. The main implementation risk is not backend data correctness, but content accuracy, conversion clarity, visual polish, accessibility, and keeping product claims aligned with the actual gateway product.
+
+## Layers
+
+| Layer | Files | Notes |
+| --- | --- | --- |
+| App shell | `app/layout.tsx` | Shared metadata, root HTML/body, global shell components |
+| Pages/routes | `app/**/page.tsx` | App Router route segments |
+| Homepage | `app/page.tsx` | Primary conversion and product narrative surface |
+| Shared components | `app/components/*` | Navbar, footer, back button, and reusable UI |
+| Styling | `app/globals.css`, `tailwind.config.ts` | Global visual system and Tailwind tokens |
+| Tests | `tests/content/*.test.mjs` | Content/CTA assertions via Node test runner |
+| CI | `.github/workflows/dependency-security.yml` | Install, build, lint, production dependency audit |
+
+## Content Model
+
+| Content Area | Purpose |
+| --- | --- |
+| Hero | State the product category and primary value proposition quickly |
+| Navigation | Move visitors to product, pricing/contact, docs/legal, or conversion actions |
+| Product explanation | Explain how PII masking protects LLM workflows |
+| Trust/compliance | Support regulated-industry buying confidence without overclaiming |
+| CTA | Convert visitor interest into signup, contact, demo, or trial intent |
+| Legal/privacy routes | Provide policy and compliance-facing information |
+
+## Critical Invariants
+
+- Product claims must be accurate and should not overstate backend capabilities.
+- Do not invent customer names, certifications, audit status, or compliance guarantees.
+- Public CTAs should be consistent and tested by content checks.
+- Navigation should remain available and accessible on desktop and mobile.
+- Generated build artifacts should not be manually edited.
+- Do not expose secrets or private operational details in public website content.
+
+## External Dependencies
+
+| Dependency | Usage |
+| --- | --- |
+| Next.js | App framework and build system |
+| React | UI rendering |
+| Tailwind CSS | Styling system |
+| Framer Motion | Animation |
+| Lucide React | Icons |
+| npm audit | Production dependency risk check |
+
+## Architecture Notes
+
+- No backend API server was identified in this repo.
+- No database or persistent data model was identified.
+- CI currently focuses on build, lint, and critical production dependency audit.
+- `CLAUDE.md` and `AGENTS.md` historically contained similar short guidance; keep `AGENTS.md` as the Codex entry point.

--- a/docs/ai/DEPENDENCY_GRAPH.md
+++ b/docs/ai/DEPENDENCY_GRAPH.md
@@ -1,0 +1,47 @@
+# Dependency Graph
+
+This is a high-signal dependency map, not a complete import graph.
+
+## High-Level Site
+
+```mermaid
+graph LR
+  Visitor["Visitor"] --> Next["Next.js App Router"]
+  Next --> Layout["app/layout.tsx"]
+  Next --> Pages["app/**/page.tsx"]
+  Layout --> Components["app/components/*"]
+  Pages --> Components
+  Pages --> Styles["app/globals.css + Tailwind"]
+  Components --> Icons["lucide-react"]
+  Components --> Motion["framer-motion"]
+  CI["GitHub Actions"] --> Build["npm run build"]
+  CI --> Lint["npm run lint"]
+  CI --> Audit["npm run audit:prod"]
+```
+
+## Important Modules
+
+| Module | Depends on | Notes |
+| --- | --- | --- |
+| `app/page.tsx` | React, Tailwind classes, shared/inline components | Main homepage and largest blast-radius file |
+| `app/layout.tsx` | Global CSS, shared shell components | Controls global page shell and metadata |
+| `app/components/Navbar.tsx` | Routing links, visual identity | High conversion and navigation impact |
+| `app/components/Footer.tsx` if present | Legal/product links | Keep legal/conversion links accurate |
+| `app/globals.css` | Tailwind/global styling | Wide visual impact |
+| `package.json` | Next/npm scripts/deps | Build, lint, test, dependency audit behavior |
+| `.github/workflows/dependency-security.yml` | npm scripts | CI quality gate |
+
+## Largest Blast Radius
+
+| Area | Why it is sensitive |
+| --- | --- |
+| Homepage hero and CTAs | Directly affects conversion and content tests |
+| Navbar/footer | Site-wide navigation and trust impact |
+| Global styles/Tailwind tokens | Can break layout, readability, mobile responsiveness |
+| Product/compliance copy | Can create legal or sales risk if overclaimed |
+| Package/dependency changes | Can break build, lint, or audit gate |
+
+## Generated or Avoid Areas
+
+- Do not manually edit `.next/`, `out/`, `node_modules/`, or Playwright output artifacts.
+- Treat untracked/generated test artifacts as user/environment output unless explicitly asked to clean them.

--- a/docs/ai/FLOWS.md
+++ b/docs/ai/FLOWS.md
@@ -1,0 +1,69 @@
+# Critical Flows
+
+## 1. Visitor Conversion Flow
+
+```mermaid
+sequenceDiagram
+  participant V as Visitor
+  participant H as Homepage
+  participant N as Navigation
+  participant C as CTA
+
+  V->>H: lands on site
+  H->>V: product category and value proposition
+  V->>N: explores routes/sections
+  V->>C: clicks primary or secondary CTA
+  C-->>V: signup/contact/demo/trial destination
+```
+
+Notes:
+- CTA labels and destinations should stay consistent across homepage, navbar, and content tests.
+- Avoid adding claims that the gateway product cannot currently support.
+
+## 2. Page Render Flow
+
+```mermaid
+graph TD
+  Request["Request"] --> Next["Next.js App Router"]
+  Next --> Layout["app/layout.tsx"]
+  Layout --> Page["app/**/page.tsx"]
+  Layout --> Shared["app/components/*"]
+  Page --> CSS["app/globals.css + Tailwind"]
+  Page --> Assets["public/*"]
+  Next --> HTML["Rendered page"]
+```
+
+## 3. Build and CI Flow
+
+```mermaid
+sequenceDiagram
+  participant Dev as Developer/Codex
+  participant NPM as npm
+  participant Next as Next build
+  participant ESLint as ESLint
+  participant CI as GitHub Actions
+
+  Dev->>NPM: npm install or npm ci
+  Dev->>Next: npm run build
+  Dev->>ESLint: npm run lint
+  Dev->>NPM: npm run test:content
+  CI->>NPM: npm ci
+  CI->>Next: npm run build
+  CI->>ESLint: npm run lint
+  CI->>NPM: npm run audit:prod
+```
+
+## 4. Content Test Flow
+
+```mermaid
+graph LR
+  Test["tests/content/*.test.mjs"] --> Source["app/page.tsx and related content"]
+  Source --> Assertions["CTA/copy assertions"]
+  Assertions --> Result["pass/fail"]
+```
+
+## Open Questions Linked to Flows
+
+- What is the canonical primary CTA destination for the website?
+- Should content tests cover all public routes or only the homepage?
+- Is the website intended to be static-exported through `out/`, deployed through Next server, or both?

--- a/docs/ai/OPEN_QUESTIONS.md
+++ b/docs/ai/OPEN_QUESTIONS.md
@@ -1,0 +1,24 @@
+# Open Questions
+
+Use this file for unknowns. Do not guess silently.
+
+## Product / Marketing
+
+- What is the canonical primary CTA: trial, demo, contact, waitlist, or install extension?
+- What exact `src` value should website signup handoffs use for homepage "Try Free" CTAs: `website_start_free_trial`, `website_try_free`, or another analytics-owned value?
+- WEB-02 website pricing now follows the user-confirmed GBP packaging direction (£0 Free, £29 Starter, £99 Team, £299 Business, Enterprise Custom) and separates masking requests from managed AI credits/BYOK. Gateway issue https://github.com/nazifsohtaoglu/neutralai-gateway/issues/777 tracks the required backend/catalog support; the live gateway public catalog and BUS-008 contract still expose USD/Pro/$499 until that is implemented.
+- Which claims are approved for public use around GDPR, UK regulated industries, zero retention, and on-prem deployment?
+- Are there real customers, pilots, certifications, or benchmarks that can be referenced publicly?
+- What is the preferred ICP for the website copy: legal, finance, healthcare, insurance, SaaS support, or broader regulated teams?
+
+## Architecture / Deployment
+
+- Is the website deployed as a static export from `out/`, as a Next server app, or through another platform?
+- Should generated `out/` assets be committed or treated as build output only?
+- Should Playwright artifacts be ignored/cleaned, or are they used as review evidence?
+
+## Testing / CI
+
+- Should content tests cover every public route or only the homepage?
+- Should a Playwright visual smoke script be added to `package.json`?
+- Should `next build` be treated as the canonical typecheck, or should a separate TypeScript check be added?

--- a/docs/ai/PROJECT_MAP.md
+++ b/docs/ai/PROJECT_MAP.md
@@ -1,0 +1,62 @@
+# Project Map
+
+This file gives Codex a fast map of the NeutralAI website repository.
+
+## Product Purpose
+
+NeutralAI Website is the public marketing/product website for NeutralAI Gateway. It communicates the product value proposition, trust posture, feature narrative, and conversion paths for visitors interested in AI data protection and PII-safe LLM usage.
+
+## Main Directories
+
+| Path | Responsibility |
+| --- | --- |
+| `app/` | Next.js App Router pages, layout, global styles, and route segments |
+| `app/components/` | Shared UI components such as navigation, footer, and reusable page elements |
+| `public/` | Static public assets |
+| `docs/` | Project documentation, dependency security notes, plans, and AI repo map |
+| `tests/content/` | Node test runner content assertions |
+| `.github/workflows/` | CI workflow for dependency/build/lint/audit checks |
+| `out/`, `.next/` | Generated build output; do not edit manually |
+
+## Entry Points
+
+| Layer | Entry point |
+| --- | --- |
+| App shell | `app/layout.tsx` |
+| Homepage | `app/page.tsx` |
+| Shared UI | `app/components/*` |
+| Global styles | `app/globals.css` |
+| Next config | `next.config.js` |
+| Package scripts | `package.json` |
+| CI | `.github/workflows/dependency-security.yml` |
+
+## Runtime and Frameworks
+
+| Area | Choice |
+| --- | --- |
+| Runtime | Node.js |
+| Framework | Next.js 16 App Router, React 18 |
+| Styling | Tailwind CSS, global CSS |
+| UI libraries | `framer-motion`, `lucide-react`, `clsx`, `tailwind-merge` |
+| Package manager | npm with `package-lock.json` |
+| Test runner | Node built-in test runner for content tests |
+| Lint | ESLint 9 with Next config |
+| Build | `next build` |
+
+## Current Worktree Note
+
+At the time this kit was installed, the target repo already had unrelated local changes in `app/components/Navbar.tsx`, `app/page.tsx`, `package.json`, Playwright output files, and `tests/content/primary-cta.test.mjs`. Treat those as user work unless explicitly told otherwise.
+
+## Fast Reading Order
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_MAP.md`
+3. `docs/ai/ARCHITECTURE.md`
+4. `docs/ai/FLOWS.md`
+5. `docs/ai/RISK_REGISTER.md`
+6. `docs/ai/TESTING_AND_COMMANDS.md`
+
+## Assumptions
+
+- Assumption: This repository is the public website, while the backend gateway product lives in a separate repository.
+- Assumption: Generated `.next`, `out`, Playwright artifacts, and `node_modules` should not be edited manually.

--- a/docs/ai/PR_RULES.md
+++ b/docs/ai/PR_RULES.md
@@ -1,0 +1,52 @@
+# PR Rules
+
+## Default Behavior
+
+- Open ready-for-review PRs unless the user explicitly asks for draft.
+- Do not prefix PR titles with `codex`.
+- Keep PRs focused on one coherent website change.
+- Do not include secret values, tokens, private keys, or credentials.
+
+## PR Title
+
+Use an outcome-oriented title:
+
+- `Improve homepage primary CTA clarity`
+- `Fix mobile navbar spacing`
+- `Add content test for demo CTA`
+
+Avoid:
+
+- `[codex] updates`
+- `misc changes`
+- `fix stuff`
+
+## PR Body Template
+
+```markdown
+## Problem
+
+What visitor, content, or maintenance problem does this solve?
+
+## What Changed
+
+- Change 1
+- Change 2
+
+## Validation
+
+- [ ] Command/check and result
+- [ ] Manual browser check, if applicable
+
+## Risks / Follow-ups
+
+- Risk or follow-up
+```
+
+## Before Opening a PR
+
+- Run `git status --short`.
+- Review the diff.
+- Confirm no unrelated user changes were included.
+- Run targeted verification from `docs/ai/TESTING_AND_COMMANDS.md`.
+- Mention tests that were not run and why.

--- a/docs/ai/RISK_REGISTER.md
+++ b/docs/ai/RISK_REGISTER.md
@@ -1,0 +1,30 @@
+# Risk Register
+
+Read this before changing sensitive website areas.
+
+## Highest-Risk Areas
+
+| Area | Files | Risk | Check before changing |
+| --- | --- | --- | --- |
+| Product claims | `app/page.tsx`, route copy, docs | Overstating compliance/security capabilities | Compare claims against actual product capability; avoid invented certifications/customers |
+| Primary CTAs | `app/page.tsx`, `app/components/Navbar.tsx`, content tests | Broken conversion path or failing content tests | Verify labels, hrefs, and `npm run test:content` |
+| Navbar/footer | `app/components/*`, `app/layout.tsx` | Broken navigation site-wide | Desktop/mobile check, accessibility basics |
+| Global styling | `app/globals.css`, `tailwind.config.ts` | Layout/readability regressions | Build and browser check at multiple widths |
+| Package/deps | `package.json`, `package-lock.json` | Build/lint/audit failures | Run build, lint, audit when dependencies change |
+| Generated artifacts | `.next/`, `out/`, Playwright outputs | Committing generated noise | Do not edit manually; avoid staging unless explicitly requested |
+
+## Specific Watch Items
+
+1. Existing local changes were present when this kit was installed. Do not revert `app/components/Navbar.tsx`, `app/page.tsx`, `package.json`, or test/artifact changes unless the user explicitly asks.
+2. Keep NeutralAI Gateway claims precise. If a capability is not verified from the gateway repo or product docs, write it as a roadmap/follow-up or ask.
+3. Marketing pages should not contain secrets, internal URLs, private deployment details, or unsupported compliance claims.
+4. Large animation changes should be checked for performance and mobile overlap.
+5. If changing CTA copy, update content tests or add coverage.
+
+## Before Changing Public Website Copy
+
+- Identify the target visitor and buying stage.
+- Check whether the claim is factual, aspirational, or unknown.
+- Avoid hallucinating customer logos, certifications, regulatory approvals, or benchmark numbers.
+- Prefer concrete product behavior over vague security language.
+- Add unclear product facts to `docs/ai/OPEN_QUESTIONS.md`.

--- a/docs/ai/TESTING_AND_COMMANDS.md
+++ b/docs/ai/TESTING_AND_COMMANDS.md
@@ -1,0 +1,44 @@
+# Testing and Commands
+
+Run commands from the repo root. If a required tool is missing, first try the user's local machine installation/path before treating it as blocked.
+
+## Commands
+
+| Purpose | Command | Working directory |
+| --- | --- | --- |
+| Install | `npm install` | repo root |
+| Dev server | `npm run dev` | repo root |
+| Production build | `npm run build` | repo root |
+| Start production server | `npm run start` | repo root |
+| Lint | `npm run lint` | repo root |
+| Content tests | `npm run test:content` | repo root |
+| Production dependency audit | `npm run audit:prod` | repo root |
+
+`npm run dev` starts Next.js on `http://localhost:3200`.
+
+## Test Selection by Change Type
+
+| Change | Minimum verification |
+| --- | --- |
+| Homepage content/CTA | `npm run test:content`, `npm run build` |
+| Shared UI component | `npm run lint`, `npm run build`; browser screenshot check when visual |
+| Global CSS/Tailwind | `npm run build`; browser check on desktop and mobile |
+| Package/dependency | `npm run build`, `npm run lint`, `npm run audit:prod` |
+| CI workflow | Review workflow syntax and run matching npm scripts locally |
+| Docs only | No functional test required unless links/scripts changed |
+
+## Browser Verification
+
+For meaningful visual changes, start the dev server and inspect the page:
+
+```bash
+npm run dev
+```
+
+Then open `http://localhost:3200` in the browser. Check at least desktop and mobile widths for layout overlap, CTA visibility, and navigation.
+
+## Known Quality Gaps
+
+- No dedicated Playwright test script is currently in `package.json`.
+- No explicit TypeScript typecheck script separate from `next build`.
+- Content tests appear limited; broaden them if changing messaging or CTAs heavily.

--- a/docs/ai/TICKET_WORKFLOW.md
+++ b/docs/ai/TICKET_WORKFLOW.md
@@ -1,0 +1,67 @@
+# Ticket Workflow
+
+Use this workflow when taking a website ticket from idea to PR.
+
+## 1. Triage
+
+Classify the ticket:
+
+- `content`
+- `visual-ui`
+- `conversion`
+- `accessibility`
+- `performance`
+- `bug`
+- `refactor`
+- `security`
+- `infra`
+- `docs`
+- `test`
+
+Then identify:
+
+- affected route or component
+- affected visitor flow
+- product claim risk
+- expected verification command
+- unknowns to capture in `OPEN_QUESTIONS.md`
+
+## 2. Plan
+
+For non-trivial work, write a short plan:
+
+1. Read the relevant route/component.
+2. Check current design and content conventions.
+3. Make the smallest focused change.
+4. Update content tests if CTA/copy expectations change.
+5. Run targeted verification.
+6. Summarize residual risk.
+
+## 3. Implementation Rules
+
+- Prefer existing components and styles over new abstractions.
+- Keep marketing claims precise and supportable.
+- Do not invent statistics, customers, compliance status, or benchmark results.
+- Do not mix unrelated redesign work into narrow tickets.
+- Preserve user changes in the worktree.
+- Never include secrets or credentials in code, docs, tests, logs, or PR text.
+
+## 4. Verification
+
+Use `docs/ai/TESTING_AND_COMMANDS.md`.
+
+If verification cannot be run, record:
+
+- command attempted or skipped
+- reason
+- expected risk
+- recommended next check
+
+## 5. Done Criteria
+
+A ticket is ready when:
+
+- the requested route/component/content change is complete
+- targeted checks have run or the reason is documented
+- mobile/desktop visual risk has been considered for UI work
+- PR notes include summary, validation, risks, and follow-ups


### PR DESCRIPTION
## Problem

The website repo had local AI workflow instructions and PR guidance that were useful for future work, but they were not committed. Local screenshot/template artifacts were also showing up in git status.

## What Changed

- Added `AGENTS.md` with the repository working rules and common commands.
- Added `docs/ai/*` workflow, project map, risk, testing, ticket, and PR guidance.
- Added a pull request template matching the project PR format.
- Updated `.gitignore` for local workflow screenshots/templates.

## Validation

- [x] `git diff --check` passed before commit.
- [x] `git status --short --branch` is clean after push.

## Risks / Follow-ups

- Docs-only change; no production website behavior changed.
