### PR TITLE
Close launch-readiness dependency ledger ownership gaps

### DIFF
--- a/docs/ai/LAUNCH_READINESS_LEDGER.md
+++ b/docs/ai/LAUNCH_READINESS_LEDGER.md
@@ -1,0 +1,31 @@
+# Launch Readiness Dependency Ledger
+
+This ledger tracks launch-critical dependencies so no blocker remains as unowned free text.
+
+Use this file for go/no-go readiness. Keep `docs/ai/OPEN_QUESTIONS.md` for non-launch unknowns.
+
+Assumption: Individual owner names and account emails stay in `docs/local/third-party-services.local.md`, while this file tracks owner roles and issue-level status.
+
+## Go/No-Go Rule
+
+- Public launch is `NO-GO` until every row marked `Pre-launch` is either `Closed` or has an approved exception with owner and date.
+- Rows marked `Post-launch` can remain open if the current website copy does not overclaim missing proof.
+
+## Dependencies
+
+| Dependency | Owner role | Tracking | Required for launch | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Pricing and catalog parity between website and live app/gateway | Product + Gateway Engineering | [#69](https://github.com/nazifsohtaoglu/neutralai-website/issues/69), [gateway#777](https://github.com/nazifsohtaoglu/neutralai-gateway/issues/777) | Pre-launch | Open (external dependency) | Website now reflects GBP packaging, but live gateway catalog still exposes older USD plan values. |
+| Public claims evidence and approval (GDPR, regulated sectors, retention/deployment claims) | Product Marketing + Compliance | [#73](https://github.com/nazifsohtaoglu/neutralai-website/issues/73) | Pre-launch | Open | Claim registry must map each public claim to verifiable evidence or remove claim language. |
+| HubSpot production forms, routing, and lead ownership | Revenue Operations + Growth Engineering | [#70](https://github.com/nazifsohtaoglu/neutralai-website/issues/70) | Pre-launch | Open | Portal/form IDs, routing, notifications, and ownership must be verified end-to-end in production. |
+| PostHog production dashboards and funnel ownership | Product Analytics | [#61](https://github.com/nazifsohtaoglu/neutralai-website/issues/61) | Pre-launch | Open | Dashboards, owners, and final URLs are required for launch reporting. |
+| Cross-CTA conversion funnel QA (signup/demo/contact/playground/extension) | Growth Engineering + QA | [#76](https://github.com/nazifsohtaoglu/neutralai-website/issues/76) | Pre-launch | Open | Prevents launch with broken or untracked conversion paths. |
+| Static hosting/export runbook ownership (redirects, headers, sitemap, output) | Platform/Infra | [#78](https://github.com/nazifsohtaoglu/neutralai-website/issues/78) | Pre-launch | Open | Deployment mode and operational ownership must be explicit for repeatable releases. |
+| Production dependency audit advisories | Engineering | [#79](https://github.com/nazifsohtaoglu/neutralai-website/issues/79) | Pre-launch | Open | Moderate advisory triage/resolution must be tracked before launch sign-off. |
+| Approved customer proof or anonymized case-study framework | Product Marketing | [#77](https://github.com/nazifsohtaoglu/neutralai-website/issues/77) | Post-launch | Open | Pre-launch copy should avoid unsupported social-proof claims until evidence is approved. |
+| SEO keyword source of truth and performance loop | Content + Growth | [#80](https://github.com/nazifsohtaoglu/neutralai-website/issues/80) | Post-launch | Open | Needed for ongoing content optimization, not a hard launch gate. |
+
+## Operating Notes
+
+- For service-account details (workspace links, named owners, registered emails), update `docs/local/third-party-services.local.md`.
+- If a dependency cannot be closed pre-launch, record an explicit exception with owner, rationale, and target date in the linked issue.

--- a/docs/ai/LAUNCH_READINESS_LEDGER.md
+++ b/docs/ai/LAUNCH_READINESS_LEDGER.md
@@ -4,7 +4,7 @@ This ledger tracks launch-critical dependencies so no blocker remains as unowned
 
 Use this file for go/no-go readiness. Keep `docs/ai/OPEN_QUESTIONS.md` for non-launch unknowns.
 
-Assumption: Individual owner names and account emails stay in `docs/local/third-party-services.local.md`, while this file tracks owner roles and issue-level status.
+Assumption: Individual owner names, account emails, and admin workspace URLs are maintained in an access-controlled private ops system outside this repository, while this file tracks owner roles and issue-level status.
 
 ## Go/No-Go Rule
 
@@ -19,6 +19,7 @@ Assumption: Individual owner names and account emails stay in `docs/local/third-
 | Public claims evidence and approval (GDPR, regulated sectors, retention/deployment claims) | Product Marketing + Compliance | [#73](https://github.com/nazifsohtaoglu/neutralai-website/issues/73) | Pre-launch | Open | Claim registry must map each public claim to verifiable evidence or remove claim language. |
 | HubSpot production forms, routing, and lead ownership | Revenue Operations + Growth Engineering | [#70](https://github.com/nazifsohtaoglu/neutralai-website/issues/70) | Pre-launch | Open | Portal/form IDs, routing, notifications, and ownership must be verified end-to-end in production. |
 | PostHog production dashboards and funnel ownership | Product Analytics | [#61](https://github.com/nazifsohtaoglu/neutralai-website/issues/61) | Pre-launch | Open | Dashboards, owners, and final URLs are required for launch reporting. |
+| Plausible production ownership decision (active ownership vs formal retirement) | Product Analytics + Growth Engineering | [#87](https://github.com/nazifsohtaoglu/neutralai-website/issues/87) | Pre-launch | Open | Launch docs and runtime wiring still reference Plausible; this must be owned or explicitly retired before go-live sign-off. |
 | Cross-CTA conversion funnel QA (signup/demo/contact/playground/extension) | Growth Engineering + QA | [#76](https://github.com/nazifsohtaoglu/neutralai-website/issues/76) | Pre-launch | Open | Prevents launch with broken or untracked conversion paths. |
 | Static hosting/export runbook ownership (redirects, headers, sitemap, output) | Platform/Infra | [#78](https://github.com/nazifsohtaoglu/neutralai-website/issues/78) | Pre-launch | Open | Deployment mode and operational ownership must be explicit for repeatable releases. |
 | Production dependency audit advisories | Engineering | [#79](https://github.com/nazifsohtaoglu/neutralai-website/issues/79) | Pre-launch | Open | Moderate advisory triage/resolution must be tracked before launch sign-off. |
@@ -27,5 +28,6 @@ Assumption: Individual owner names and account emails stay in `docs/local/third-
 
 ## Operating Notes
 
-- For service-account details (workspace links, named owners, registered emails), update `docs/local/third-party-services.local.md`.
+- Do not store service-account emails, private admin links, or owner contact details in repository-tracked files.
+- Keep sensitive operator/account metadata in an approved private system (password manager, private ops docs, or equivalent access-controlled store).
 - If a dependency cannot be closed pre-launch, record an explicit exception with owner, rationale, and target date in the linked issue.

--- a/docs/ai/OPEN_QUESTIONS.md
+++ b/docs/ai/OPEN_QUESTIONS.md
@@ -2,21 +2,18 @@
 
 Use this file for unknowns. Do not guess silently.
 
+## Launch Readiness Dependencies
+
+- Launch blockers are tracked in `docs/ai/LAUNCH_READINESS_LEDGER.md`.
+- Rule: do not leave launch-critical blockers as unowned free-text questions in this file.
+
 ## Product / Marketing
 
 - What is the canonical primary CTA: trial, demo, contact, waitlist, or install extension?
 - What exact `src` value should website signup handoffs use for homepage "Try Free" CTAs: `website_start_free_trial`, `website_try_free`, or another analytics-owned value?
-- WEB-02 website pricing now follows the user-confirmed GBP packaging direction (£0 Free, £29 Starter, £99 Team, £299 Business, Enterprise Custom) and separates masking requests from managed AI credits/BYOK. Gateway issue https://github.com/nazifsohtaoglu/neutralai-gateway/issues/777 tracks the required backend/catalog support; the live gateway public catalog and BUS-008 contract still expose USD/Pro/$499 until that is implemented.
-- Which claims are approved for public use around GDPR, UK regulated industries, zero retention, and on-prem deployment?
-- Are there real customers, pilots, certifications, or benchmarks that can be referenced publicly?
 - What is the preferred ICP for the website copy: legal, finance, healthcare, insurance, SaaS support, or broader regulated teams?
-- WEB-103 asks for at least 3 articles targeting keywords with search volume >100/mo, but this repo has no approved SEO data source or keyword-volume export. Which SEO tool/export should be treated as the canonical volume source?
+- WEB-103 content planning still needs an approved SEO data source for keyword-volume exports. Which SEO tool/export should be treated as the canonical source?
 - WEB-104 now has a local Playwright-generated demo video, captions, and poster. If marketing wants external hosting, what hosted URL should replace the local asset? Browser extension or admin dashboard footage still needs explicit approval before it is shown publicly.
-- WEB-105 needs approved real customer outcomes, testimonials, usage counts, or anonymized case-study evidence before the homepage should call anything a customer case study or show social-proof usage numbers.
-- WEB-106 needs the live HubSpot portal ID, region, form IDs, contact property names, notification workflow, confirmation email workflow, and Slack routing configured outside the repo before production leads can be verified end-to-end.
-- WEB-106 asks for HubSpot tracking script attribution, but global visitor tracking should wait for approved cookie consent/analytics ownership so the website does not add non-essential tracking before consent.
-- WEB-107 needs a confirmed Plausible workspace/domain, dashboard owner, and approved goal/funnel definitions before production analytics can be verified beyond the website consent-gated wiring.
-- WEB-61 needs the approved PostHog workspace/project, project region/host, dashboard owner, and final dashboard/funnel URLs before production analytics can be marked fully complete beyond consent-gated website wiring.
 - WEB-09 should switch the Developers SDK cards to public registry install commands only after the gateway BUS-012 SDK publication checks confirm `neutralai-sdk` and `neutralai-node-sdk` are live.
 
 ## Architecture / Deployment

--- a/docs/ai/PROJECT_MAP.md
+++ b/docs/ai/PROJECT_MAP.md
@@ -55,6 +55,7 @@ At the time this kit was installed, the target repo already had unrelated local 
 4. `docs/ai/FLOWS.md`
 5. `docs/ai/RISK_REGISTER.md`
 6. `docs/ai/TESTING_AND_COMMANDS.md`
+7. `docs/ai/LAUNCH_READINESS_LEDGER.md` for launch go/no-go dependencies
 
 ## Assumptions
 

--- a/tests/content/analytics.test.mjs
+++ b/tests/content/analytics.test.mjs
@@ -57,6 +57,7 @@ test('posthog dashboard and funnel setup is documented', () => {
   const analyticsDocs = readSource('docs/analytics-setup.md')
   const headersSource = readSource('public/_headers')
   const openQuestions = readSource('docs/ai/OPEN_QUESTIONS.md')
+  const launchLedger = readSource('docs/ai/LAUNCH_READINESS_LEDGER.md')
 
   assert.match(analyticsDocs, /PostHog Dashboard And Funnel Setup/)
   assert.match(analyticsDocs, /Team dashboard:/)
@@ -66,7 +67,9 @@ test('posthog dashboard and funnel setup is documented', () => {
   assert.match(analyticsDocs, /no prompt content or form field values/)
   assert.match(headersSource, /https:\/\/us\.i\.posthog\.com/)
   assert.match(headersSource, /https:\/\/eu\.i\.posthog\.com/)
-  assert.match(openQuestions, /WEB-61 needs the approved PostHog workspace/)
+  assert.match(openQuestions, /Launch blockers are tracked in `docs\/ai\/LAUNCH_READINESS_LEDGER\.md`\./)
+  assert.match(launchLedger, /PostHog production dashboards and funnel ownership/)
+  assert.match(launchLedger, /\[#61\]\(https:\/\/github\.com\/nazifsohtaoglu\/neutralai-website\/issues\/61\)/)
 })
 
 test('utm attribution persists after consent and can enrich HubSpot leads', () => {
@@ -74,7 +77,7 @@ test('utm attribution persists after consent and can enrich HubSpot leads', () =
   const hubspotSource = readSource('app/components/HubSpotLeadForm.tsx')
   const analyticsDocs = readSource('docs/analytics-setup.md')
   const hubspotDocs = readSource('docs/hubspot-crm-setup.md')
-  const openQuestions = readSource('docs/ai/OPEN_QUESTIONS.md')
+  const launchLedger = readSource('docs/ai/LAUNCH_READINESS_LEDGER.md')
 
   for (const field of ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'referrer_host', 'landing_page_path']) {
     assert.match(analyticsSource, new RegExp(field))
@@ -88,5 +91,6 @@ test('utm attribution persists after consent and can enrich HubSpot leads', () =
   assert.match(analyticsSource, /stored\.landing_page_path/)
   assert.match(hubspotSource, /getLeadAttribution/)
   assert.match(hubspotSource, /Object\.entries\(getLeadAttribution\(\)\)/)
-  assert.match(openQuestions, /WEB-107 needs a confirmed Plausible workspace/)
+  assert.match(launchLedger, /HubSpot production forms, routing, and lead ownership/)
+  assert.match(launchLedger, /\[#70\]\(https:\/\/github\.com\/nazifsohtaoglu\/neutralai-website\/issues\/70\)/)
 })

--- a/tests/content/analytics.test.mjs
+++ b/tests/content/analytics.test.mjs
@@ -70,6 +70,8 @@ test('posthog dashboard and funnel setup is documented', () => {
   assert.match(openQuestions, /Launch blockers are tracked in `docs\/ai\/LAUNCH_READINESS_LEDGER\.md`\./)
   assert.match(launchLedger, /PostHog production dashboards and funnel ownership/)
   assert.match(launchLedger, /\[#61\]\(https:\/\/github\.com\/nazifsohtaoglu\/neutralai-website\/issues\/61\)/)
+  assert.match(launchLedger, /Plausible production ownership decision/)
+  assert.match(launchLedger, /\[#87\]\(https:\/\/github\.com\/nazifsohtaoglu\/neutralai-website\/issues\/87\)/)
 })
 
 test('utm attribution persists after consent and can enrich HubSpot leads', () => {


### PR DESCRIPTION
## Problem

`docs/ai/OPEN_QUESTIONS.md` had launch-critical blockers tracked as free-text unknowns without explicit owner roles, go/no-go status, or linked execution issues.

## What Changed

- Added `docs/ai/LAUNCH_READINESS_LEDGER.md` with owner-role, issue links, and pre-launch vs post-launch gate status for each launch dependency.
- Updated `docs/ai/OPEN_QUESTIONS.md` so launch blockers are tracked via the ledger instead of unowned free-text entries.
- Added the ledger to `docs/ai/PROJECT_MAP.md` fast reading order for launch go/no-go tasks.
- Updated `tests/content/analytics.test.mjs` to assert the new ledger-based tracking model.

## Validation

- [x] `npm run test:content`

## Risks / Follow-ups

- Named owners and account-level details still need to be filled in local operational tracker (`docs/local/third-party-services.local.md`).
- Pre-launch rows remain open until linked issues (#61, #69, #70, #73, #76, #78, #79) are closed or explicitly exception-approved.

Closes #68
