### PR TITLE
Add document redaction proof block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Short repository guide for Codex. Longer working context lives under `docs/ai/`.
 - Add unknown or unclear points to `docs/ai/OPEN_QUESTIONS.md`.
 - Do not revert unrelated user changes.
 - Keep changes small and focused.
+- If a public claim, metric, benchmark, pricing point, UI element, or copy choice seems weak, confusing, risky, or unlikely to add value, say so proactively before or while implementing it. Do not wait for the user to challenge it.
 - When creating PRs, open ready-for-review PRs unless the user explicitly asks for draft. Do not prefix PR titles with `codex`.
 
 ## Common Commands

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -370,6 +370,31 @@ const healthcareTrustPoints = [
   },
 ] as const
 
+// Source of truth: nazifsohtaoglu/neutralai-gateway#782 document redaction artifacts.
+const documentRedactionProof = {
+  benchmarkLabel: 'Live canary smoke',
+  benchmarkValue: 'Dense 10-page text PDF in ~3.1s',
+  sourceNote: 'Live gateway canary run found 835 sensitive spans; simple 10-page text PDF smoke measured ~153ms. Product smoke, not a third-party evaluation.',
+} as const
+
+const documentRedactionPoints = [
+  {
+    icon: FileText,
+    label: 'PDF redaction',
+    body: 'Supports simple text PDFs today and returns generated PDF output with visual blackout marks.',
+  },
+  {
+    icon: ScanSearch,
+    label: 'Office and images',
+    body: 'Extracts Office document text and supports OCR-backed image detection when OCR is configured.',
+  },
+  {
+    icon: ClipboardCheck,
+    label: 'Audit-safe metadata',
+    body: 'Records file hash, page count, finding counts, and approximate locations without raw sensitive text in standard logs.',
+  },
+] as const
+
 type DeploymentCard = {
   icon: LucideIcon
   title: string
@@ -1231,6 +1256,39 @@ function Trust() {
                   <p className="mt-3 text-sm leading-6 text-slate-300">{point.body}</p>
                 </div>
               ))}
+            </div>
+          </div>
+        </div>
+
+        <div id="document-redaction-proof" className="mt-10 scroll-mt-28 overflow-hidden rounded-[28px] border border-cyan-300/20 bg-[linear-gradient(135deg,rgba(14,165,233,0.12),rgba(15,23,42,0.96)_48%,rgba(148,163,184,0.10))] p-6">
+          <div className="grid gap-8 lg:grid-cols-[0.86fr_1.14fr] lg:items-start">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-cyan-200">Document proof</p>
+              <h3 className="mt-4 font-heading text-3xl font-semibold">Protect files before document content reaches AI workflows.</h3>
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300 md:text-base">
+                NeutralAI document handling extends PII protection beyond chat prompts, with document-aware extraction, redaction output, and audit-safe finding metadata for supported upload flows.
+              </p>
+              <p className="mt-3 text-xs leading-6 text-slate-500">
+                Supports simple text PDFs today. OCR-backed image detection depends on configured OCR runtime.
+              </p>
+            </div>
+
+            <div className="grid gap-4">
+              <div className="rounded-2xl border border-white/10 bg-background/80 p-5">
+                <p className="text-xs uppercase tracking-[0.16em] text-slate-500">{documentRedactionProof.benchmarkLabel}</p>
+                <p className="mt-2 font-heading text-2xl font-semibold text-white">{documentRedactionProof.benchmarkValue}</p>
+                <p className="mt-3 text-sm leading-6 text-slate-400">{documentRedactionProof.sourceNote}</p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-3">
+                {documentRedactionPoints.map((point) => (
+                  <div key={point.label} className="rounded-2xl border border-white/10 bg-background/70 p-5">
+                    <point.icon className="h-5 w-5 text-cyan-200" />
+                    <p className="mt-3 font-mono text-xs uppercase tracking-[0.18em] text-cyan-200">{point.label}</p>
+                    <p className="mt-3 text-sm leading-6 text-slate-300">{point.body}</p>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         </div>

--- a/docs/ai/OPEN_QUESTIONS.md
+++ b/docs/ai/OPEN_QUESTIONS.md
@@ -22,3 +22,4 @@ Use this file for unknowns. Do not guess silently.
 - Should content tests cover every public route or only the homepage?
 - Should a Playwright visual smoke script be added to `package.json`?
 - Should `next build` be treated as the canonical typecheck, or should a separate TypeScript check be added?
+- Should gateway add a documented, non-secret live document redaction smoke script for internal canary tenants so website proof claims can be refreshed without ad hoc SSH commands?

--- a/tests/content/trust-signals.test.mjs
+++ b/tests/content/trust-signals.test.mjs
@@ -103,6 +103,31 @@ test('homepage carries healthcare trust copy without blanket HIPAA claims', () =
   assert.doesNotMatch(homeSource, /BAA included/)
 })
 
+test('homepage carries document redaction proof without overclaiming OCR or PDF coverage', () => {
+  const homeSource = readSource('app/page.tsx')
+
+  assert.match(homeSource, /Source of truth: nazifsohtaoglu\/neutralai-gateway#782 document redaction artifacts/)
+  assert.match(homeSource, /id="document-redaction-proof"/)
+  assert.match(homeSource, /Document proof/)
+  assert.match(homeSource, /Protect files before document content reaches AI workflows/)
+  assert.match(homeSource, /document-aware extraction, redaction output, and audit-safe finding metadata/)
+  assert.match(homeSource, /Supports simple text PDFs today/)
+  assert.match(homeSource, /OCR-backed image detection depends on configured OCR runtime/)
+  assert.match(homeSource, /Live canary smoke/)
+  assert.match(homeSource, /Dense 10-page text PDF in ~3\.1s/)
+  assert.match(homeSource, /Live gateway canary run found 835 sensitive spans/)
+  assert.match(homeSource, /simple 10-page text PDF smoke measured ~153ms/)
+  assert.match(homeSource, /not a third-party evaluation/)
+  assert.match(homeSource, /PDF redaction/)
+  assert.match(homeSource, /visual blackout marks/)
+  assert.match(homeSource, /Office document text/)
+  assert.match(homeSource, /OCR-backed image detection when OCR is configured/)
+  assert.match(homeSource, /file hash, page count, finding counts, and approximate locations/)
+  assert.doesNotMatch(homeSource, /universal PDF layout-preserving redaction/)
+  assert.doesNotMatch(homeSource, /perfect OCR coverage/)
+  assert.doesNotMatch(homeSource, /independent third-party benchmark/)
+})
+
 test('security page describes architecture, encryption, and public trust links', () => {
   const securitySource = readSource('app/security/page.tsx')
 


### PR DESCRIPTION
## Problem

Visitors currently see strong prompt-masking proof, but the website does not explain that NeutralAI can also handle PII in supported uploaded documents. That leaves the document redaction work from the gateway repo invisible on the public trust surface.

Closes #26.

## What Changed

- Added a homepage document proof block for PDF redaction, Office/image extraction, and audit-safe metadata.
- Kept copy careful: simple text PDFs today, OCR-backed image detection only when OCR is configured, and no third-party benchmark claim.
- Added content tests to lock the document redaction claim guardrails.
- Added a repo instruction to proactively call out weak/risky public claims, metrics, pricing, UI, or copy choices.

## Validation

- [x] npm run test:content
- [x] npm run lint
- [x] npm run build
- [x] Desktop and mobile browser smoke on http://localhost:3200/#document-redaction-proof
- [x] Live gateway canary smoke: simple 10-page synthetic text PDF returned 200, 10 findings, PDF output, 153.2ms gateway processing
- [x] Live gateway canary smoke: dense 10-page text PDF returned 200, 835 findings, PDF output, 3098.78ms gateway processing

## Risks / Follow-ups

- This is product smoke evidence, not a third-party benchmark.
- OCR/scanned PDFs and complex layout-preserving redaction can vary materially, so the public copy avoids universal PDF or perfect OCR claims.
- Follow-up: add a documented gateway live document-redaction smoke script for repeatable refreshes without ad hoc SSH commands.