### PR TITLE
Remove duplicate main landmarks across routes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -144,9 +144,9 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
         />
         <Navbar />
-        <main className="min-h-screen">
+        <div className="min-h-screen">
           {children}
-        </main>
+        </div>
         <Footer />
         <Suspense fallback={null}>
           <AnalyticsProvider />

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+
+export default function NotFoundPage() {
+  return (
+    <main className="min-h-screen pt-24">
+      <section className="container-custom py-20 md:py-24">
+        <div className="mx-auto max-w-2xl rounded-[28px] border border-white/10 bg-background-secondary/70 p-8 text-center md:p-10">
+          <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">404</p>
+          <h1 className="mt-4 font-heading text-4xl font-bold md:text-5xl">Page not found</h1>
+          <p className="mt-4 text-base leading-7 text-slate-300">
+            The page you requested is unavailable or has moved. You can continue from the homepage or
+            browse the use cases.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
+            <Link href="/" className="btn btn-cta px-8 py-4">
+              Go to Homepage
+            </Link>
+            <Link href="/use-cases" className="btn btn-secondary px-8 py-4">
+              Explore Use Cases
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/use-cases/finance/page.tsx
+++ b/app/use-cases/finance/page.tsx
@@ -22,19 +22,21 @@ export const metadata: Metadata = {
 
 export default function FinanceUseCaseAliasPage() {
   return (
-    <section className="mx-auto flex min-h-[60vh] max-w-2xl flex-col items-start justify-center gap-4 px-6 py-20 text-slate-100">
-      <p className="text-sm font-semibold uppercase tracking-[0.24em] text-cyan-300">Route updated</p>
-      <h1 className="text-3xl font-semibold leading-tight text-balance md:text-4xl">This page has moved</h1>
-      <p className="max-w-prose text-base leading-relaxed text-slate-200">
-        The finance use-case route now lives at{' '}
-        <a className="font-semibold text-cyan-300 underline decoration-cyan-400/60 underline-offset-4" href="/use-cases/financial-services">
-          /use-cases/financial-services
+    <main className="min-h-screen">
+      <section className="mx-auto flex min-h-[60vh] max-w-2xl flex-col items-start justify-center gap-4 px-6 py-20 text-slate-100">
+        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-cyan-300">Route updated</p>
+        <h1 className="text-3xl font-semibold leading-tight text-balance md:text-4xl">This page has moved</h1>
+        <p className="max-w-prose text-base leading-relaxed text-slate-200">
+          The finance use-case route now lives at{' '}
+          <a className="font-semibold text-cyan-300 underline decoration-cyan-400/60 underline-offset-4" href="/use-cases/financial-services">
+            /use-cases/financial-services
+          </a>
+          .
+        </p>
+        <a className="btn btn-primary px-6 py-3 text-sm font-semibold" href="/use-cases/financial-services">
+          Go to Financial Services Use Case
         </a>
-        .
-      </p>
-      <a className="btn btn-primary px-6 py-3 text-sm font-semibold" href="/use-cases/financial-services">
-        Go to Financial Services Use Case
-      </a>
-    </section>
+      </section>
+    </main>
   )
 }

--- a/tests/content/landmarks.test.mjs
+++ b/tests/content/landmarks.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const appDir = join(root, 'app')
+
+function listPageFiles(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true })
+  const pages = []
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      pages.push(...listPageFiles(fullPath))
+      continue
+    }
+
+    if (entry.isFile() && entry.name === 'page.tsx') {
+      pages.push(fullPath)
+    }
+  }
+
+  return pages
+}
+
+function countMainLandmarks(source) {
+  const matches = source.match(/<main(?:\s|>)/g)
+  return matches ? matches.length : 0
+}
+
+function delegatesToUseCasePage(source) {
+  return source.includes('<UseCasePage ')
+}
+
+test('root layout delegates main landmark ownership to routes', () => {
+  const source = readFileSync(join(root, 'app/layout.tsx'), 'utf8')
+  assert.equal(
+    countMainLandmarks(source),
+    0,
+    'app/layout.tsx should not render a <main> landmark',
+  )
+})
+
+test('shared use-case template owns a single main landmark', () => {
+  const source = readFileSync(join(root, 'app/use-cases/UseCasePage.tsx'), 'utf8')
+  assert.equal(countMainLandmarks(source), 1, 'UseCasePage should render one <main>')
+})
+
+test('each route page renders one main landmark directly or via shared template', () => {
+  const pageFiles = listPageFiles(appDir)
+  assert.ok(pageFiles.length > 0, 'expected at least one app route page')
+
+  for (const pageFile of pageFiles) {
+    const source = readFileSync(pageFile, 'utf8')
+    const count = countMainLandmarks(source)
+
+    if (count === 1) {
+      continue
+    }
+
+    assert.ok(
+      count === 0 && delegatesToUseCasePage(source),
+      `${pageFile.replace(`${root}/`, '')} should render one <main> directly or delegate to UseCasePage`,
+    )
+  }
+})

--- a/tests/content/landmarks.test.mjs
+++ b/tests/content/landmarks.test.mjs
@@ -48,6 +48,11 @@ test('shared use-case template owns a single main landmark', () => {
   assert.equal(countMainLandmarks(source), 1, 'UseCasePage should render one <main>')
 })
 
+test('custom not-found page owns a single main landmark', () => {
+  const source = readFileSync(join(root, 'app/not-found.tsx'), 'utf8')
+  assert.equal(countMainLandmarks(source), 1, 'app/not-found.tsx should render one <main>')
+})
+
 test('each route page renders one main landmark directly or via shared template', () => {
   const pageFiles = listPageFiles(appDir)
   assert.ok(pageFiles.length > 0, 'expected at least one app route page')


### PR DESCRIPTION
## Problem

Root layout wrapped every route with a `<main>` while route pages also rendered their own `<main>`, creating duplicate/nested main landmarks and weaker accessibility semantics.

Closes #66.

## What Changed

- Removed `<main>` from `app/layout.tsx` and kept visual behavior with a non-landmark `div.min-h-screen` wrapper.
- Added a route-level `<main className="min-h-screen">` wrapper to `app/use-cases/finance/page.tsx` so the alias page keeps a single main landmark after layout change.
- Added `tests/content/landmarks.test.mjs` to assert:
  - root layout does not own a `<main>` landmark,
  - shared `UseCasePage` owns exactly one `<main>`,
  - each route page renders one `<main>` directly or delegates via `UseCasePage`.

## Validation

- [x] `npm run lint`
- [x] `npm run test:content`
- [x] `npm run build`
- [x] Manual landmark smoke with local dev server:
  - homepage `<main>` count: `1`
  - `/use-cases/financial-services` `<main>` count: `1`

## Risks / Follow-ups

- The landmark regression guard currently recognizes delegation through `UseCasePage`. If future routes delegate to a different shared template, the test should be extended deliberately.
