### PR TITLE
Add consent-gated conversion analytics

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -88,11 +88,23 @@ export default function ComparePage() {
               vaulting, policy enforcement, browser coverage, telemetry, and evidence.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
-              <Link href={siteConfig.signupUrl} className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto">
+              <Link
+                href={siteConfig.signupUrl}
+                className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto"
+                data-analytics-event="CTA Click"
+                data-analytics-label="Try Free"
+                data-analytics-placement="compare_hero"
+              >
                 Try Free
                 <ArrowRight className="h-5 w-5" />
               </Link>
-              <Link href="/contact" className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto">
+              <Link
+                href="/contact"
+                className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto"
+                data-analytics-event="CTA Click"
+                data-analytics-label="Talk to Sales"
+                data-analytics-placement="compare_hero"
+              >
                 Talk to Sales
               </Link>
               <Link href="/presidio-alternative" className="text-primary-light transition hover:text-primary">

--- a/app/components/AnalyticsProvider.tsx
+++ b/app/components/AnalyticsProvider.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import Script from 'next/script'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { siteConfig } from '../site'
+import {
+  captureAttribution,
+  getAnalyticsConsent,
+  setAnalyticsConsent,
+  trackAnalyticsEvent,
+  type AnalyticsConsent,
+  type AnalyticsProperties,
+} from '../lib/analytics'
+
+function safeDestination(element: HTMLElement) {
+  const href = element instanceof HTMLAnchorElement ? element.href : ''
+  if (!href) {
+    return ''
+  }
+
+  try {
+    const url = new URL(href)
+    return url.origin === window.location.origin ? url.pathname : `${url.hostname}${url.pathname}`
+  } catch {
+    return ''
+  }
+}
+
+function getEventProperties(element: HTMLElement, pathname: string): AnalyticsProperties {
+  return {
+    label: element.dataset.analyticsLabel || element.textContent?.trim().replace(/\s+/g, ' ').slice(0, 80) || 'unknown',
+    placement: element.dataset.analyticsPlacement || 'unspecified',
+    destination: element.dataset.analyticsDestination || safeDestination(element),
+    page_path: pathname,
+  }
+}
+
+export default function AnalyticsProvider() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [consent, setConsent] = useState<AnalyticsConsent | null>(() => getAnalyticsConsent())
+  const analyticsEnabled = Boolean(siteConfig.analytics.plausibleDomain)
+  const canLoadAnalytics = consent === 'accepted' && analyticsEnabled
+
+  useEffect(() => {
+    if (consent === 'accepted') {
+      captureAttribution()
+    }
+  }, [consent, pathname, searchParams])
+
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      const target = event.target
+      if (!(target instanceof Element)) {
+        return
+      }
+
+      const element = target.closest<HTMLElement>('[data-analytics-event]')
+      if (!element?.dataset.analyticsEvent) {
+        return
+      }
+
+      trackAnalyticsEvent(element.dataset.analyticsEvent, getEventProperties(element, pathname))
+    }
+
+    document.addEventListener('click', handleClick)
+    return () => document.removeEventListener('click', handleClick)
+  }, [pathname])
+
+  function chooseConsent(nextConsent: AnalyticsConsent) {
+    setAnalyticsConsent(nextConsent)
+    setConsent(nextConsent)
+
+    if (nextConsent === 'accepted') {
+      captureAttribution()
+    }
+  }
+
+  return (
+    <>
+      {canLoadAnalytics ? (
+        <Script
+          id="plausible-analytics"
+          src={siteConfig.analytics.plausibleScriptUrl}
+          data-domain={siteConfig.analytics.plausibleDomain}
+          strategy="afterInteractive"
+        />
+      ) : null}
+
+      {consent === null ? (
+        <div className="fixed inset-x-4 bottom-4 z-[70] mx-auto max-w-3xl rounded-2xl border border-white/10 bg-background-secondary/95 p-4 shadow-[0_24px_80px_rgba(2,8,23,0.55)] backdrop-blur md:p-5">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="font-heading text-base font-semibold text-white">Analytics consent</p>
+              <p className="mt-1 text-sm leading-6 text-slate-400">
+                We use privacy-friendly analytics to understand page performance and CTA conversion. No analytics runs until you accept.
+              </p>
+            </div>
+            <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
+              <button
+                type="button"
+                onClick={() => chooseConsent('declined')}
+                className="rounded-xl border border-white/10 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-white/20 hover:text-white"
+              >
+                Decline
+              </button>
+              <button
+                type="button"
+                onClick={() => chooseConsent('accepted')}
+                className="rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-primary-light"
+              >
+                Accept analytics
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/app/components/HubSpotLeadForm.tsx
+++ b/app/components/HubSpotLeadForm.tsx
@@ -3,6 +3,7 @@
 import Script from 'next/script'
 import { useEffect, useId, useState } from 'react'
 import { siteConfig } from '../site'
+import { getLeadAttribution } from '../lib/analytics'
 
 type HubSpotFormApi = {
   forms?: {
@@ -119,6 +120,9 @@ export default function HubSpotLeadForm({
           setHiddenField(form, 'website_intent', intent)
           setHiddenField(form, 'lead_source', leadSource)
           setHiddenField(form, 'website_page_url', window.location.href)
+          Object.entries(getLeadAttribution()).forEach(([name, value]) => {
+            setHiddenField(form, name, String(value))
+          })
         },
       })
     } catch {

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -80,7 +80,13 @@ export default function Navbar() {
           <Link href="/contact" className="whitespace-nowrap text-sm text-slate-300 transition-colors hover:text-white 2xl:text-base">
             Contact
           </Link>
-          <Link href={siteConfig.signupUrl} className="btn btn-cta whitespace-nowrap px-5 py-3 text-sm 2xl:text-base">
+          <Link
+            href={siteConfig.signupUrl}
+            className="btn btn-cta whitespace-nowrap px-5 py-3 text-sm 2xl:text-base"
+            data-analytics-event="CTA Click"
+            data-analytics-label="Get Started Free"
+            data-analytics-placement="navbar_desktop"
+          >
             Get Started Free
           </Link>
         </div>
@@ -131,6 +137,9 @@ export default function Navbar() {
             href={siteConfig.signupUrl}
             className="btn btn-cta w-full mt-4"
             onClick={() => setIsOpen(false)}
+            data-analytics-event="CTA Click"
+            data-analytics-label="Get Started Free"
+            data-analytics-placement="navbar_mobile"
           >
             Get Started Free
           </Link>

--- a/app/components/home/CtaSection.tsx
+++ b/app/components/home/CtaSection.tsx
@@ -18,17 +18,35 @@ export default function CtaSection() {
             NeutralAI is for teams that already know AI usage is happening and want a credible way to reduce prompt risk without slowing everyone down.
           </p>
           <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <a href={siteConfig.signupUrl} className="btn btn-cta w-full px-8 py-4 text-lg sm:w-auto">
+            <a
+              href={siteConfig.signupUrl}
+              className="btn btn-cta w-full px-8 py-4 text-lg sm:w-auto"
+              data-analytics-event="CTA Click"
+              data-analytics-label="Try Free"
+              data-analytics-placement="homepage_final_cta"
+            >
               Try Free
               <ArrowRight className="h-5 w-5" />
             </a>
-            <a href={contactLinks.enterprise} className="btn btn-secondary w-full px-8 py-4 text-lg sm:w-auto">
+            <a
+              href={contactLinks.enterprise}
+              className="btn btn-secondary w-full px-8 py-4 text-lg sm:w-auto"
+              data-analytics-event="CTA Click"
+              data-analytics-label="Talk to Sales"
+              data-analytics-placement="homepage_final_cta"
+            >
               Talk to Sales
             </a>
           </div>
           <p className="mt-4 text-sm text-slate-400">
             Need a security or commercial conversation first?{' '}
-            <a href={contactLinks.enterprise} className="text-primary-light hover:text-primary">
+            <a
+              href={contactLinks.enterprise}
+              className="text-primary-light hover:text-primary"
+              data-analytics-event="CTA Click"
+              data-analytics-label="Contact NeutralAI"
+              data-analytics-placement="homepage_final_cta"
+            >
               Contact NeutralAI
             </a>
             .

--- a/app/components/home/Hero.tsx
+++ b/app/components/home/Hero.tsx
@@ -38,11 +38,23 @@ export default function Hero() {
             </p>
 
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-              <a href={siteConfig.signupUrl} className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto">
+              <a
+                href={siteConfig.signupUrl}
+                className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto"
+                data-analytics-event="CTA Click"
+                data-analytics-label="Try Free"
+                data-analytics-placement="homepage_hero"
+              >
                 Try Free
                 <ArrowRight className="h-5 w-5" />
               </a>
-              <a href={siteConfig.demoUrl} className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto">
+              <a
+                href={siteConfig.demoUrl}
+                className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto"
+                data-analytics-event="CTA Click"
+                data-analytics-label="Book Demo"
+                data-analytics-placement="homepage_hero"
+              >
                 Book Demo
               </a>
             </div>

--- a/app/components/home/ProductSurface.tsx
+++ b/app/components/home/ProductSurface.tsx
@@ -48,7 +48,13 @@ export default function ProductSurface() {
                   NeutralAI can protect browser-based AI usage in the flow people already know, which is exactly why adoption can move faster.
                 </p>
                 <div className="mt-5 flex flex-col gap-3 sm:flex-row">
-                  <a href={siteConfig.signupUrl} className="btn btn-cta w-full sm:w-auto">
+                  <a
+                    href={siteConfig.signupUrl}
+                    className="btn btn-cta w-full sm:w-auto"
+                    data-analytics-event="CTA Click"
+                    data-analytics-label="Try Free"
+                    data-analytics-placement="homepage_product_surface"
+                  >
                     Try Free
                   </a>
                   <a href="/install-extension" className="btn btn-secondary w-full sm:w-auto">

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -62,11 +62,23 @@ export default function DemoPage() {
               The demo flow is designed for buyers who want to understand masking, evidence, restore controls, and rollout options before committing to a live call.
             </p>
             <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
-              <Link href={siteConfig.signupUrl} className="btn btn-cta justify-center px-8 py-4">
+              <Link
+                href={siteConfig.signupUrl}
+                className="btn btn-cta justify-center px-8 py-4"
+                data-analytics-event="CTA Click"
+                data-analytics-label="Try Free"
+                data-analytics-placement="demo_hero"
+              >
                 Try Free
                 <ArrowRight className="h-5 w-5" />
               </Link>
-              <Link href={contactLinks.demo} className="btn btn-secondary justify-center px-8 py-4">
+              <Link
+                href={contactLinks.demo}
+                className="btn btn-secondary justify-center px-8 py-4"
+                data-analytics-event="CTA Click"
+                data-analytics-label="Book Live Demo"
+                data-analytics-placement="demo_hero"
+              >
                 Book Live Demo
                 <CalendarDays className="h-5 w-5" />
               </Link>
@@ -119,10 +131,22 @@ export default function DemoPage() {
                     Start with the interactive masking playground, or book a live walkthrough for browser, API, and rollout planning.
                   </p>
                   <div className="mt-7 flex flex-col justify-center gap-3 sm:flex-row">
-                    <Link href="/playground" className="btn btn-cta justify-center px-7 py-4">
+                    <Link
+                      href="/playground"
+                      className="btn btn-cta justify-center px-7 py-4"
+                      data-analytics-event="CTA Click"
+                      data-analytics-label="Try Playground"
+                      data-analytics-placement="demo_video_fallback"
+                    >
                       Try Playground
                     </Link>
-                    <Link href={contactLinks.demo} className="btn btn-secondary justify-center px-7 py-4">
+                    <Link
+                      href={contactLinks.demo}
+                      className="btn btn-secondary justify-center px-7 py-4"
+                      data-analytics-event="CTA Click"
+                      data-analytics-label="Book Live Demo"
+                      data-analytics-placement="demo_video_fallback"
+                    >
                       Book Live Demo
                     </Link>
                   </div>
@@ -161,12 +185,24 @@ export default function DemoPage() {
               Bring a representative prompt, document, or browser workflow and the team can walk through the control model with you.
             </p>
             <div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
-              <Link href={siteConfig.signupUrl} className="btn btn-cta justify-center px-7 py-4">
-                Try Free
-              </Link>
-              <Link href={contactLinks.enterprise} className="btn btn-secondary justify-center px-7 py-4">
-                Talk to Sales
-              </Link>
+                  <Link
+                    href={siteConfig.signupUrl}
+                    className="btn btn-cta justify-center px-7 py-4"
+                    data-analytics-event="CTA Click"
+                    data-analytics-label="Try Free"
+                    data-analytics-placement="demo_bottom_cta"
+                  >
+                    Try Free
+                  </Link>
+                  <Link
+                    href={contactLinks.enterprise}
+                    className="btn btn-secondary justify-center px-7 py-4"
+                    data-analytics-event="CTA Click"
+                    data-analytics-label="Talk to Sales"
+                    data-analytics-placement="demo_bottom_cta"
+                  >
+                    Talk to Sales
+                  </Link>
             </div>
           </div>
         </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import { DM_Sans, JetBrains_Mono, Space_Grotesk } from 'next/font/google'
 import './globals.css'
 import Navbar from './components/Navbar'
 import Footer from './components/Footer'
+import AnalyticsProvider from './components/AnalyticsProvider'
 import { siteConfig } from './site'
 
 const dmSans = DM_Sans({
@@ -146,6 +148,9 @@ export default function RootLayout({
           {children}
         </main>
         <Footer />
+        <Suspense fallback={null}>
+          <AnalyticsProvider />
+        </Suspense>
       </body>
     </html>
   )

--- a/app/lib/analytics.ts
+++ b/app/lib/analytics.ts
@@ -122,25 +122,32 @@ export function getStoredAttribution(): AnalyticsProperties {
   }
 }
 
+function mergeAttribution(stored: AnalyticsProperties, current: AnalyticsProperties) {
+  const merged = {
+    ...stored,
+    ...current,
+  }
+
+  if (stored.landing_page_path) {
+    merged.landing_page_path = stored.landing_page_path
+  }
+
+  return merged
+}
+
 export function captureAttribution() {
   if (!hasAnalyticsConsent()) {
     return {}
   }
 
-  const merged = {
-    ...getStoredAttribution(),
-    ...currentUrlAttribution(),
-  }
+  const merged = mergeAttribution(getStoredAttribution(), currentUrlAttribution())
 
   safeLocalStorageSet(ANALYTICS_ATTRIBUTION_KEY, JSON.stringify(merged))
   return merged
 }
 
 export function getLeadAttribution(): AnalyticsProperties {
-  return {
-    ...getStoredAttribution(),
-    ...currentUrlAttribution(),
-  }
+  return mergeAttribution(getStoredAttribution(), currentUrlAttribution())
 }
 
 function getPlausibleQueue() {

--- a/app/lib/analytics.ts
+++ b/app/lib/analytics.ts
@@ -1,0 +1,172 @@
+'use client'
+
+export type AnalyticsConsent = 'accepted' | 'declined'
+export type AnalyticsProperties = Record<string, string | number | boolean>
+
+export const ANALYTICS_CONSENT_KEY = 'neutralai_analytics_consent'
+export const ANALYTICS_ATTRIBUTION_KEY = 'neutralai_analytics_attribution'
+
+const attributionParams = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+] as const
+
+type PlausibleOptions = {
+  props?: AnalyticsProperties
+  url?: string
+}
+
+type PlausibleFn = {
+  (eventName: string, options?: PlausibleOptions): void
+  q?: [string, PlausibleOptions | undefined][]
+}
+
+declare global {
+  interface Window {
+    plausible?: PlausibleFn
+  }
+}
+
+function safeLocalStorageGet(key: string) {
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function safeLocalStorageSet(key: string, value: string) {
+  try {
+    window.localStorage.setItem(key, value)
+  } catch {
+    // Ignore storage failures so consent UI never blocks navigation.
+  }
+}
+
+function normalizePath() {
+  return `${window.location.pathname}${window.location.hash || ''}`
+}
+
+function referrerHost(referrer: string) {
+  if (!referrer) {
+    return ''
+  }
+
+  try {
+    const url = new URL(referrer)
+    return url.hostname === window.location.hostname ? '' : url.hostname
+  } catch {
+    return ''
+  }
+}
+
+export function getAnalyticsConsent(): AnalyticsConsent | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const consent = safeLocalStorageGet(ANALYTICS_CONSENT_KEY)
+  return consent === 'accepted' || consent === 'declined' ? consent : null
+}
+
+export function setAnalyticsConsent(consent: AnalyticsConsent) {
+  safeLocalStorageSet(ANALYTICS_CONSENT_KEY, consent)
+}
+
+export function hasAnalyticsConsent() {
+  return getAnalyticsConsent() === 'accepted'
+}
+
+export function currentUrlAttribution(): AnalyticsProperties {
+  if (typeof window === 'undefined') {
+    return {}
+  }
+
+  const searchParams = new URLSearchParams(window.location.search)
+  const attribution: AnalyticsProperties = {}
+
+  for (const param of attributionParams) {
+    const value = searchParams.get(param)
+    if (value) {
+      attribution[param] = value.slice(0, 120)
+    }
+  }
+
+  const host = referrerHost(document.referrer)
+  if (host) {
+    attribution.referrer_host = host
+  }
+
+  attribution.landing_page_path = normalizePath()
+
+  return attribution
+}
+
+export function getStoredAttribution(): AnalyticsProperties {
+  if (typeof window === 'undefined') {
+    return {}
+  }
+
+  const stored = safeLocalStorageGet(ANALYTICS_ATTRIBUTION_KEY)
+  if (!stored) {
+    return {}
+  }
+
+  try {
+    return JSON.parse(stored) as AnalyticsProperties
+  } catch {
+    return {}
+  }
+}
+
+export function captureAttribution() {
+  if (!hasAnalyticsConsent()) {
+    return {}
+  }
+
+  const merged = {
+    ...getStoredAttribution(),
+    ...currentUrlAttribution(),
+  }
+
+  safeLocalStorageSet(ANALYTICS_ATTRIBUTION_KEY, JSON.stringify(merged))
+  return merged
+}
+
+export function getLeadAttribution(): AnalyticsProperties {
+  return {
+    ...getStoredAttribution(),
+    ...currentUrlAttribution(),
+  }
+}
+
+function getPlausibleQueue() {
+  if (!window.plausible) {
+    const plausible: PlausibleFn = (eventName, options) => {
+      plausible.q = plausible.q || []
+      plausible.q.push([eventName, options])
+    }
+    window.plausible = plausible
+  }
+
+  return window.plausible
+}
+
+export function trackAnalyticsEvent(eventName: string, properties: AnalyticsProperties = {}, options: Omit<PlausibleOptions, 'props'> = {}) {
+  if (typeof window === 'undefined' || !hasAnalyticsConsent()) {
+    return
+  }
+
+  const props = {
+    ...getStoredAttribution(),
+    ...properties,
+  }
+
+  getPlausibleQueue()(eventName, {
+    ...options,
+    props,
+  })
+}

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -7,6 +7,7 @@ import {
   ArrowRight,
   CheckCircle2,
   Clipboard,
+  Copy,
   Eraser,
   Gauge,
   Loader2,
@@ -18,6 +19,7 @@ import {
 } from 'lucide-react'
 import BackButton from '../components/BackButton'
 import { siteConfig } from '../site'
+import { trackAnalyticsEvent } from '../lib/analytics'
 
 type MaskingMode = 'irreversible' | 'reversible'
 type ResultSource = 'live' | 'demo'
@@ -333,6 +335,11 @@ export default function PlaygroundPage() {
       return
     }
 
+    trackAnalyticsEvent('Playground Mask Submit', {
+      mode,
+      prompt_length: prompt.length,
+    })
+
     const requestVersion = requestVersionRef.current + 1
     const requestPreview = localPreview
     requestVersionRef.current = requestVersion
@@ -404,6 +411,24 @@ export default function PlaygroundPage() {
     clearMaskResult('Waiting for prompt')
   }
 
+  async function copySanitizedOutput() {
+    if (!visibleMaskedText) {
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(visibleMaskedText)
+    } catch {
+      return
+    }
+
+    trackAnalyticsEvent('Playground Result Copy', {
+      mode,
+      result_source: source,
+      finding_count: findings.length,
+    })
+  }
+
   return (
     <main className="min-h-screen pt-24">
       <section className="relative overflow-hidden py-12 md:py-16">
@@ -424,7 +449,13 @@ export default function PlaygroundPage() {
                   Try a sample
                   <Play className="h-5 w-5" />
                 </Link>
-                <Link href={siteConfig.signupUrl} className="btn btn-secondary justify-center px-8 py-4">
+                <Link
+                  href={siteConfig.signupUrl}
+                  className="btn btn-secondary justify-center px-8 py-4"
+                  data-analytics-event="CTA Click"
+                  data-analytics-label="Get your free API key"
+                  data-analytics-placement="playground_hero"
+                >
                   Get your free API key
                   <ArrowRight className="h-5 w-5" />
                 </Link>
@@ -515,7 +546,15 @@ export default function PlaygroundPage() {
                     Clear prompt
                   </button>
                 </div>
-                <button type="button" onClick={runMasking} disabled={!canSubmit} className="btn btn-cta justify-center px-7 py-3 disabled:cursor-not-allowed disabled:opacity-60">
+                <button
+                  type="button"
+                  onClick={runMasking}
+                  disabled={!canSubmit}
+                  className="btn btn-cta justify-center px-7 py-3 disabled:cursor-not-allowed disabled:opacity-60"
+                  data-analytics-event="Playground Mask Button Click"
+                  data-analytics-label="Mask prompt"
+                  data-analytics-placement="playground_input"
+                >
                   {isLoading ? <Loader2 className="h-5 w-5 animate-spin" /> : <Eraser className="h-5 w-5" />}
                   Mask prompt
                 </button>
@@ -545,6 +584,15 @@ export default function PlaygroundPage() {
                     <h2 className="font-heading text-2xl font-semibold text-white">Detection view</h2>
                     <p className="mt-2 text-sm text-slate-400">Results appear after you run masking from the raw prompt panel.</p>
                   </div>
+                  <button
+                    type="button"
+                    onClick={copySanitizedOutput}
+                    disabled={!hasResult}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/10 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-primary/40 hover:text-primary-light disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <Copy className="h-4 w-4" />
+                    Copy sanitized
+                  </button>
                 </div>
 
                 <div className="mt-5 grid gap-4 lg:grid-cols-2">
@@ -640,11 +688,23 @@ export default function PlaygroundPage() {
               </div>
             </div>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-              <Link href={siteConfig.signupUrl} className="btn btn-cta justify-center px-8 py-4">
+              <Link
+                href={siteConfig.signupUrl}
+                className="btn btn-cta justify-center px-8 py-4"
+                data-analytics-event="CTA Click"
+                data-analytics-label="Get your free API key"
+                data-analytics-placement="playground_bottom_cta"
+              >
                 Get your free API key
                 <ArrowRight className="h-5 w-5" />
               </Link>
-              <Link href="/contact" className="btn btn-secondary justify-center px-8 py-4">
+              <Link
+                href="/contact"
+                className="btn btn-secondary justify-center px-8 py-4"
+                data-analytics-event="CTA Click"
+                data-analytics-label="Talk to Sales"
+                data-analytics-placement="playground_bottom_cta"
+              >
                 Talk to Sales
               </Link>
             </div>

--- a/app/site.ts
+++ b/app/site.ts
@@ -15,6 +15,10 @@ export const siteConfig = {
   demoVideoSrc: '/demo/neutralai-product-walkthrough.webm',
   demoVideoCaptionsSrc: '/demo/neutralai-product-walkthrough.vtt',
   demoVideoPosterSrc: '/demo/neutralai-product-walkthrough-poster.png',
+  analytics: {
+    plausibleDomain: process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN ?? '',
+    plausibleScriptUrl: process.env.NEXT_PUBLIC_PLAUSIBLE_SCRIPT_URL ?? 'https://plausible.io/js/script.js',
+  },
   hubspot: {
     portalId: process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID ?? '',
     region: process.env.NEXT_PUBLIC_HUBSPOT_REGION ?? 'eu1',

--- a/docs/ai/OPEN_QUESTIONS.md
+++ b/docs/ai/OPEN_QUESTIONS.md
@@ -15,6 +15,7 @@ Use this file for unknowns. Do not guess silently.
 - WEB-105 needs approved real customer outcomes, testimonials, usage counts, or anonymized case-study evidence before the homepage should call anything a customer case study or show social-proof usage numbers.
 - WEB-106 needs the live HubSpot portal ID, region, form IDs, contact property names, notification workflow, confirmation email workflow, and Slack routing configured outside the repo before production leads can be verified end-to-end.
 - WEB-106 asks for HubSpot tracking script attribution, but global visitor tracking should wait for approved cookie consent/analytics ownership so the website does not add non-essential tracking before consent.
+- WEB-107 needs a confirmed Plausible workspace/domain, dashboard owner, and approved goal/funnel definitions before production analytics can be verified beyond the website consent-gated wiring.
 
 ## Architecture / Deployment
 

--- a/docs/analytics-setup.md
+++ b/docs/analytics-setup.md
@@ -1,0 +1,57 @@
+# Analytics Setup
+
+NeutralAI website analytics must stay consent-gated. Do not add analytics cookies, tracking scripts, replay tools, or advertising pixels before the visitor accepts analytics.
+
+## Provider
+
+The website is wired for Plausible through public environment variables:
+
+- `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`
+- `NEXT_PUBLIC_PLAUSIBLE_SCRIPT_URL` defaults to `https://plausible.io/js/script.js`
+
+If `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` is missing, the consent banner still records the visitor's choice locally, but no third-party analytics script is loaded.
+
+## Consent Behaviour
+
+- Analytics script loading is blocked until the visitor accepts analytics.
+- Declining analytics stores only the consent choice.
+- UTM attribution is persisted in `localStorage` only after analytics consent is accepted.
+- CTA and playground events are ignored when analytics consent is not accepted.
+
+## Events
+
+Use these names when creating Plausible goals/funnels:
+
+- `CTA Click`
+- `Playground Mask Submit`
+- `Playground Mask Button Click`
+- `Playground Result Copy`
+
+Recommended funnel views:
+
+- Homepage -> pricing anchor -> signup handoff.
+- Homepage -> playground -> signup handoff.
+- Homepage/demo/blog -> contact intent page.
+
+## Attribution
+
+After consent, the website stores and attaches:
+
+- `utm_source`
+- `utm_medium`
+- `utm_campaign`
+- `utm_term`
+- `utm_content`
+- `referrer_host`
+- `landing_page_path`
+
+HubSpot forms also attempt to pass these values as hidden fields when the matching HubSpot properties exist.
+
+## Dashboard Setup Outside The Repo
+
+- Create or confirm the Plausible site.
+- Add the production domain to `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`.
+- Create goals for CTA clicks and playground interactions.
+- Build the three recommended funnels.
+- Confirm dashboard access for the team.
+- Run one consent-accepted smoke test and one consent-declined smoke test after deployment.

--- a/docs/hubspot-crm-setup.md
+++ b/docs/hubspot-crm-setup.md
@@ -24,6 +24,13 @@ The HubSpot forms should capture these buyer qualification fields:
 - `website_intent`
 - `lead_source`
 - `website_page_url`
+- `utm_source`
+- `utm_medium`
+- `utm_campaign`
+- `utm_term`
+- `utm_content`
+- `referrer_host`
+- `landing_page_path`
 
 ## Form Routing
 

--- a/tests/content/analytics.test.mjs
+++ b/tests/content/analytics.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+
+function readSource(path) {
+  return readFileSync(join(root, path), 'utf8')
+}
+
+test('analytics script is consent-gated and env configured', () => {
+  const layoutSource = readSource('app/layout.tsx')
+  const siteSource = readSource('app/site.ts')
+  const providerSource = readSource('app/components/AnalyticsProvider.tsx')
+  const analyticsSource = readSource('app/lib/analytics.ts')
+
+  assert.match(layoutSource, /<AnalyticsProvider \/>/)
+  assert.match(siteSource, /NEXT_PUBLIC_PLAUSIBLE_DOMAIN/)
+  assert.match(siteSource, /NEXT_PUBLIC_PLAUSIBLE_SCRIPT_URL/)
+  assert.match(providerSource, /consent === 'accepted'/)
+  assert.match(providerSource, /<Script/)
+  assert.match(providerSource, /data-domain=\{siteConfig\.analytics\.plausibleDomain\}/)
+  assert.match(providerSource, /No analytics runs until you accept/)
+  assert.match(analyticsSource, /ANALYTICS_CONSENT_KEY/)
+  assert.match(analyticsSource, /hasAnalyticsConsent\(\)/)
+})
+
+test('conversion tracking captures CTA clicks and playground events without prompt content', () => {
+  const providerSource = readSource('app/components/AnalyticsProvider.tsx')
+  const heroSource = readSource('app/components/home/Hero.tsx')
+  const ctaSource = readSource('app/components/home/CtaSection.tsx')
+  const navbarSource = readSource('app/components/Navbar.tsx')
+  const demoSource = readSource('app/demo/page.tsx')
+  const playgroundSource = readSource('app/playground/page.tsx')
+
+  assert.match(providerSource, /\[data-analytics-event\]/)
+  assert.match(providerSource, /dataset\.analyticsEvent/)
+  assert.match(heroSource, /data-analytics-label="Try Free"/)
+  assert.match(heroSource, /data-analytics-label="Book Demo"/)
+  assert.match(ctaSource, /data-analytics-label="Talk to Sales"/)
+  assert.match(navbarSource, /data-analytics-label="Get Started Free"/)
+  assert.match(demoSource, /data-analytics-placement="demo_hero"/)
+  assert.match(playgroundSource, /trackAnalyticsEvent\('Playground Mask Submit'/)
+  assert.match(playgroundSource, /trackAnalyticsEvent\('Playground Result Copy'/)
+  assert.match(playgroundSource, /prompt_length: prompt\.length/)
+  assert.doesNotMatch(playgroundSource, /trackAnalyticsEvent\([^)]*prompt[,}]/)
+})
+
+test('utm attribution persists after consent and can enrich HubSpot leads', () => {
+  const analyticsSource = readSource('app/lib/analytics.ts')
+  const hubspotSource = readSource('app/components/HubSpotLeadForm.tsx')
+  const analyticsDocs = readSource('docs/analytics-setup.md')
+  const hubspotDocs = readSource('docs/hubspot-crm-setup.md')
+  const openQuestions = readSource('docs/ai/OPEN_QUESTIONS.md')
+
+  for (const field of ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'referrer_host', 'landing_page_path']) {
+    assert.match(analyticsSource, new RegExp(field))
+    assert.match(analyticsDocs, new RegExp(field))
+    assert.match(hubspotDocs, new RegExp(field))
+  }
+
+  assert.match(analyticsSource, /ANALYTICS_ATTRIBUTION_KEY/)
+  assert.match(analyticsSource, /captureAttribution/)
+  assert.match(hubspotSource, /getLeadAttribution/)
+  assert.match(hubspotSource, /Object\.entries\(getLeadAttribution\(\)\)/)
+  assert.match(openQuestions, /WEB-107 needs a confirmed Plausible workspace/)
+})

--- a/tests/content/analytics.test.mjs
+++ b/tests/content/analytics.test.mjs
@@ -62,6 +62,8 @@ test('utm attribution persists after consent and can enrich HubSpot leads', () =
 
   assert.match(analyticsSource, /ANALYTICS_ATTRIBUTION_KEY/)
   assert.match(analyticsSource, /captureAttribution/)
+  assert.match(analyticsSource, /function mergeAttribution/)
+  assert.match(analyticsSource, /stored\.landing_page_path/)
   assert.match(hubspotSource, /getLeadAttribution/)
   assert.match(hubspotSource, /Object\.entries\(getLeadAttribution\(\)\)/)
   assert.match(openQuestions, /WEB-107 needs a confirmed Plausible workspace/)

--- a/tests/content/primary-cta.test.mjs
+++ b/tests/content/primary-cta.test.mjs
@@ -44,8 +44,8 @@ test('navbar primary CTA invites users to get started free', () => {
 test('homepage hero uses Try Free, Book Demo, and a demoted extension install link', () => {
   const homeSource = readHomepageSource()
 
-  assert.match(homeSource, /href=\{siteConfig\.signupUrl\}[\s\S]{0,180}>\s*Try Free/)
-  assert.match(homeSource, /href=\{siteConfig\.demoUrl\}[\s\S]{0,180}>\s*Book Demo/)
+  assert.match(homeSource, /href=\{siteConfig\.signupUrl\}[\s\S]{0,320}>\s*Try Free/)
+  assert.match(homeSource, /href=\{siteConfig\.demoUrl\}[\s\S]{0,320}>\s*Book Demo/)
   assert.match(homeSource, /className="text-primary-light[^"]*"[\s\S]{0,80}>\s*Install browser extension/)
   assert.doesNotMatch(homeSource, /className="btn btn-cta[^"]*"[\s\S]{0,120}>\s*Install Extension/)
 })
@@ -88,7 +88,7 @@ test('extension-focused homepage card keeps Try Free primary and install seconda
 
   assert.match(
     homeSource,
-    /Same tab\.[\s\S]*href=\{siteConfig\.signupUrl\}[\s\S]{0,180}>\s*Try Free/
+    /Same tab\.[\s\S]*href=\{siteConfig\.signupUrl\}[\s\S]{0,320}>\s*Try Free/
   )
   assert.match(
     homeSource,
@@ -100,8 +100,8 @@ test('extension-focused homepage card keeps Try Free primary and install seconda
 test('final CTA keeps Try Free as the primary action and sales as secondary', () => {
   const homeSource = readHomepageSource()
 
-  assert.match(homeSource, /function CtaSection\(\)[\s\S]*href=\{siteConfig\.signupUrl\}[\s\S]{0,180}>\s*Try Free/)
-  assert.match(homeSource, /function CtaSection\(\)[\s\S]*href=\{contactLinks\.enterprise\}[\s\S]{0,180}>\s*Talk to Sales/)
+  assert.match(homeSource, /function CtaSection\(\)[\s\S]*href=\{siteConfig\.signupUrl\}[\s\S]{0,320}>\s*Try Free/)
+  assert.match(homeSource, /function CtaSection\(\)[\s\S]*href=\{contactLinks\.enterprise\}[\s\S]{0,320}>\s*Talk to Sales/)
 })
 
 test('public positioning avoids beta and pilot language', () => {


### PR DESCRIPTION
## Problem
WEB-107 needs a consent-safe analytics pipeline so the website can measure CTA conversion, playground engagement, and lead attribution without loading tracking before consent.

## What Changed
- Added a consent-gated Plausible analytics provider and local attribution helper.
- Tagged key Try Free, Book Demo, Talk to Sales, demo, compare, and playground CTAs with analytics metadata.
- Added playground submit/copy analytics without sending prompt content.
- Passed accepted UTM/referrer attribution into HubSpot hidden fields when matching CRM properties exist.
- Documented analytics setup, recommended funnels, and the remaining dashboard/env ownership question.

## Validation
- `npm run lint`
- `npm run test:content`
- `npm run build`
- Browser smoke on `http://localhost:3200`: consent banner, accept flow, playground sample, mask result, and copy sanitized output.

## Risks / Follow-ups
- Plausible production domain, dashboard owner, goals, and funnel configuration still need to be confirmed outside the repo before production analytics can be fully verified.
- No secrets or provider tokens were added.

Closes #45