### PR TITLE
Add healthcare trust messaging

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -350,6 +350,26 @@ const benchmarkProof = {
   appBenchmarkUrl: `${siteConfig.appBaseUrl}/pii-benchmark`,
 } as const
 
+// Source of truth: nazifsohtaoglu/neutralai-gateway#779 healthcare pack artifacts.
+const healthcareTrustPoints = [
+  {
+    label: 'PHI-aware masking',
+    body: 'Patient names, contact details, medical record numbers, health plan/member IDs, and device/UDI-style identifiers can be handled before model routing.',
+  },
+  {
+    label: 'Minimum-necessary posture',
+    body: 'Prompts keep useful clinical or operational context while direct identifiers are reduced before they leave the approved workflow.',
+  },
+  {
+    label: 'Review-ready evidence',
+    body: 'Audit metadata, breach workflow support, and an evidence pack are available under review/NDA without putting raw PHI into standard reports.',
+  },
+  {
+    label: 'BAA review support',
+    body: 'BAA review is available for eligible healthcare deployments, with final terms and deployment responsibilities reviewed commercially.',
+  },
+] as const
+
 type DeploymentCard = {
   icon: LucideIcon
   title: string
@@ -1178,6 +1198,40 @@ function Trust() {
             <a href="/presidio-alternative" className="btn btn-secondary justify-center px-6 py-3 text-sm">
               Read Presidio comparison
             </a>
+          </div>
+        </div>
+
+        <div id="healthcare-trust" className="mt-10 scroll-mt-28 overflow-hidden rounded-[28px] border border-emerald-400/20 bg-[linear-gradient(135deg,rgba(16,185,129,0.12),rgba(15,23,42,0.96)_46%,rgba(6,182,212,0.10))] p-6">
+          <div className="grid gap-8 lg:grid-cols-[0.82fr_1.18fr] lg:items-start">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-emerald-300">Healthcare trust</p>
+              <h3 className="mt-4 font-heading text-3xl font-semibold">HIPAA-ready deployment support without blanket claims.</h3>
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300 md:text-base">
+                NeutralAI helps healthcare and healthtech teams protect PHI before prompts reach AI providers, with PHI-aware controls, audit evidence, and BAA review support for eligible deployments.
+              </p>
+              <p className="mt-3 text-xs leading-6 text-slate-500">
+                Not legal advice. BAA terms, deployment model, and customer obligations require review.
+              </p>
+
+              <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+                <a href="/contact" className="btn btn-cta justify-center px-6 py-3 text-sm">
+                  Discuss healthcare deployment
+                  <ArrowRight className="h-4 w-4" />
+                </a>
+                <a href="/use-cases/healthcare" className="btn btn-secondary justify-center px-6 py-3 text-sm">
+                  View healthcare use case
+                </a>
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              {healthcareTrustPoints.map((point) => (
+                <div key={point.label} className="rounded-2xl border border-white/10 bg-background/80 p-5">
+                  <p className="font-mono text-xs uppercase tracking-[0.2em] text-emerald-300">{point.label}</p>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">{point.body}</p>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
 

--- a/app/use-cases/content.ts
+++ b/app/use-cases/content.ts
@@ -57,7 +57,7 @@ export const healthcareUseCase: UseCasePageContent = {
   eyebrow: 'Healthcare use case',
   title: 'Protect PHI before healthcare prompts reach AI providers.',
   description:
-    'NeutralAI helps healthcare and healthtech teams mask patient names, NHS numbers, medical record references, member IDs, and contact details before AI processing.',
+    'NeutralAI helps healthcare and healthtech teams mask patient names, NHS numbers, medical record references, health plan/member IDs, device identifiers, and contact details before AI processing.',
   primaryCta: 'Discuss healthcare deployment',
   secondaryCta: 'Try a PHI demo',
   proofLabel: 'PHI-aware controls',
@@ -72,7 +72,7 @@ export const healthcareUseCase: UseCasePageContent = {
   workflow: [
     {
       title: 'Detect PHI-style identifiers',
-      body: 'Identify patient names, contact data, NHS numbers, medical record references, health plan IDs, and other sensitive values in prompts.',
+      body: 'Identify patient names, contact data, NHS numbers, medical record references, health plan/member IDs, device or UDI-style identifiers, and other sensitive values in prompts.',
     },
     {
       title: 'Apply minimum-necessary masking',
@@ -80,10 +80,10 @@ export const healthcareUseCase: UseCasePageContent = {
     },
     {
       title: 'Prepare for compliance review',
-      body: 'Use audit-safe metadata and deployment review materials to support healthcare security and BAA conversations.',
+      body: 'Use audit-safe metadata, breach workflow support, and evidence pack materials under review/NDA to support healthcare security and BAA conversations.',
     },
   ],
-  entities: ['PERSON', 'EMAIL', 'PHONE', 'UK_NHS', 'MRN', 'HEALTH_PLAN_ID', 'DATE_TIME'],
+  entities: ['PERSON', 'EMAIL', 'PHONE', 'UK_NHS', 'MRN', 'HEALTH_PLAN_ID', 'DEVICE_UDI', 'DATE_TIME'],
   trustSignals: [
     {
       icon: HeartPulse,

--- a/tests/content/trust-signals.test.mjs
+++ b/tests/content/trust-signals.test.mjs
@@ -86,6 +86,23 @@ test('homepage carries benchmark proof without overclaiming independence', () =>
   assert.doesNotMatch(homeSource, /independent third-party evaluation/)
 })
 
+test('homepage carries healthcare trust copy without blanket HIPAA claims', () => {
+  const homeSource = readSource('app/page.tsx')
+
+  assert.match(homeSource, /Source of truth: nazifsohtaoglu\/neutralai-gateway#779 healthcare pack artifacts/)
+  assert.match(homeSource, /id="healthcare-trust"/)
+  assert.match(homeSource, /HIPAA-ready deployment support without blanket claims/)
+  assert.match(homeSource, /PHI-aware controls/)
+  assert.match(homeSource, /medical record numbers, health plan\/member IDs, and device\/UDI-style identifiers/)
+  assert.match(homeSource, /Minimum-necessary posture/)
+  assert.match(homeSource, /evidence pack are available under review\/NDA/)
+  assert.match(homeSource, /BAA review is available for eligible healthcare deployments/)
+  assert.match(homeSource, /href="\/contact"/)
+  assert.match(homeSource, /href="\/use-cases\/healthcare"/)
+  assert.doesNotMatch(homeSource, /NeutralAI is HIPAA compliant/)
+  assert.doesNotMatch(homeSource, /BAA included/)
+})
+
 test('security page describes architecture, encryption, and public trust links', () => {
   const securitySource = readSource('app/security/page.tsx')
 

--- a/tests/content/use-cases.test.mjs
+++ b/tests/content/use-cases.test.mjs
@@ -22,6 +22,8 @@ test('vertical use-case pages exist for finance and healthcare', () => {
   assert.match(content, /CREDIT_CARD/)
   assert.match(content, /UK_NHS/)
   assert.match(content, /MRN/)
+  assert.match(content, /HEALTH_PLAN_ID/)
+  assert.match(content, /DEVICE_UDI/)
 })
 
 test('healthcare copy avoids blanket HIPAA claims while supporting BAA review language', () => {
@@ -29,6 +31,9 @@ test('healthcare copy avoids blanket HIPAA claims while supporting BAA review la
 
   assert.match(content, /PHI-aware masking/)
   assert.match(content, /BAA review/)
+  assert.match(content, /health plan\/member IDs/)
+  assert.match(content, /device or UDI-style identifiers/)
+  assert.match(content, /evidence pack materials under review\/NDA/)
   assert.match(content, /not presenting this page as legal advice or a blanket HIPAA compliance claim/)
   assert.doesNotMatch(content, /is HIPAA compliant/)
   assert.doesNotMatch(content, /BAA included/)


### PR DESCRIPTION
## Problem

Healthcare buyers need a public trust surface that explains NeutralAI's PHI-aware deployment support without making blanket HIPAA compliance or BAA-included claims.

Closes #24.

## What Changed

- Added a healthcare trust block to the homepage trust section with internal traceability to gateway PR #779.
- Expanded the healthcare use-case copy to mention health plan/member IDs, device/UDI-style identifiers, BAA review support, and evidence pack review/NDA language.
- Added content tests to guard against risky blanket HIPAA and BAA claims.

## Validation

- [x] npm run test:content
- [x] npm run lint
- [x] npm run build
- [x] Manual browser check on http://localhost:3200/#healthcare-trust

## Risks / Follow-ups

- Healthcare compliance language remains sensitive; final BAA and legal positioning should continue to be reviewed before any stronger public claims.