### PR TITLE
Add homepage social proof signals

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -61,9 +61,9 @@ function FooterLink({ href, label }: { href: string; label: string }) {
 
 export default function Footer() {
   return (
-    <footer className="relative mt-10 overflow-hidden border-t border-border/80 bg-background-secondary md:mt-14">
+    <footer className="relative mt-20 overflow-hidden border-t border-border/80 bg-background-secondary md:mt-14">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(34,211,238,0.08),transparent_22%),radial-gradient(circle_at_top_right,rgba(249,115,22,0.08),transparent_18%)]" />
-      <div className="container-custom relative py-8 md:py-10">
+      <div className="container-custom relative pt-12 pb-8 md:py-10">
         <div className="mb-6 grid gap-6 md:grid-cols-[1.15fr_repeat(3,minmax(0,1fr))]">
           <div>
             <Link href="/" className="mb-2 flex items-center gap-2">

--- a/app/components/home/Hero.tsx
+++ b/app/components/home/Hero.tsx
@@ -63,19 +63,19 @@ export default function Hero() {
               ))}
             </div>
 
-            <div className="mt-8 grid gap-3 sm:grid-cols-3">
+          </div>
+
+          <div className="space-y-4 lg:-mt-3 xl:-mt-4">
+            <ProductVisual />
+            <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-3">
               {complianceProofs.map((proof) => (
-                <div key={proof.label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+                <div key={proof.label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 shadow-2xl shadow-black/10 backdrop-blur">
                   <proof.icon className="h-5 w-5 text-primary-light" />
                   <p className="mt-3 text-xs uppercase tracking-[0.2em] text-slate-500">{proof.label}</p>
                   <p className="mt-1 font-heading text-lg font-semibold text-slate-100">{proof.value}</p>
                 </div>
               ))}
             </div>
-          </div>
-
-          <div className="lg:-mt-3 xl:-mt-4">
-            <ProductVisual />
           </div>
         </div>
       </div>

--- a/app/components/home/Hero.tsx
+++ b/app/components/home/Hero.tsx
@@ -3,6 +3,18 @@ import { siteConfig } from '../../site'
 import { complianceProofs, trustBadges } from '../../data/homepage'
 import ProductVisual from './ProductVisual'
 
+function ProofCard({ proof }: { proof: (typeof complianceProofs)[number] }) {
+  return (
+    <div className="min-w-0 rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+      <proof.icon className="h-5 w-5 text-primary-light" />
+      <p className="mt-3 break-words text-[10px] uppercase tracking-[0.14em] text-slate-500 sm:text-xs sm:tracking-[0.18em]">
+        {proof.label}
+      </p>
+      <p className="mt-1 break-words font-heading text-base font-semibold text-slate-100 sm:text-lg">{proof.value}</p>
+    </div>
+  )
+}
+
 export default function Hero() {
   return (
     <section className="relative overflow-hidden pt-28 pb-20 md:pt-36 md:pb-24">
@@ -65,11 +77,7 @@ export default function Hero() {
 
             <div className="mt-8 grid gap-3 sm:grid-cols-3 lg:hidden">
               {complianceProofs.map((proof) => (
-                <div key={proof.label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
-                  <proof.icon className="h-5 w-5 text-primary-light" />
-                  <p className="mt-3 text-xs uppercase tracking-[0.2em] text-slate-500">{proof.label}</p>
-                  <p className="mt-1 font-heading text-lg font-semibold text-slate-100">{proof.value}</p>
-                </div>
+                <ProofCard key={proof.label} proof={proof} />
               ))}
             </div>
           </div>
@@ -78,11 +86,7 @@ export default function Hero() {
             <ProductVisual />
             <div className="mt-4 hidden gap-3 lg:grid lg:grid-cols-3">
               {complianceProofs.map((proof) => (
-                <div key={proof.label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
-                  <proof.icon className="h-5 w-5 text-primary-light" />
-                  <p className="mt-3 text-xs uppercase tracking-[0.2em] text-slate-500">{proof.label}</p>
-                  <p className="mt-1 font-heading text-lg font-semibold text-slate-100">{proof.value}</p>
-                </div>
+                <ProofCard key={proof.label} proof={proof} />
               ))}
             </div>
           </div>

--- a/app/components/home/Hero.tsx
+++ b/app/components/home/Hero.tsx
@@ -63,13 +63,22 @@ export default function Hero() {
               ))}
             </div>
 
+            <div className="mt-8 grid gap-3 sm:grid-cols-3 lg:hidden">
+              {complianceProofs.map((proof) => (
+                <div key={proof.label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+                  <proof.icon className="h-5 w-5 text-primary-light" />
+                  <p className="mt-3 text-xs uppercase tracking-[0.2em] text-slate-500">{proof.label}</p>
+                  <p className="mt-1 font-heading text-lg font-semibold text-slate-100">{proof.value}</p>
+                </div>
+              ))}
+            </div>
           </div>
 
-          <div className="space-y-4 lg:-mt-3 xl:-mt-4">
+          <div className="lg:-mt-3 xl:-mt-4">
             <ProductVisual />
-            <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-3">
+            <div className="mt-4 hidden gap-3 lg:grid lg:grid-cols-3">
               {complianceProofs.map((proof) => (
-                <div key={proof.label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 shadow-2xl shadow-black/10 backdrop-blur">
+                <div key={proof.label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
                   <proof.icon className="h-5 w-5 text-primary-light" />
                   <p className="mt-3 text-xs uppercase tracking-[0.2em] text-slate-500">{proof.label}</p>
                   <p className="mt-1 font-heading text-lg font-semibold text-slate-100">{proof.value}</p>

--- a/app/components/home/SocialProofSection.tsx
+++ b/app/components/home/SocialProofSection.tsx
@@ -1,0 +1,63 @@
+import { CheckCircle2 } from 'lucide-react'
+import { evaluationStories, socialProofIndustries, socialProofMetrics } from '../../data/homepage'
+import SectionIntro from './SectionIntro'
+
+export default function SocialProofSection() {
+  return (
+    <section id="social-proof" className="section bg-background-secondary">
+      <div className="container-custom">
+        <SectionIntro
+          eyebrow="Social Proof"
+          title="Proof buyers can verify."
+          description="Evidence for regulated teams: supported industries, public benchmark scope, measured gateway overhead, and evaluation patterns without invented customer claims."
+        />
+
+        <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {socialProofIndustries.map((industry) => (
+            <article key={industry.title} className="rounded-[22px] border border-white/10 bg-background p-5">
+              <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary-light">
+                <industry.icon className="h-5 w-5" />
+              </div>
+              <h3 className="mt-4 font-heading text-xl font-semibold text-white">{industry.title}</h3>
+              <p className="mt-3 text-sm leading-6 text-slate-400">{industry.body}</p>
+            </article>
+          ))}
+        </div>
+
+        <div className="mt-8 grid gap-4 lg:grid-cols-[0.95fr_1.05fr]">
+          <div className="rounded-[28px] border border-primary/20 bg-[radial-gradient(circle_at_top_left,rgba(34,211,238,0.14),transparent_28%),linear-gradient(180deg,rgba(15,23,42,0.96),rgba(2,6,23,0.96))] p-6 md:p-7">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Proof-backed metrics</p>
+            <h3 className="mt-4 font-heading text-3xl font-semibold text-white">Concrete signals buyers can verify.</h3>
+            <p className="mt-4 text-sm leading-7 text-slate-300">
+              These numbers come from product surfaces, benchmark artifacts, and documented website claims. Production usage counts and customer outcomes are published only when an approved source exists.
+            </p>
+
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              {socialProofMetrics.map((metric) => (
+                <div key={metric.label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+                  <p className="font-heading text-3xl font-semibold text-white">{metric.value}</p>
+                  <p className="mt-2 font-mono text-[11px] uppercase tracking-[0.18em] text-primary-light">{metric.label}</p>
+                  <p className="mt-3 text-sm leading-6 text-slate-400">{metric.detail}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-4">
+            {evaluationStories.map((story) => (
+              <article key={story.label} className="rounded-[28px] border border-white/10 bg-background p-6">
+                <p className="font-mono text-xs uppercase tracking-[0.24em] text-[#fdba74]">{story.label}</p>
+                <h3 className="mt-4 font-heading text-2xl font-semibold text-white">{story.title}</h3>
+                <p className="mt-4 text-sm leading-7 text-slate-300">{story.body}</p>
+                <div className="mt-5 flex items-start gap-3 rounded-2xl border border-emerald-400/20 bg-emerald-400/10 p-4 text-sm leading-6 text-emerald-100">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-300" />
+                  <span>{story.outcome}</span>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/data/homepage.ts
+++ b/app/data/homepage.ts
@@ -5,10 +5,13 @@ import {
   FileText,
   Gauge,
   Globe,
+  Landmark,
   KeyRound,
+  Scale,
   Languages,
   Lock,
   Network,
+  Stethoscope,
   ScanSearch,
   Server,
   ShieldCheck,
@@ -332,6 +335,67 @@ export const complianceProofs = [
     icon: Timer,
     label: 'Measured overhead',
     value: '~41 ms',
+  },
+] as const
+
+export const socialProofIndustries = [
+  {
+    icon: Landmark,
+    title: 'Financial Services',
+    body: 'Customer, payment, claim, and account context before model routing.',
+  },
+  {
+    icon: Stethoscope,
+    title: 'Healthcare',
+    body: 'PHI-aware masking posture for healthcare and healthtech evaluations.',
+  },
+  {
+    icon: Scale,
+    title: 'Legal',
+    body: 'Matter, client, and document-review prompts with clearer AI boundaries.',
+  },
+  {
+    icon: Building2,
+    title: 'Public Sector',
+    body: 'Citizen-service and internal policy workflows where auditability matters.',
+  },
+] as const
+
+export const socialProofMetrics = [
+  {
+    value: '20+',
+    label: 'PII entity types',
+    detail: 'Names, contacts, account identifiers, cards, IBANs, NHS-style IDs, and custom rules.',
+  },
+  {
+    value: '10',
+    label: 'benchmark languages',
+    detail: 'Current multilingual benchmark scope across English, Turkish, German, French, Spanish, and more.',
+  },
+  {
+    value: '99.8%',
+    label: 'public overall F1',
+    detail: 'Gateway-owned product benchmark, not a third-party independent evaluation.',
+  },
+  {
+    value: '~41 ms',
+    label: 'measured overhead',
+    detail: 'NeutralAI gateway overhead measured separately from model generation time.',
+  },
+] as const
+
+export const evaluationStories = [
+  {
+    label: 'Finance evaluation pattern',
+    title: 'A regulated team wants AI summaries without leaking customer identifiers.',
+    body: 'NeutralAI sits in front of prompt traffic, masks payment and contact details, and gives security reviewers evidence before wider rollout.',
+    outcome: 'Buyer outcome: safer evaluation path before approving production AI workflows.',
+  },
+  {
+    label: 'Healthcare evaluation pattern',
+    title: 'A healthtech team needs useful AI output while reducing raw PHI exposure.',
+    body: 'Prompts keep operational context while direct patient identifiers are tokenized or removed before external model routing.',
+    outcome: 'Buyer outcome: clearer BAA and deployment review conversations without blanket compliance claims.',
   },
 ] as const
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -132,8 +132,11 @@ export default function RootLayout({
   }
 
   return (
-    <html lang="en" className="scroll-smooth">
-      <body className={`${dmSans.variable} ${jetBrainsMono.variable} ${spaceGrotesk.variable} font-body bg-background text-slate-50 antialiased`}>
+    <html lang="en" className="scroll-smooth" suppressHydrationWarning>
+      <body
+        className={`${dmSans.variable} ${jetBrainsMono.variable} ${spaceGrotesk.variable} font-body bg-background text-slate-50 antialiased`}
+        suppressHydrationWarning
+      >
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import Hero from './components/home/Hero'
 import HowItWorks from './components/home/HowItWorks'
 import PricingSection from './components/home/PricingSection'
 import ProductSurface from './components/home/ProductSurface'
+import SocialProofSection from './components/home/SocialProofSection'
 import TrustSection from './components/home/TrustSection'
 import WhyItMatters from './components/home/WhyItMatters'
 
@@ -16,6 +17,7 @@ export default function Home() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(pricingFaqStructuredData) }}
       />
       <Hero />
+      <SocialProofSection />
       <ProductSurface />
       <WhyItMatters />
       <HowItWorks />

--- a/docs/ai/OPEN_QUESTIONS.md
+++ b/docs/ai/OPEN_QUESTIONS.md
@@ -12,6 +12,7 @@ Use this file for unknowns. Do not guess silently.
 - What is the preferred ICP for the website copy: legal, finance, healthcare, insurance, SaaS support, or broader regulated teams?
 - WEB-103 asks for at least 3 articles targeting keywords with search volume >100/mo, but this repo has no approved SEO data source or keyword-volume export. Which SEO tool/export should be treated as the canonical volume source?
 - WEB-104 now has a local Playwright-generated demo video, captions, and poster. If marketing wants external hosting, what hosted URL should replace the local asset? Browser extension or admin dashboard footage still needs explicit approval before it is shown publicly.
+- WEB-105 needs approved real customer outcomes, testimonials, usage counts, or anonymized case-study evidence before the homepage should call anything a customer case study or show social-proof usage numbers.
 
 ## Architecture / Deployment
 

--- a/tests/content/trust-signals.test.mjs
+++ b/tests/content/trust-signals.test.mjs
@@ -15,6 +15,7 @@ function readHomepageSource() {
     'app/data/homepage.ts',
     'app/components/home/DetectionEngine.tsx',
     'app/components/home/Hero.tsx',
+    'app/components/home/SocialProofSection.tsx',
     'app/components/home/TrustSection.tsx',
   ]
     .map(readSource)
@@ -35,6 +36,28 @@ test('homepage exposes concrete trust badges and detection details', () => {
   assert.match(homeSource, /EMAIL/)
   assert.match(homeSource, /CREDIT_CARD/)
   assert.match(homeSource, /PHONE_NUMBER, PERSON, CREDIT_CARD, IBAN, SSN, TR_ID_NUMBER, UK_NHS_NUMBER/)
+})
+
+test('homepage adds social proof without fake customer claims', () => {
+  const homeSource = readHomepageSource()
+
+  assert.match(homeSource, /<SocialProofSection \/>/)
+  assert.match(homeSource, /Proof buyers can verify/)
+  assert.match(homeSource, /Financial Services/)
+  assert.match(homeSource, /Healthcare/)
+  assert.match(homeSource, /Legal/)
+  assert.match(homeSource, /Public Sector/)
+  assert.match(homeSource, /Proof-backed metrics/)
+  assert.match(homeSource, /20\+/)
+  assert.match(homeSource, /10/)
+  assert.match(homeSource, /99\.8%/)
+  assert.match(homeSource, /~41 ms/)
+  assert.match(homeSource, /Finance evaluation pattern/)
+  assert.match(homeSource, /Healthcare evaluation pattern/)
+  assert.match(homeSource, /Production usage counts and customer outcomes are published only when an approved source exists/)
+  assert.doesNotMatch(homeSource, /Trusted by .*customers/)
+  assert.doesNotMatch(homeSource, /testimonial/i)
+  assert.doesNotMatch(homeSource, /customer logo/i)
 })
 
 test('homepage adds a scannable detection engine deep dive', () => {


### PR DESCRIPTION
## Problem

The homepage needs social proof for regulated buyers, but the repo does not yet have approved customer logos, testimonials, production usage counts, or real anonymized customer outcomes. Publishing invented proof would be risky and misleading.

## What Changed

- Added a homepage social proof section after the hero with industry relevance, proof-backed metrics, and evaluation patterns.
- Kept claims tied to product surfaces, benchmark artifacts, and documented website claims rather than fake customer evidence.
- Added content coverage to prevent fake customer/logo/testimonial language from being introduced.
- Logged the missing approved customer evidence in OPEN_QUESTIONS.

## Validation

- [x] npm run test:content
- [x] npm run lint
- [x] npm run build
- [x] npm run audit:prod
- [x] Playwright desktop and mobile screenshots for #social-proof

## Risks / Follow-ups

- npm audit still reports existing Next.js/PostCSS advisories, but audit:prod exits 0 because the repo gates on critical severity.
- Real customer outcomes, testimonials, usage counts, or anonymized case studies should be added only after an approved source exists.

Closes #43