### PR TITLE
Fix static export-safe behavior for /use-cases/finance

### DIFF
--- a/app/use-cases/finance/page.tsx
+++ b/app/use-cases/finance/page.tsx
@@ -1,5 +1,40 @@
-import { permanentRedirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { siteConfig } from '../../site'
 
-export default function FinanceUseCaseRedirect() {
-  permanentRedirect('/use-cases/financial-services')
+export const metadata: Metadata = {
+  title: 'Finance use case moved',
+  description:
+    'The finance alias route has moved to the canonical financial services use-case page.',
+  alternates: {
+    canonical: '/use-cases/financial-services',
+  },
+  robots: {
+    index: false,
+    follow: true,
+  },
+  openGraph: {
+    title: 'AI Data Protection for Financial Services',
+    description:
+      'Mask customer and payment identifiers before financial services prompts reach external AI providers.',
+    url: `${siteConfig.url}/use-cases/financial-services`,
+  },
+}
+
+export default function FinanceUseCaseAliasPage() {
+  return (
+    <section className="mx-auto flex min-h-[60vh] max-w-2xl flex-col items-start justify-center gap-4 px-6 py-20 text-slate-100">
+      <p className="text-sm font-semibold uppercase tracking-[0.24em] text-cyan-300">Route updated</p>
+      <h1 className="text-3xl font-semibold leading-tight text-balance md:text-4xl">This page has moved</h1>
+      <p className="max-w-prose text-base leading-relaxed text-slate-200">
+        The finance use-case route now lives at{' '}
+        <a className="font-semibold text-cyan-300 underline decoration-cyan-400/60 underline-offset-4" href="/use-cases/financial-services">
+          /use-cases/financial-services
+        </a>
+        .
+      </p>
+      <a className="btn btn-primary px-6 py-3 text-sm font-semibold" href="/use-cases/financial-services">
+        Go to Financial Services Use Case
+      </a>
+    </section>
+  )
 }

--- a/docs/ai/OPEN_QUESTIONS.md
+++ b/docs/ai/OPEN_QUESTIONS.md
@@ -21,6 +21,7 @@ Use this file for unknowns. Do not guess silently.
 ## Architecture / Deployment
 
 - Is the website deployed as a static export from `out/`, as a Next server app, or through another platform?
+- Assumption: Until hosting-level redirect support is confirmed, `/use-cases/finance` is implemented as a static fallback alias page that canonicalizes to `/use-cases/financial-services` instead of using App Router runtime redirects.
 - Should generated `out/` assets be committed or treated as build output only?
 - Should Playwright artifacts be ignored/cleaned, or are they used as review evidence?
 

--- a/tests/content/use-cases.test.mjs
+++ b/tests/content/use-cases.test.mjs
@@ -38,6 +38,15 @@ test('vertical use-case pages exist for finance, healthcare, and legal', () => {
   assert.match(content, /PRIVILEGED_CONTEXT/)
 })
 
+test('legacy finance alias is static-export safe and points to canonical route', () => {
+  const alias = readSource('app/use-cases/finance/page.tsx')
+
+  assert.doesNotMatch(alias, /permanentRedirect/)
+  assert.match(alias, /canonical: '\/use-cases\/financial-services'/)
+  assert.match(alias, /robots:\s*{\s*index:\s*false,\s*follow:\s*true,?\s*}/)
+  assert.match(alias, /Go to Financial Services Use Case/)
+})
+
 test('vertical copy avoids blanket compliance claims while supporting review language', () => {
   const content = readSource('app/use-cases/content.ts')
 


### PR DESCRIPTION
## Problem

`/use-cases/finance` used an App Router runtime `permanentRedirect`, which exported to a Next redirect/error payload under static export instead of a reliable static experience.

## What Changed

- Replaced runtime redirect page with a static fallback alias page at `/use-cases/finance`.
- Added canonical + `noindex, follow` metadata and a clear CTA link to `/use-cases/financial-services`.
- Added content test coverage to prevent regressions back to runtime redirect usage.
- Documented deployment assumption in `docs/ai/OPEN_QUESTIONS.md`.

## Validation

- [x] `npm run test:content`
- [x] `npm run build`
- [x] Manually inspected `out/use-cases/finance/index.html` for canonical/noindex and removal of redirect error payload behavior.

## Risks / Follow-ups

- Hosting-level 308 redirect behavior is still not confirmed. If infra confirms support, we may replace the static fallback with a host-managed redirect.

Closes #64
