### PR TITLE
Add visual smoke suite for responsive launch checks

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -74,7 +74,10 @@ export default function Navbar() {
   }, [])
 
   return (
-    <nav className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${scrolled ? 'glass py-3' : 'py-4'}`}>
+    <nav
+      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${scrolled ? 'glass py-3' : 'py-4'}`}
+      data-visual-smoke="navbar-root"
+    >
       <div className="mx-auto flex w-full max-w-[1760px] items-center justify-between gap-5 px-6 lg:px-8">
         <Link href="/" className="flex flex-shrink-0 items-center gap-2">
           <Image src="/logo-sm.webp" alt="NeutralAI" width={40} height={40} className="w-10 h-10 rounded-lg" priority />
@@ -121,10 +124,11 @@ export default function Navbar() {
       </div>
 
       {isOpen && (
-        <motion.div 
+        <motion.div
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
           className="xl:hidden absolute top-full left-0 right-0 max-h-[calc(100vh-72px)] overflow-y-auto glass border-t border-border p-4"
+          data-visual-smoke="mobile-nav-panel"
         >
           {primaryNavLinks.map((link) => (
             <Link 

--- a/app/components/home/Hero.tsx
+++ b/app/components/home/Hero.tsx
@@ -94,7 +94,7 @@ export default function Hero() {
             </div>
           </div>
 
-          <div className="lg:-mt-3 xl:-mt-4">
+          <div className="lg:-mt-3 xl:-mt-4" data-visual-smoke="home-primary-media">
             <ProductVisual />
             <div className="mt-4 hidden gap-3 lg:grid lg:grid-cols-3">
               {complianceProofs.map((proof) => (

--- a/docs/ai/TESTING_AND_COMMANDS.md
+++ b/docs/ai/TESTING_AND_COMMANDS.md
@@ -11,6 +11,7 @@ Run commands from the repo root. If a required tool is missing, first try the us
 | Production build | `npm run build` | repo root |
 | Start production server | `npm run start` | repo root |
 | Lint | `npm run lint` | repo root |
+| Visual smoke checks | `npm run test:visual-smoke` | repo root (after `npm run build`) |
 | Content tests | `npm run test:content` | repo root |
 | Production dependency audit | `npm run audit:prod` | repo root |
 | Pre-review security gate | `./scripts/codex-security-pre-review.sh` | repo root |
@@ -22,24 +23,24 @@ Run commands from the repo root. If a required tool is missing, first try the us
 | Change | Minimum verification |
 | --- | --- |
 | Homepage content/CTA | `npm run test:content`, `npm run build` |
-| Shared UI component | `npm run lint`, `npm run build`; browser screenshot check when visual |
-| Global CSS/Tailwind | `npm run build`; browser check on desktop and mobile |
+| Shared UI component | `npm run lint`, `npm run build`, `npm run test:visual-smoke` |
+| Global CSS/Tailwind | `npm run build`, `npm run test:visual-smoke` |
 | Package/dependency | `npm run build`, `npm run lint`, `npm run audit:prod` |
 | CI workflow | Review workflow syntax and run matching npm scripts locally |
 | Docs only | No functional test required unless links/scripts changed |
 
 ## Browser Verification
 
-For meaningful visual changes, start the dev server and inspect the page:
+For meaningful visual changes, run:
 
 ```bash
-npm run dev
+npm run build
+npm run test:visual-smoke
 ```
 
-Then open `http://localhost:3200` in the browser. Check at least desktop and mobile widths for layout overlap, CTA visibility, and navigation.
+`test:visual-smoke` serves `out/` locally, runs Playwright checks for desktop/tablet/mobile across launch-critical routes, asserts no horizontal overflow, validates mobile nav placement, and saves screenshots to `output/visual-smoke/`.
 
 ## Known Quality Gaps
 
-- No dedicated Playwright test script is currently in `package.json`.
 - No explicit TypeScript typecheck script separate from `next build`.
 - Content tests appear limited; broaden them if changing messaging or CTAs heavily.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "record:demo-video": "node scripts/record-neutralai-demo-video.mjs",
+    "test:visual-smoke": "node scripts/visual-smoke.mjs",
     "test:content": "node --test tests/content/*.test.mjs",
     "lint": "eslint .",
     "audit:prod": "npm audit --omit=dev --audit-level=critical"

--- a/scripts/visual-smoke.mjs
+++ b/scripts/visual-smoke.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+import { createServer } from 'node:http'
+import { createReadStream } from 'node:fs'
+import { access, mkdir, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import process from 'node:process'
+import { chromium } from 'playwright'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const rootDir = path.join(__dirname, '..')
+const outDir = path.join(rootDir, 'out')
+const artifactRoot = path.join(rootDir, 'output', 'visual-smoke')
+const resolvedOutDir = path.resolve(outDir)
+
+const scenarios = [
+  { name: 'home-desktop', route: '/', viewport: { width: 1440, height: 900 } },
+  { name: 'home-tablet', route: '/', viewport: { width: 1024, height: 1366 } },
+  { name: 'home-mobile', route: '/', viewport: { width: 390, height: 844 }, checkMobileNav: true, checkPrimaryMedia: true },
+  { name: 'pricing-desktop', route: '/#pricing', viewport: { width: 1440, height: 900 } },
+  { name: 'contact-desktop', route: '/contact/', viewport: { width: 1440, height: 900 } },
+  { name: 'demo-desktop', route: '/demo/', viewport: { width: 1440, height: 900 } },
+  { name: 'playground-desktop', route: '/playground/', viewport: { width: 1440, height: 900 } },
+  { name: 'use-case-finance-desktop', route: '/use-cases/financial-services/', viewport: { width: 1440, height: 900 } },
+]
+
+const mimeTypes = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.xml': 'application/xml; charset=utf-8',
+}
+
+function nowStamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-')
+}
+
+async function ensureOutExists() {
+  const indexFile = path.join(outDir, 'index.html')
+  try {
+    await access(indexFile)
+  } catch {
+    throw new Error('Missing out/index.html. Run `npm run build` before visual smoke checks.')
+  }
+}
+
+async function resolveStaticFile(urlPathname) {
+  const normalizedPath = decodeURIComponent(urlPathname.split('?')[0]).replace(/^\/+/, '')
+  const candidate = path.join(outDir, normalizedPath)
+
+  const candidatePaths = []
+  if (normalizedPath === '') {
+    candidatePaths.push(path.join(outDir, 'index.html'))
+  } else {
+    candidatePaths.push(candidate)
+    if (!path.extname(candidate)) {
+      candidatePaths.push(path.join(candidate, 'index.html'))
+    }
+    if (normalizedPath.endsWith('/')) {
+      candidatePaths.push(path.join(candidate, 'index.html'))
+    }
+  }
+
+  for (const maybePath of candidatePaths) {
+    try {
+      const resolvedPath = path.resolve(maybePath)
+      const relativePath = path.relative(resolvedOutDir, resolvedPath)
+      if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+        continue
+      }
+
+      const fileStat = await stat(maybePath)
+      if (fileStat.isFile()) {
+        return resolvedPath
+      }
+    } catch {
+      // Try next candidate.
+    }
+  }
+
+  return null
+}
+
+async function startStaticServer() {
+  const server = createServer(async (req, res) => {
+    try {
+      const filePath = await resolveStaticFile(req.url ?? '/')
+      if (!filePath) {
+        res.statusCode = 404
+        res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+        res.end('Not Found')
+        return
+      }
+
+      const extension = path.extname(filePath).toLowerCase()
+      res.statusCode = 200
+      res.setHeader('Content-Type', mimeTypes[extension] ?? 'application/octet-stream')
+      createReadStream(filePath).pipe(res)
+    } catch (error) {
+      res.statusCode = 500
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+      res.end(`Server error: ${error instanceof Error ? error.message : 'unknown error'}`)
+    }
+  })
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    server.close()
+    throw new Error('Could not start static server on 127.0.0.1')
+  }
+  return { server, port: address.port }
+}
+
+async function assertNoHorizontalOverflow(page, scenarioName) {
+  const overflow = await page.evaluate(() => {
+    const doc = document.documentElement
+    const body = document.body
+    const docOverflow = doc.scrollWidth - doc.clientWidth
+    const bodyOverflow = body ? body.scrollWidth - body.clientWidth : 0
+    return Math.max(docOverflow, bodyOverflow)
+  })
+
+  if (overflow > 1) {
+    throw new Error(`${scenarioName}: detected horizontal overflow of ${overflow}px`)
+  }
+}
+
+async function assertPrimaryMediaVisible(page, scenarioName) {
+  const media = page.locator('[data-visual-smoke="home-primary-media"]')
+  if ((await media.count()) === 0) {
+    throw new Error(`${scenarioName}: missing [data-visual-smoke="home-primary-media"]`)
+  }
+  await media.first().waitFor({ state: 'visible', timeout: 7000 })
+  const box = await media.first().boundingBox()
+  if (!box || box.width < 220 || box.height < 220) {
+    throw new Error(`${scenarioName}: primary media appears blank or collapsed (${JSON.stringify(box)})`)
+  }
+}
+
+async function assertMobileMenuPlacement(page, scenarioName) {
+  const toggle = page.getByRole('button', { name: /open navigation menu/i })
+  await toggle.click()
+
+  const panel = page.locator('[data-visual-smoke="mobile-nav-panel"]')
+  await panel.waitFor({ state: 'visible', timeout: 5000 })
+  await page.waitForTimeout(450)
+
+  const geometry = await page.evaluate(() => {
+    const nav = document.querySelector('[data-visual-smoke="navbar-root"]')
+    const menu = document.querySelector('[data-visual-smoke="mobile-nav-panel"]')
+    if (!nav || !menu) {
+      return null
+    }
+    const navRect = nav.getBoundingClientRect()
+    const menuRect = menu.getBoundingClientRect()
+    return {
+      navBottom: navRect.bottom,
+      menuTop: menuRect.top,
+      menuRight: menuRect.right,
+      viewportWidth: window.innerWidth,
+    }
+  })
+
+  if (!geometry) {
+    throw new Error(`${scenarioName}: unable to measure mobile nav geometry`)
+  }
+  if (geometry.menuTop + 1 < geometry.navBottom) {
+    throw new Error(`${scenarioName}: mobile nav overlaps navbar (menuTop=${geometry.menuTop}, navBottom=${geometry.navBottom})`)
+  }
+  if (geometry.menuRight - geometry.viewportWidth > 1) {
+    throw new Error(`${scenarioName}: mobile nav extends past viewport by ${geometry.menuRight - geometry.viewportWidth}px`)
+  }
+}
+
+async function run() {
+  await ensureOutExists()
+  const runDir = path.join(artifactRoot, nowStamp())
+  await mkdir(runDir, { recursive: true })
+  const { server, port } = await startStaticServer()
+  const baseUrl = `http://127.0.0.1:${port}`
+  const browser = await chromium.launch({ headless: true })
+
+  let passed = 0
+  const failures = []
+
+  try {
+    for (const scenario of scenarios) {
+      const context = await browser.newContext({
+        viewport: scenario.viewport,
+        deviceScaleFactor: 1,
+      })
+
+      try {
+        const page = await context.newPage()
+        await page.goto(`${baseUrl}${scenario.route}`, { waitUntil: 'networkidle' })
+        await page.waitForTimeout(300)
+
+        await assertNoHorizontalOverflow(page, scenario.name)
+
+        if (scenario.checkPrimaryMedia) {
+          await assertPrimaryMediaVisible(page, scenario.name)
+        }
+
+        if (scenario.checkMobileNav) {
+          await assertMobileMenuPlacement(page, scenario.name)
+          await assertNoHorizontalOverflow(page, `${scenario.name} (with menu open)`)
+        }
+
+        const screenshotFile = path.join(runDir, `${scenario.name}.png`)
+        await page.screenshot({ path: screenshotFile, fullPage: true })
+        passed += 1
+        process.stdout.write(`PASS ${scenario.name}\n`)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        failures.push(`${scenario.name}: ${message}`)
+        process.stderr.write(`FAIL ${scenario.name}: ${message}\n`)
+      } finally {
+        await context.close()
+      }
+    }
+  } finally {
+    await browser.close()
+    server.close()
+  }
+
+  process.stdout.write(`\nVisual smoke artifacts: ${runDir}\n`)
+  process.stdout.write(`Scenarios passed: ${passed}/${scenarios.length}\n`)
+
+  if (failures.length > 0) {
+    process.stderr.write('\nVisual smoke failures:\n')
+    for (const failure of failures) {
+      process.stderr.write(`- ${failure}\n`)
+    }
+    process.exitCode = 1
+    return
+  }
+}
+
+run().catch((error) => {
+  process.stderr.write(`Fatal visual smoke error: ${error instanceof Error ? error.message : String(error)}\n`)
+  process.exit(1)
+})

--- a/scripts/visual-smoke.mjs
+++ b/scripts/visual-smoke.mjs
@@ -207,7 +207,10 @@ async function run() {
 
       try {
         const page = await context.newPage()
-        await page.goto(`${baseUrl}${scenario.route}`, { waitUntil: 'networkidle' })
+        const response = await page.goto(`${baseUrl}${scenario.route}`, { waitUntil: 'networkidle' })
+        if (!response || !response.ok()) {
+          throw new Error(`${scenario.name}: expected 2xx/3xx response but got ${response?.status() ?? 'no response'}`)
+        }
         await page.waitForTimeout(300)
 
         await assertNoHorizontalOverflow(page, scenario.name)


### PR DESCRIPTION
## Problem

The website lacked an automated visual smoke check path for launch-critical responsive regressions. Nav overlap, horizontal overflow, and blank hero media could slip through lint/build/content checks.

Closes #71.

## What Changed

- Added `npm run test:visual-smoke` and a new `scripts/visual-smoke.mjs` Playwright runner.
- Covered homepage desktop/tablet/mobile plus pricing, contact, demo, playground, and finance use-case routes.
- Added assertions for horizontal overflow, mobile nav placement, and home primary media visibility.
- Added stable `data-visual-smoke` hooks in navbar and hero media wrappers for reliable checks.
- Updated `docs/ai/TESTING_AND_COMMANDS.md` to document visual smoke usage for meaningful UI changes.
- Hardened the local static artifact server path resolution in the smoke script to prevent traversal outside `out/`.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run test:visual-smoke`
- [x] `npm run test:content`
- [x] `./scripts/codex-security-pre-review.sh`

## Risks / Follow-ups

- Visual smoke currently runs as a documented local workflow, not CI-gated yet.
- Screenshot artifacts are generated under `output/visual-smoke/` and intentionally ignored by git.
