### PR TITLE
Define SEO keyword source and content performance loop

### DIFF
--- a/docs/ai/LAUNCH_READINESS_LEDGER.md
+++ b/docs/ai/LAUNCH_READINESS_LEDGER.md
@@ -24,7 +24,7 @@ Assumption: Individual owner names, account emails, and admin workspace URLs are
 | Static hosting/export runbook ownership (redirects, headers, sitemap, output) | Platform/Infra | [#78](https://github.com/nazifsohtaoglu/neutralai-website/issues/78) | Pre-launch | Open | Deployment mode and operational ownership must be explicit for repeatable releases. |
 | Production dependency audit advisories | Engineering | [#79](https://github.com/nazifsohtaoglu/neutralai-website/issues/79) | Pre-launch | Open | Moderate advisory triage/resolution must be tracked before launch sign-off. |
 | Approved customer proof or anonymized case-study framework | Product Marketing | [#77](https://github.com/nazifsohtaoglu/neutralai-website/issues/77) | Post-launch | Open | Pre-launch copy should avoid unsupported social-proof claims until evidence is approved. |
-| SEO keyword source of truth and performance loop | Content + Growth | [#80](https://github.com/nazifsohtaoglu/neutralai-website/issues/80) | Post-launch | Open | Needed for ongoing content optimization, not a hard launch gate. |
+| SEO keyword source of truth and performance loop | Content + Growth | [#80](https://github.com/nazifsohtaoglu/neutralai-website/issues/80) | Post-launch | Closed | Canonical source stack, keyword map, and review cadence are documented in `docs/seo-keyword-performance-loop.md`. |
 
 ## Operating Notes
 

--- a/docs/ai/OPEN_QUESTIONS.md
+++ b/docs/ai/OPEN_QUESTIONS.md
@@ -12,7 +12,6 @@ Use this file for unknowns. Do not guess silently.
 - What is the canonical primary CTA: trial, demo, contact, waitlist, or install extension?
 - What exact `src` value should website signup handoffs use for homepage "Try Free" CTAs: `website_start_free_trial`, `website_try_free`, or another analytics-owned value?
 - What is the preferred ICP for the website copy: legal, finance, healthcare, insurance, SaaS support, or broader regulated teams?
-- WEB-103 content planning still needs an approved SEO data source for keyword-volume exports. Which SEO tool/export should be treated as the canonical source?
 - WEB-104 now has a local Playwright-generated demo video, captions, and poster. If marketing wants external hosting, what hosted URL should replace the local asset? Browser extension or admin dashboard footage still needs explicit approval before it is shown publicly.
 - WEB-09 should switch the Developers SDK cards to public registry install commands only after the gateway BUS-012 SDK publication checks confirm `neutralai-sdk` and `neutralai-node-sdk` are live.
 

--- a/docs/ai/TICKET_WORKFLOW.md
+++ b/docs/ai/TICKET_WORKFLOW.md
@@ -43,6 +43,7 @@ For blog articles or content hub work:
 
 - Define the visual story before creating the image: audience, tension, product role, and desired emotional takeaway.
 - Write an art-direction prompt for each hero visual before generating or sourcing assets.
+- Include the keyword source reference (approved export/date) and buyer intent in the ticket before implementation starts.
 - Avoid generic diagrams, stock-photo filler, literal dashboards, and images that only repeat article text.
 - Prefer professional editorial scenes, metaphors, and product-motion storytelling that make NeutralAI's role clear without overclaiming capabilities.
 - Keep generated visuals free of readable text, customer logos, credentials, invented metrics, and unsupported compliance claims.

--- a/docs/seo-keyword-performance-loop.md
+++ b/docs/seo-keyword-performance-loop.md
@@ -1,0 +1,79 @@
+# SEO Keyword Source of Truth and Content Performance Loop
+
+Decision date: 2026-05-15  
+Decision owner role: Content + Growth
+
+This document defines the canonical SEO workflow for WEB-103 planning and for future blog/use-case tickets.
+
+## Canonical Sources
+
+1. Search demand source of truth: Google Ads Keyword Planner export (monthly search volume).
+2. Search performance source of truth: Google Search Console Performance export (queries, clicks, impressions, CTR, average position).
+3. Conversion source of truth: PostHog CTA and funnel dashboards defined in `docs/analytics-setup.md`.
+
+Assumption: Product Analytics and Growth maintain access to Google Ads Keyword Planner and Google Search Console in private ops systems.
+
+## Why This Source Stack
+
+- Keyword Planner provides standardized monthly search-demand inputs for pre-publication keyword selection.
+- Search Console provides real query and ranking outcomes after publication.
+- PostHog ties SEO traffic to conversion-intent behavior instead of measuring traffic alone.
+
+Using one tool alone is weak: search-volume-only planning misses on-page performance, and ranking-only reporting misses demand opportunity.
+
+## Required Data Contract
+
+Every tracked page must have one row in the SEO tracker with these fields:
+
+- `url_path`
+- `content_type` (`blog` or `use_case`)
+- `primary_keyword`
+- `secondary_keywords` (comma separated, optional)
+- `buyer_intent` (`problem-aware`, `solution-aware`, `vendor-comparison`, `implementation`)
+- `keyword_source_export_date` (date of the Keyword Planner export used)
+- `monthly_search_volume_band` (as provided by Keyword Planner export)
+- `search_console_snapshot_date`
+- `clicks_28d`
+- `impressions_28d`
+- `ctr_28d`
+- `avg_position_28d`
+- `primary_cta_target` (`signup`, `demo`, `enterprise`, `security-review`)
+- `next_review_date`
+- `owner_role`
+
+## Current Target Keyword Map
+
+| URL path | Primary keyword | Buyer intent | Review cadence |
+| --- | --- | --- | --- |
+| `/blog/why-pii-masking-matters-for-enterprise-ai-adoption` | pii masking for enterprise ai | problem-aware | Every 28 days |
+| `/blog/how-uk-financial-services-teams-use-ai-safely-under-fca-guidance` | ai governance financial services uk | implementation | Every 28 days |
+| `/blog/hidden-cost-of-shadow-ai-security-control-point` | shadow ai risk management | problem-aware | Every 28 days |
+| `/blog/pii-detection-accuracy-regex-vs-ner-vs-llm` | pii detection accuracy | solution-aware | Every 28 days |
+| `/blog/from-presidio-to-production-regulated-teams` | presidio alternative for production | vendor-comparison | Every 28 days |
+| `/blog/neutralai-vs-private-ai-vs-nightfall-pii-detection-benchmark-2026` | pii detection benchmark comparison | vendor-comparison | Every 28 days |
+| `/use-cases/legal` | legal ai data protection | implementation | Every 28 days |
+| `/use-cases/financial-services` | financial services ai data protection | implementation | Every 28 days |
+| `/use-cases/healthcare` | healthcare ai data protection | implementation | Every 28 days |
+| `/use-cases/insurance` | insurance ai data protection | implementation | Every 28 days |
+
+## Performance Review Loop
+
+1. Weekly (every Monday): export last 28 days from Search Console and refresh tracker metrics.
+2. Monthly (first business day): export latest Keyword Planner volumes for all primary keywords.
+3. Monthly review: flag pages that match any of:
+   - average position worse than 20 with impressions above 100/month
+   - CTR below 1.5% for non-branded queries
+   - conversion-intent CTA clicks below target baseline for that page cluster
+4. Refresh cycle: queue one content refresh ticket per flagged page cluster with a clear hypothesis.
+5. Post-refresh verification: compare 28-day and 56-day snapshots before and after refresh.
+
+## Ticket Requirements for Future Content Work
+
+For every new blog or use-case ticket:
+
+- include at least one target primary keyword from the approved Keyword Planner export
+- declare buyer intent in the ticket body
+- include success checks for Search Console and PostHog after publish
+- avoid unsupported claims or invented benchmark/customer evidence
+
+Tickets that do not include keyword source and buyer intent are not ready for implementation.

--- a/docs/seo-keyword-performance-loop.md
+++ b/docs/seo-keyword-performance-loop.md
@@ -54,7 +54,6 @@ Every tracked page must have one row in the SEO tracker with these fields:
 | `/use-cases/legal` | legal ai data protection | implementation | Every 28 days |
 | `/use-cases/financial-services` | financial services ai data protection | implementation | Every 28 days |
 | `/use-cases/healthcare` | healthcare ai data protection | implementation | Every 28 days |
-| `/use-cases/insurance` | insurance ai data protection | implementation | Every 28 days |
 
 ## Performance Review Loop
 


### PR DESCRIPTION
## Problem

WEB-103 content planning and SEO execution did not have a documented canonical keyword-volume source or a repeatable performance loop, which left issue #80 open.

## What Changed

- Added `docs/seo-keyword-performance-loop.md` with:
  - canonical source stack (Keyword Planner + Search Console + PostHog)
  - required data contract fields
  - current blog/use-case keyword + buyer intent mapping
  - weekly/monthly review cadence and refresh loop
- Removed the resolved SEO source-of-truth unknown from `docs/ai/OPEN_QUESTIONS.md`.
- Marked the SEO dependency as closed in `docs/ai/LAUNCH_READINESS_LEDGER.md` with a reference to the new doc.
- Updated `docs/ai/TICKET_WORKFLOW.md` to require keyword source reference and buyer intent for future blog/content tickets.

## Validation

- [x] `npm run test:content` (pass)
- [x] Docs consistency review across AI workflow files
- [ ] `./scripts/codex-security-pre-review.sh` (script is not present on `main` in this branch context)

## Risks / Follow-ups

- Assumption: Product Analytics + Growth maintain access to Keyword Planner and Search Console in private ops systems.
- Follow-up: Close issue #80 after owner confirms the first live tracker export is captured using this contract.

Closes #80
