### PR TITLE
Add regulated industry use case pages

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -11,8 +11,10 @@ const productLinks = [
   { label: 'Compare', href: homeSections.compare },
   { label: 'Playground', href: '/playground' },
   { label: 'Demo', href: siteConfig.demoUrl },
-  { label: 'Finance Use Case', href: '/use-cases/finance' },
+  { label: 'Use Cases', href: '/use-cases' },
+  { label: 'Finance Use Case', href: '/use-cases/financial-services' },
   { label: 'Healthcare Use Case', href: '/use-cases/healthcare' },
+  { label: 'Legal Use Case', href: '/use-cases/legal' },
   { label: 'Blog', href: '/blog' },
   { label: 'Presidio Alternative', href: '/presidio-alternative' },
   { label: 'Pricing', href: homeSections.pricing },
@@ -80,7 +82,7 @@ export default function Footer() {
           </div>
 
           <div>
-            <h4 className="mb-2 font-heading font-semibold">Product</h4>
+            <p className="mb-2 font-heading font-semibold text-white">Product</p>
             <ul className="space-y-2 text-sm text-slate-500">
               {productLinks.map((link) => (
                 <li key={link.label}>
@@ -91,7 +93,7 @@ export default function Footer() {
           </div>
 
           <div>
-            <h4 className="mb-2 font-heading font-semibold">Launch</h4>
+            <p className="mb-2 font-heading font-semibold text-white">Launch</p>
             <ul className="space-y-2 text-sm text-slate-500">
               {launchLinks.map((link) => (
                 <li key={link.label}>
@@ -102,7 +104,7 @@ export default function Footer() {
           </div>
 
           <div>
-            <h4 className="mb-2 font-heading font-semibold">Company</h4>
+            <p className="mb-2 font-heading font-semibold text-white">Company</p>
             <ul className="space-y-2 text-sm text-slate-500">
               {legalLinks.map((link) => (
                 <li key={link.label}>

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -20,8 +20,10 @@ const navLinks = [
 ]
 
 const useCaseLinks = [
-  { name: 'Finance', href: '/use-cases/finance' },
+  { name: 'All Use Cases', href: '/use-cases' },
+  { name: 'Finance', href: '/use-cases/financial-services' },
   { name: 'Healthcare', href: '/use-cases/healthcare' },
+  { name: 'Legal', href: '/use-cases/legal' },
 ] as const
 
 export default function Navbar() {
@@ -93,6 +95,8 @@ export default function Navbar() {
 
         <button 
           className="xl:hidden text-slate-300"
+          aria-label={isOpen ? 'Close navigation menu' : 'Open navigation menu'}
+          aria-expanded={isOpen}
           onClick={() => setIsOpen(!isOpen)}
         >
           {isOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}

--- a/app/components/home/UseCasesSection.tsx
+++ b/app/components/home/UseCasesSection.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
+import { useCases } from '../../use-cases/content'
+import SectionIntro from './SectionIntro'
+
+const indexLink = { label: 'All use cases', href: '/use-cases' } as const
+const useCaseLinks = [
+  { label: 'Financial services', href: '/use-cases/financial-services' },
+  { label: 'Healthcare', href: '/use-cases/healthcare' },
+  { label: 'Legal', href: '/use-cases/legal' },
+] as const
+
+export default function UseCasesSection() {
+  return (
+    <section id="industries" className="section">
+      <div className="container-custom">
+        <SectionIntro
+          eyebrow="Industries"
+          title="Use cases buyers can recognize."
+          description="Industry pages help regulated teams map NeutralAI to the workflows, identifiers, and review questions they already face."
+        />
+
+        <div className="mt-10 grid gap-4 lg:grid-cols-3">
+          {useCases.map((useCase) => (
+            <Link
+              key={useCase.href}
+              href={useCase.href}
+              className="group rounded-[24px] border border-white/10 bg-background-secondary p-5 transition hover:border-primary/40 hover:bg-white/[0.04]"
+            >
+              <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#fdba74]">{useCase.title}</p>
+              <h3 className="mt-4 font-heading text-2xl font-semibold text-white">{useCase.content.proofLabel}</h3>
+              <p className="mt-3 text-sm leading-6 text-slate-400">{useCase.summary}</p>
+              <span className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-primary-light">
+                View use case
+                <ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
+              </span>
+            </Link>
+          ))}
+        </div>
+
+        <div className="mt-8 flex flex-wrap items-center gap-3 text-sm text-slate-400">
+          <Link href={indexLink.href} className="text-primary-light hover:text-primary">
+            {indexLink.label}
+          </Link>
+          {useCaseLinks.map((link) => (
+            <Link key={link.href} href={link.href} className="text-primary-light hover:text-primary">
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -726,11 +726,12 @@ body {
 
 .btn-cta {
   background: var(--accent-cta);
-  color: white;
+  color: #111827;
 }
 
 .btn-cta:hover {
   background: var(--accent-cta-hover);
+  color: #111827;
   transform: translateY(-2px);
   box-shadow: 0 10px 30px rgba(249, 115, 22, 0.3);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import PricingSection from './components/home/PricingSection'
 import ProductSurface from './components/home/ProductSurface'
 import SocialProofSection from './components/home/SocialProofSection'
 import TrustSection from './components/home/TrustSection'
+import UseCasesSection from './components/home/UseCasesSection'
 import WhyItMatters from './components/home/WhyItMatters'
 
 export default function Home() {
@@ -18,6 +19,7 @@ export default function Home() {
       />
       <Hero />
       <SocialProofSection />
+      <UseCasesSection />
       <ProductSurface />
       <WhyItMatters />
       <HowItWorks />

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -20,14 +20,18 @@ const routes = [
   '/support/browser-extension',
   '/terms',
   '/trust-center',
-  '/use-cases/finance',
+  '/use-cases',
+  '/use-cases/financial-services',
   '/use-cases/healthcare',
+  '/use-cases/legal',
 ] as const
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticRoutes = routes.map((route) => ({
     url: `${siteConfig.url}${route}`,
-    lastModified: route === '/trust-center' || route === '/presidio-alternative' || route.startsWith('/insights/')
+    lastModified: route.startsWith('/use-cases')
+      ? '2026-05-12'
+      : route === '/trust-center' || route === '/presidio-alternative' || route.startsWith('/insights/')
       ? '2026-05-08'
       : '2026-03-29',
     changeFrequency: route === '' ? ('weekly' as const) : ('monthly' as const),

--- a/app/use-cases/UseCasePage.tsx
+++ b/app/use-cases/UseCasePage.tsx
@@ -18,6 +18,26 @@ export type UseCasePageContent = {
     body: string
   }[]
   entities: string[]
+  complianceMapping: {
+    label: string
+    body: string
+  }[]
+  faq: {
+    question: string
+    answer: string
+  }[]
+  faqStructuredData: {
+    '@context': 'https://schema.org'
+    '@type': 'FAQPage'
+    mainEntity: {
+      '@type': 'Question'
+      name: string
+      acceptedAnswer: {
+        '@type': 'Answer'
+        text: string
+      }
+    }[]
+  }
   trustSignals: {
     icon: LucideIcon
     title: string
@@ -29,6 +49,10 @@ export type UseCasePageContent = {
 export default function UseCasePage({ content }: { content: UseCasePageContent }) {
   return (
     <main className="min-h-screen pt-24">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(content.faqStructuredData) }}
+      />
       <section className="relative overflow-hidden py-20 md:py-24">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_12%,rgba(6,182,212,0.18),transparent_28%),radial-gradient(circle_at_82%_18%,rgba(249,115,22,0.15),transparent_24%)]" />
         <div className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
@@ -131,6 +155,48 @@ export default function UseCasePage({ content }: { content: UseCasePageContent }
           <div className="mt-8 rounded-[24px] border border-white/10 bg-white/[0.035] p-5 text-sm leading-7 text-slate-400">
             <BadgeCheck className="mb-3 h-5 w-5 text-primary-light" />
             {content.disclaimer}
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container-custom">
+          <div className="grid gap-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-start">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Compliance mapping</p>
+              <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
+                Translate the gateway into review language.
+              </h2>
+              <p className="mt-5 text-lg leading-8 text-slate-400">
+                These mappings are practical review prompts, not automatic compliance guarantees. They help buyers connect masking, routing, and evidence to the controls their industry already discusses.
+              </p>
+            </div>
+
+            <div className="grid gap-4">
+              {content.complianceMapping.map((item) => (
+                <div key={item.label} className="rounded-[24px] border border-white/10 bg-background-secondary p-5">
+                  <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#fdba74]">{item.label}</p>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">{item.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section bg-background-secondary">
+        <div className="container-custom">
+          <div className="mx-auto max-w-3xl text-center">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">FAQ</p>
+            <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">Questions buyers ask first</h2>
+          </div>
+          <div className="mx-auto mt-10 grid max-w-5xl gap-4">
+            {content.faq.map((item) => (
+              <article key={item.question} className="rounded-[24px] border border-white/10 bg-background/80 p-5 md:p-6">
+                <h3 className="font-heading text-xl font-semibold text-white">{item.question}</h3>
+                <p className="mt-3 text-sm leading-7 text-slate-400">{item.answer}</p>
+              </article>
+            ))}
           </div>
         </div>
       </section>

--- a/app/use-cases/content.ts
+++ b/app/use-cases/content.ts
@@ -1,5 +1,85 @@
-import { ClipboardCheck, HeartPulse, Landmark, LockKeyhole, Scale, ShieldCheck } from 'lucide-react'
+import {
+  BriefcaseBusiness,
+  ClipboardCheck,
+  FileSearch,
+  HeartPulse,
+  Landmark,
+  LockKeyhole,
+  Scale,
+  ShieldCheck,
+} from 'lucide-react'
 import type { UseCasePageContent } from './UseCasePage'
+
+type Faq = UseCasePageContent['faq']
+
+function faqStructuredData(faq: Faq): UseCasePageContent['faqStructuredData'] {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faq.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  }
+}
+
+const financeFaq = [
+  {
+    question: 'How does NeutralAI protect financial AI workflows?',
+    answer:
+      'NeutralAI detects and masks customer identifiers, payment details, account references, and claim context before prompts are routed to external AI providers.',
+  },
+  {
+    question: 'Does NeutralAI make an FCA or PRA approval claim?',
+    answer:
+      'No. NeutralAI provides a gateway boundary, masking policy, and audit evidence that can support financial services review conversations, but it does not guarantee regulatory approval.',
+  },
+  {
+    question: 'Can financial teams keep enough context for useful AI output?',
+    answer:
+      'Yes. The gateway can replace sensitive values with placeholders or governed tokens while preserving the surrounding business context needed for summaries, triage, and review.',
+  },
+]
+
+const healthcareFaq = [
+  {
+    question: 'How does NeutralAI handle healthcare AI prompts?',
+    answer:
+      'NeutralAI can mask PHI-style identifiers such as patient names, contact details, NHS numbers, medical record references, member IDs, and device identifiers before AI processing.',
+  },
+  {
+    question: 'Is NeutralAI making a blanket HIPAA compliance claim?',
+    answer:
+      'No. Healthcare deployments depend on the customer workflow, deployment model, contractual terms, and BAA review. This page describes PHI-aware controls without presenting legal advice.',
+  },
+  {
+    question: 'What healthcare workflows are a good fit?',
+    answer:
+      'Clinical note summarization, patient support triage, operational ticket analysis, and internal assistant workflows are common starting points when they mix useful context with patient identifiers.',
+  },
+]
+
+const legalFaq = [
+  {
+    question: 'How does NeutralAI support legal document review AI?',
+    answer:
+      'NeutralAI masks client names, matter references, contact details, and privileged context indicators before prompts or document excerpts are sent to AI providers.',
+  },
+  {
+    question: 'Does NeutralAI guarantee privilege protection?',
+    answer:
+      'No. NeutralAI is a technical control that can reduce exposure and produce audit evidence, but privilege, confidentiality, and professional duties require legal and operational review.',
+  },
+  {
+    question: 'Which legal workflows can start with a gateway pattern?',
+    answer:
+      'Contract review, matter summarization, discovery triage, client support drafting, and internal knowledge workflows are practical candidates for controlled AI adoption.',
+  },
+]
 
 export const financeUseCase: UseCasePageContent = {
   eyebrow: 'Finance use case',
@@ -9,7 +89,7 @@ export const financeUseCase: UseCasePageContent = {
   primaryCta: 'See financial AI protection',
   secondaryCta: 'Try a masking demo',
   proofLabel: 'Regulated workflow',
-  proofTitle: 'Built for teams facing FCA, PRA, and GDPR review pressure.',
+  proofTitle: 'Built for teams facing FCA, PRA, PCI-DSS, and GDPR review pressure.',
   proofBody:
     'The value is not a generic detector. NeutralAI gives security and compliance reviewers a gateway boundary, policy controls, and audit evidence for AI-assisted workflows.',
   painPoints: [
@@ -32,6 +112,22 @@ export const financeUseCase: UseCasePageContent = {
     },
   ],
   entities: ['PERSON', 'EMAIL', 'PHONE', 'IBAN', 'CREDIT_CARD', 'POLICY_ID', 'CLAIM_REF'],
+  complianceMapping: [
+    {
+      label: 'FCA and PRA review',
+      body: 'Show where AI prompt traffic is controlled, which values are masked, and what audit-safe metadata proves the control ran.',
+    },
+    {
+      label: 'PCI-DSS scoping',
+      body: 'Reduce unnecessary exposure of card-like values and payment details before staff or product workflows use AI assistance.',
+    },
+    {
+      label: 'GDPR data minimisation',
+      body: 'Route only the information needed for the AI task while masking direct identifiers before provider egress.',
+    },
+  ],
+  faq: financeFaq,
+  faqStructuredData: faqStructuredData(financeFaq),
   trustSignals: [
     {
       icon: Landmark,
@@ -50,7 +146,7 @@ export const financeUseCase: UseCasePageContent = {
     },
   ],
   disclaimer:
-    'NeutralAI supports regulated AI adoption workflows, but this page is not legal advice and does not claim automatic FCA, PRA, or GDPR approval for any customer deployment.',
+    'NeutralAI supports regulated AI adoption workflows, but this page is not legal advice and does not claim automatic FCA, PRA, PCI-DSS, or GDPR approval for any customer deployment.',
 }
 
 export const healthcareUseCase: UseCasePageContent = {
@@ -84,6 +180,22 @@ export const healthcareUseCase: UseCasePageContent = {
     },
   ],
   entities: ['PERSON', 'EMAIL', 'PHONE', 'UK_NHS', 'MRN', 'HEALTH_PLAN_ID', 'DEVICE_UDI', 'DATE_TIME'],
+  complianceMapping: [
+    {
+      label: 'HIPAA review support',
+      body: 'Support BAA and security review conversations with PHI-aware masking, deployment-model discussion, and evidence that avoids raw patient identifiers.',
+    },
+    {
+      label: 'Minimum necessary',
+      body: 'Keep the useful clinical or operational prompt context while removing direct identifiers before model routing.',
+    },
+    {
+      label: 'Operational audit',
+      body: 'Record policy events and findings in a way that helps review teams without turning reports into another PHI store.',
+    },
+  ],
+  faq: healthcareFaq,
+  faqStructuredData: faqStructuredData(healthcareFaq),
   trustSignals: [
     {
       icon: HeartPulse,
@@ -104,3 +216,92 @@ export const healthcareUseCase: UseCasePageContent = {
   disclaimer:
     'NeutralAI is not presenting this page as legal advice or a blanket HIPAA compliance claim. BAA terms, deployment model, and customer obligations require review.',
 }
+
+export const legalUseCase: UseCasePageContent = {
+  eyebrow: 'Legal use case',
+  title: 'Use AI for legal work without exposing client or matter data.',
+  description:
+    'NeutralAI helps legal teams mask client names, matter identifiers, contact details, privileged context, and document-review excerpts before prompts reach AI providers.',
+  primaryCta: 'Discuss legal AI controls',
+  secondaryCta: 'Try a legal masking demo',
+  proofLabel: 'Matter confidentiality',
+  proofTitle: 'Designed for client privilege, document review AI, and matter confidentiality conversations.',
+  proofBody:
+    'Legal buyers need a practical boundary before document review, drafting, and matter-summary prompts leave approved workflows. NeutralAI gives teams a place to mask identifiers and preserve evidence for review.',
+  painPoints: [
+    'Contract, discovery, and matter summaries can include client names, counterparties, case facts, and privileged context.',
+    'Fee earners and operations teams may test AI tools before information governance has approved a safe path.',
+    'Risk reviewers need proof of prompt controls without copying confidential matter data into reports.',
+  ],
+  workflow: [
+    {
+      title: 'Detect client and matter signals',
+      body: 'Find names, email addresses, phone numbers, matter IDs, document references, and privilege-sensitive context before AI egress.',
+    },
+    {
+      title: 'Mask excerpts before model routing',
+      body: 'Send sanitized contract, discovery, or support text onward while preserving the legal task and separating raw values from model traffic.',
+    },
+    {
+      title: 'Evidence the approved route',
+      body: 'Use audit-safe metadata and masked examples to support information governance, procurement, and client assurance conversations.',
+    },
+  ],
+  entities: ['PERSON', 'EMAIL', 'PHONE', 'CLIENT_NAME', 'MATTER_ID', 'DOCUMENT_ID', 'PRIVILEGED_CONTEXT'],
+  complianceMapping: [
+    {
+      label: 'Client confidentiality',
+      body: 'Reduce exposure of client and matter identifiers before legal teams use AI for drafting, review, or summarization.',
+    },
+    {
+      label: 'Privilege review',
+      body: 'Create a technical checkpoint that supports privilege-aware workflows without claiming the tool decides legal privilege.',
+    },
+    {
+      label: 'Information governance',
+      body: 'Give risk, procurement, and client-facing teams evidence that approved AI paths run through masking and policy controls.',
+    },
+  ],
+  faq: legalFaq,
+  faqStructuredData: faqStructuredData(legalFaq),
+  trustSignals: [
+    {
+      icon: Scale,
+      title: 'Legal-specific workflows',
+      body: 'NeutralAI frames AI use around contract review, discovery triage, matter summaries, and client-support drafting.',
+    },
+    {
+      icon: FileSearch,
+      title: 'Document review boundary',
+      body: 'Sensitive excerpts can be masked before they leave approved document or browser workflows for model processing.',
+    },
+    {
+      icon: BriefcaseBusiness,
+      title: 'Client assurance posture',
+      body: 'Audit-safe evidence helps firms explain the control boundary without publishing raw matter details.',
+    },
+  ],
+  disclaimer:
+    'NeutralAI is not legal advice and does not guarantee privilege protection. Client confidentiality, professional duties, and deployment terms require legal and operational review.',
+}
+
+export const useCases = [
+  {
+    title: 'Financial services',
+    href: '/use-cases/financial-services',
+    summary: 'Mask customer, payment, account, and claim identifiers before AI prompt egress.',
+    content: financeUseCase,
+  },
+  {
+    title: 'Healthcare',
+    href: '/use-cases/healthcare',
+    summary: 'Protect PHI-style identifiers before clinical, support, or operational prompts reach AI providers.',
+    content: healthcareUseCase,
+  },
+  {
+    title: 'Legal',
+    href: '/use-cases/legal',
+    summary: 'Keep client, matter, and document-review context under a controlled AI gateway path.',
+    content: legalUseCase,
+  },
+] as const

--- a/app/use-cases/finance/page.tsx
+++ b/app/use-cases/finance/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from 'next/navigation'
+import { permanentRedirect } from 'next/navigation'
 
 export default function FinanceUseCaseRedirect() {
-  redirect('/use-cases/financial-services')
+  permanentRedirect('/use-cases/financial-services')
 }

--- a/app/use-cases/finance/page.tsx
+++ b/app/use-cases/finance/page.tsx
@@ -1,23 +1,5 @@
-import type { Metadata } from 'next'
-import UseCasePage from '../UseCasePage'
-import { financeUseCase } from '../content'
-import { siteConfig } from '../../site'
+import { redirect } from 'next/navigation'
 
-export const metadata: Metadata = {
-  title: 'AI Data Protection for Financial Services',
-  description:
-    'See how NeutralAI helps financial services teams mask IBANs, card data, customer names, and claim references before AI prompts reach model providers.',
-  alternates: {
-    canonical: '/use-cases/finance',
-  },
-  openGraph: {
-    title: 'AI Data Protection for Financial Services',
-    description:
-      'Mask customer and payment identifiers before financial services prompts reach external AI providers.',
-    url: `${siteConfig.url}/use-cases/finance`,
-  },
-}
-
-export default function FinanceUseCasePage() {
-  return <UseCasePage content={financeUseCase} />
+export default function FinanceUseCaseRedirect() {
+  redirect('/use-cases/financial-services')
 }

--- a/app/use-cases/financial-services/page.tsx
+++ b/app/use-cases/financial-services/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import UseCasePage from '../UseCasePage'
+import { financeUseCase } from '../content'
+import { siteConfig } from '../../site'
+
+export const metadata: Metadata = {
+  title: 'AI Data Protection for Financial Services',
+  description:
+    'See how NeutralAI helps financial services teams mask IBANs, card data, customer names, and claim references before AI prompts reach model providers.',
+  alternates: {
+    canonical: '/use-cases/financial-services',
+  },
+  openGraph: {
+    title: 'AI Data Protection for Financial Services',
+    description:
+      'Mask customer and payment identifiers before financial services prompts reach external AI providers.',
+    url: `${siteConfig.url}/use-cases/financial-services`,
+  },
+}
+
+export default function FinancialServicesUseCasePage() {
+  return <UseCasePage content={financeUseCase} />
+}

--- a/app/use-cases/legal/page.tsx
+++ b/app/use-cases/legal/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import UseCasePage from '../UseCasePage'
+import { legalUseCase } from '../content'
+import { siteConfig } from '../../site'
+
+export const metadata: Metadata = {
+  title: 'AI Data Protection for Legal Teams',
+  description:
+    'See how NeutralAI helps legal teams mask client names, matter IDs, privileged context, and document review excerpts before AI prompts reach model providers.',
+  alternates: {
+    canonical: '/use-cases/legal',
+  },
+  openGraph: {
+    title: 'AI Data Protection for Legal Teams',
+    description:
+      'Mask client, matter, and privileged context before legal AI workflows reach external model providers.',
+    url: `${siteConfig.url}/use-cases/legal`,
+  },
+}
+
+export default function LegalUseCasePage() {
+  return <UseCasePage content={legalUseCase} />
+}

--- a/app/use-cases/page.tsx
+++ b/app/use-cases/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, ShieldCheck } from 'lucide-react'
+import { siteConfig } from '../site'
+import { useCases } from './content'
+
+export const metadata: Metadata = {
+  title: 'AI Use Cases for Regulated Teams',
+  description:
+    'Explore NeutralAI use cases for financial services, healthcare, and legal teams protecting sensitive data before AI prompt egress.',
+  alternates: {
+    canonical: '/use-cases',
+  },
+  openGraph: {
+    title: 'AI Use Cases for Regulated Teams',
+    description:
+      'Industry pages for financial services, healthcare, and legal teams adopting AI with PII masking and audit evidence.',
+    url: `${siteConfig.url}/use-cases`,
+  },
+}
+
+export default function UseCasesIndexPage() {
+  return (
+    <main className="min-h-screen pt-24">
+      <section className="relative overflow-hidden py-20 md:py-24">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_12%,rgba(6,182,212,0.18),transparent_28%),radial-gradient(circle_at_82%_18%,rgba(249,115,22,0.15),transparent_24%)]" />
+        <div className="container-custom relative z-10">
+          <div className="max-w-4xl">
+            <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              Industries
+            </div>
+            <h1 className="mt-5 font-heading text-5xl font-bold md:text-7xl">
+              AI use cases for regulated teams.
+            </h1>
+            <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
+              NeutralAI gives finance, healthcare, and legal teams a practical gateway pattern for masking sensitive data before AI prompts reach external model providers.
+            </p>
+          </div>
+
+          <div className="mt-12 grid gap-4 lg:grid-cols-3">
+            {useCases.map((useCase) => (
+              <Link
+                key={useCase.href}
+                href={useCase.href}
+                className="group rounded-[28px] border border-white/10 bg-background-secondary p-6 transition hover:border-primary/40 hover:bg-white/[0.04]"
+              >
+                <p className="font-mono text-xs uppercase tracking-[0.22em] text-[#fdba74]">{useCase.title}</p>
+                <h2 className="mt-4 font-heading text-2xl font-semibold text-white">{useCase.content.title}</h2>
+                <p className="mt-4 text-sm leading-7 text-slate-400">{useCase.summary}</p>
+                <span className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-primary-light">
+                  View use case
+                  <ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/content/blog/from-presidio-to-production-regulated-teams.mdx
+++ b/content/blog/from-presidio-to-production-regulated-teams.mdx
@@ -58,3 +58,5 @@ These questions are often more important than the first demo.
 NeutralAI builds on the idea that detection should be part of a larger control layer. The product focuses on masking sensitive prompt data before model egress, producing audit-ready proof, and giving regulated teams a path from browser adoption to governed rollout.
 
 For a deeper comparison, see the [Presidio alternative page](/presidio-alternative) and Microsoft’s [Presidio documentation](https://microsoft.github.io/presidio/).
+
+Legal teams evaluating document review workflows can also read the [legal AI data protection](/use-cases/legal) use case.

--- a/content/blog/how-uk-financial-services-teams-use-ai-safely-under-fca-guidance.mdx
+++ b/content/blog/how-uk-financial-services-teams-use-ai-safely-under-fca-guidance.mdx
@@ -66,3 +66,5 @@ A control point gives security and compliance teams a place to enforce policy, m
 Start with the FCA’s pages on [AI in financial services](https://www.fca.org.uk/firms/ai-financial-services) and its [AI update](https://www.fca.org.uk/publications/corporate-documents/artificial-intelligence-ai-update-further-governments-response-ai-white-paper). Then map your highest-risk prompt paths and decide where masking, tokenization, and audit evidence should sit.
 
 NeutralAI is designed for that boundary: the point before sensitive prompt data leaves approved workflows.
+
+For a finance-specific walkthrough, see the [financial services AI data protection](/use-cases/financial-services) use case.

--- a/content/blog/why-pii-masking-matters-for-enterprise-ai-adoption.mdx
+++ b/content/blog/why-pii-masking-matters-for-enterprise-ai-adoption.mdx
@@ -68,3 +68,5 @@ Start with masking, measure where false positives or missed entities appear, and
 The goal is to make AI adoption easier to approve. When security teams can see the control boundary, review evidence, and understand what data is masked, they can move from blanket objections to governed rollout.
 
 PII masking is not the whole AI governance program, but it is one of the first controls that makes enterprise AI adoption practical.
+
+Healthcare teams can see the industry-specific version in the [healthcare AI data protection](/use-cases/healthcare) use case.

--- a/tests/content/use-cases.test.mjs
+++ b/tests/content/use-cases.test.mjs
@@ -9,24 +9,36 @@ function readSource(path) {
   return readFileSync(join(root, path), 'utf8')
 }
 
-test('vertical use-case pages exist for finance and healthcare', () => {
-  const finance = readSource('app/use-cases/finance/page.tsx')
+test('vertical use-case pages exist for finance, healthcare, and legal', () => {
+  const index = readSource('app/use-cases/page.tsx')
+  const finance = readSource('app/use-cases/financial-services/page.tsx')
   const healthcare = readSource('app/use-cases/healthcare/page.tsx')
+  const legal = readSource('app/use-cases/legal/page.tsx')
   const content = readSource('app/use-cases/content.ts')
+  const indexSurface = `${index}\n${content}`
 
+  assert.match(index, /AI use cases for regulated teams/)
+  assert.match(indexSurface, /\/use-cases\/financial-services/)
+  assert.match(indexSurface, /\/use-cases\/healthcare/)
+  assert.match(indexSurface, /\/use-cases\/legal/)
   assert.match(finance, /AI Data Protection for Financial Services/)
-  assert.match(finance, /canonical: '\/use-cases\/finance'/)
+  assert.match(finance, /canonical: '\/use-cases\/financial-services'/)
   assert.match(healthcare, /PHI-Aware AI Data Protection for Healthcare/)
   assert.match(healthcare, /canonical: '\/use-cases\/healthcare'/)
+  assert.match(legal, /AI Data Protection for Legal Teams/)
+  assert.match(legal, /canonical: '\/use-cases\/legal'/)
   assert.match(content, /IBAN/)
   assert.match(content, /CREDIT_CARD/)
   assert.match(content, /UK_NHS/)
   assert.match(content, /MRN/)
   assert.match(content, /HEALTH_PLAN_ID/)
   assert.match(content, /DEVICE_UDI/)
+  assert.match(content, /MATTER_ID/)
+  assert.match(content, /CLIENT_NAME/)
+  assert.match(content, /PRIVILEGED_CONTEXT/)
 })
 
-test('healthcare copy avoids blanket HIPAA claims while supporting BAA review language', () => {
+test('vertical copy avoids blanket compliance claims while supporting review language', () => {
   const content = readSource('app/use-cases/content.ts')
 
   assert.match(content, /PHI-aware masking/)
@@ -35,16 +47,23 @@ test('healthcare copy avoids blanket HIPAA claims while supporting BAA review la
   assert.match(content, /device or UDI-style identifiers/)
   assert.match(content, /evidence pack materials under review\/NDA/)
   assert.match(content, /not presenting this page as legal advice or a blanket HIPAA compliance claim/)
+  assert.match(content, /client privilege/)
+  assert.match(content, /matter confidentiality/)
+  assert.match(content, /legal advice and does not guarantee privilege protection/)
   assert.doesNotMatch(content, /is HIPAA compliant/)
+  assert.doesNotMatch(content, /HIPAA-compliant AI gateway/)
   assert.doesNotMatch(content, /BAA included/)
+  assert.doesNotMatch(content, /guarantees privilege/)
 })
 
-test('use-case routes are discoverable from navigation, footer, and sitemap', () => {
+test('use-case routes are discoverable from homepage, navigation, footer, and sitemap', () => {
+  const homepage = readSource('app/components/home/UseCasesSection.tsx')
   const navbar = readSource('app/components/Navbar.tsx')
   const footer = readSource('app/components/Footer.tsx')
   const sitemap = readSource('app/sitemap.ts')
 
-  for (const route of ["'/use-cases/finance'", "'/use-cases/healthcare'"]) {
+  for (const route of ["'/use-cases'", "'/use-cases/financial-services'", "'/use-cases/healthcare'", "'/use-cases/legal'"]) {
+    assert.ok(homepage.includes(route))
     assert.ok(navbar.includes(route))
     assert.ok(footer.includes(route))
     assert.ok(sitemap.includes(route))
@@ -53,4 +72,29 @@ test('use-case routes are discoverable from navigation, footer, and sitemap', ()
   assert.match(navbar, /Use Cases/)
   assert.match(footer, /Finance Use Case/)
   assert.match(footer, /Healthcare Use Case/)
+  assert.match(footer, /Legal Use Case/)
+  assert.match(homepage, /Industries/)
+})
+
+test('use-case pages publish FAQ structured data for industry SEO', () => {
+  const component = readSource('app/use-cases/UseCasePage.tsx')
+  const content = readSource('app/use-cases/content.ts')
+
+  assert.match(component, /type="application\/ld\+json"/)
+  assert.match(component, /JSON\.stringify\(content\.faqStructuredData\)/)
+  assert.match(content, /'@type': 'FAQPage'/)
+  assert.match(content, /mainEntity: faq\.map/)
+  assert.match(content, /financial AI workflows/)
+  assert.match(content, /healthcare AI prompts/)
+  assert.match(content, /legal document review AI/)
+})
+
+test('blog articles link to relevant use-case pages', () => {
+  const financeArticle = readSource('content/blog/how-uk-financial-services-teams-use-ai-safely-under-fca-guidance.mdx')
+  const piiArticle = readSource('content/blog/why-pii-masking-matters-for-enterprise-ai-adoption.mdx')
+  const presidioArticle = readSource('content/blog/from-presidio-to-production-regulated-teams.mdx')
+
+  assert.match(financeArticle, /\[financial services AI data protection\]\(\/use-cases\/financial-services\)/)
+  assert.match(piiArticle, /\[healthcare AI data protection\]\(\/use-cases\/healthcare\)/)
+  assert.match(presidioArticle, /\[legal AI data protection\]\(\/use-cases\/legal\)/)
 })


### PR DESCRIPTION
## Problem

Closes #46. The site had partial finance/healthcare use-case coverage, but WEB-108 also needs a use-case index, legal vertical coverage, FAQ schema, homepage/navigation discovery, and blog cross-links for industry SEO and sales enablement.

## What Changed

- Added `/use-cases`, `/use-cases/financial-services`, and `/use-cases/legal`, with `/use-cases/finance` preserved as a redirect.
- Expanded shared use-case content with compliance mapping, FAQ content, FAQPage structured data, and conservative industry-specific disclaimers.
- Added a homepage Industries section plus nav, footer, sitemap, and blog internal links.
- Fixed Lighthouse accessibility findings for the mobile nav button, CTA contrast, and footer heading order.
- Expanded content tests for WEB-108 route, schema, discovery, and claim-safety coverage.

## Validation

- [x] `node --test tests/content/use-cases.test.mjs`
- [x] `npm run test:content`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Playwright browser smoke at desktop/mobile widths for `/use-cases`, `/use-cases/financial-services`, and `/use-cases/legal`
- [x] Lighthouse accessibility/SEO: `/use-cases`, `/use-cases/financial-services`, `/use-cases/healthcare`, `/use-cases/legal` all scored 100/100 for both categories locally

## Risks / Follow-ups

- Assumption: `/use-cases/financial-services` should be the canonical finance URL because the ticket requested that path; `/use-cases/finance` remains as a redirect for compatibility.
- Industry copy stays conservative and does not claim automatic FCA, PRA, PCI-DSS, GDPR, HIPAA, BAA, or privilege compliance.