### PR TITLE
Add accessibility smoke coverage for landmarks, keyboard nav, and contrast

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -101,7 +101,7 @@ function ContactFormPanel({ intent }: { intent: ContactIntent }) {
       </div>
 
       <div className="mt-6 flex flex-col gap-4 border-t border-white/10 pt-6 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-sm leading-6 text-slate-500">
+        <p className="text-sm leading-6 text-slate-400">
           Prefer email? Reach us at{' '}
           <a href={contactLinks.salesMailto} className="text-primary-light transition-colors hover:text-primary">
             {siteConfig.salesEmail}

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -445,7 +445,7 @@ export default function PlaygroundPage() {
                 Paste a prompt, choose reversible or irreversible masking, and preview the sanitized output with entity labels and confidence scores.
               </p>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-                <Link href="#playground-demo" className="btn btn-cta justify-center px-8 py-4">
+                <Link href="#playground-demo" className="btn btn-primary justify-center px-8 py-4">
                   Try a sample
                   <Play className="h-5 w-5" />
                 </Link>
@@ -537,7 +537,7 @@ export default function PlaygroundPage() {
               />
 
               <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex flex-col gap-2 text-sm text-slate-500 sm:flex-row sm:items-center sm:gap-5">
+                <div className="flex flex-col gap-2 text-sm text-slate-400 sm:flex-row sm:items-center sm:gap-5">
                   <span className={isOverLimit ? 'text-orange-300' : undefined}>
                     {prompt.length}/{MAX_PROMPT_LENGTH} recommended characters
                   </span>
@@ -603,7 +603,7 @@ export default function PlaygroundPage() {
                     </div>
                     <div className="min-h-[150px] whitespace-pre-wrap break-words font-mono text-sm leading-7 text-slate-200">
                       {hasResult ? renderHighlightedText(prompt, findings, 'original') : (
-                        <span className="font-body text-sm leading-6 text-slate-500">
+                        <span className="font-body text-sm leading-6 text-slate-400">
                           Write a prompt or choose a sample, then press Mask prompt.
                         </span>
                       )}
@@ -617,7 +617,7 @@ export default function PlaygroundPage() {
                     </div>
                     <div className="min-h-[150px] whitespace-pre-wrap break-words font-mono text-sm leading-7 text-slate-200">
                       {hasResult ? renderHighlightedText(visibleMaskedText, tokens, 'masked') : (
-                        <span className="font-body text-sm leading-6 text-slate-500">
+                        <span className="font-body text-sm leading-6 text-slate-400">
                           Sanitized output will appear here.
                         </span>
                       )}

--- a/docs/ai/TESTING_AND_COMMANDS.md
+++ b/docs/ai/TESTING_AND_COMMANDS.md
@@ -11,6 +11,7 @@ Run commands from the repo root. If a required tool is missing, first try the us
 | Production build | `npm run build` | repo root |
 | Start production server | `npm run start` | repo root |
 | Lint | `npm run lint` | repo root |
+| Accessibility smoke checks | `npm run test:a11y-smoke` | repo root (after `npm run build`) |
 | Visual smoke checks | `npm run test:visual-smoke` | repo root (after `npm run build`) |
 | Content tests | `npm run test:content` | repo root |
 | Production dependency audit | `npm run audit:prod` | repo root |
@@ -23,20 +24,23 @@ Run commands from the repo root. If a required tool is missing, first try the us
 | Change | Minimum verification |
 | --- | --- |
 | Homepage content/CTA | `npm run test:content`, `npm run build` |
-| Shared UI component | `npm run lint`, `npm run build`, `npm run test:visual-smoke` |
-| Global CSS/Tailwind | `npm run build`, `npm run test:visual-smoke` |
+| Shared UI component | `npm run lint`, `npm run build`, `npm run test:a11y-smoke`, `npm run test:visual-smoke` |
+| Global CSS/Tailwind | `npm run build`, `npm run test:a11y-smoke`, `npm run test:visual-smoke` |
 | Package/dependency | `npm run build`, `npm run lint`, `npm run audit:prod` |
 | CI workflow | Review workflow syntax and run matching npm scripts locally |
 | Docs only | No functional test required unless links/scripts changed |
 
 ## Browser Verification
 
-For meaningful visual changes, run:
+For meaningful visual and accessibility changes, run:
 
 ```bash
 npm run build
+npm run test:a11y-smoke
 npm run test:visual-smoke
 ```
+
+`test:a11y-smoke` serves `out/` locally, runs Playwright checks for landmarks/headings/interactive-control names on representative routes, validates contrast-sensitive text selectors, verifies consent-banner controls and desktop/mobile keyboard reachability, and saves a JSON report to `output/accessibility-smoke/`.
 
 `test:visual-smoke` serves `out/` locally, runs Playwright checks for desktop/tablet/mobile across launch-critical routes, asserts no horizontal overflow, validates mobile nav placement, and saves screenshots to `output/visual-smoke/`.
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "record:demo-video": "node scripts/record-neutralai-demo-video.mjs",
     "test:visual-smoke": "node scripts/visual-smoke.mjs",
+    "test:a11y-smoke": "node scripts/accessibility-smoke.mjs",
     "test:content": "node --test tests/content/*.test.mjs",
     "lint": "eslint .",
     "audit:prod": "npm audit --omit=dev --audit-level=critical"

--- a/scripts/accessibility-smoke.mjs
+++ b/scripts/accessibility-smoke.mjs
@@ -32,7 +32,7 @@ const scenarios = [
     name: 'contact',
     route: '/contact/',
     contrast: [
-      { selector: 'p.text-sm.leading-6.text-slate-400', minRatio: 4.5, label: 'contact secondary copy contrast' },
+      { selector: 'p:has(> a[href^="mailto:sales@neutralai.co.uk?subject=NeutralAI%20commercial%20enquiry"])', minRatio: 4.5, label: 'contact secondary copy contrast' },
     ],
   },
   {

--- a/scripts/accessibility-smoke.mjs
+++ b/scripts/accessibility-smoke.mjs
@@ -88,7 +88,12 @@ export async function resolveStaticFileFromRoot(staticRoot, urlPathname) {
   let normalizedPath
 
   try {
-    normalizedPath = decodeURIComponent(urlPathname.split('?')[0]).replace(/^\/+/, '')
+    if (!urlPathname.startsWith('/') || urlPathname.startsWith('//')) {
+      return null
+    }
+
+    const pathname = new URL(urlPathname, 'http://localhost').pathname
+    normalizedPath = decodeURIComponent(pathname).replace(/^\/+/, '')
   } catch {
     return null
   }

--- a/scripts/accessibility-smoke.mjs
+++ b/scripts/accessibility-smoke.mjs
@@ -1,0 +1,538 @@
+#!/usr/bin/env node
+
+import { createServer } from 'node:http'
+import { createReadStream } from 'node:fs'
+import { access, mkdir, realpath, stat, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const rootDir = path.join(__dirname, '..')
+const outDir = path.join(rootDir, 'out')
+const artifactRoot = path.join(rootDir, 'output', 'accessibility-smoke')
+
+const desktopViewport = { width: 1366, height: 900 }
+const mobileViewport = { width: 390, height: 844 }
+
+const scenarios = [
+  {
+    name: 'home',
+    route: '/',
+    contrast: [],
+  },
+  {
+    name: 'developers',
+    route: '/developers/',
+    contrast: [],
+  },
+  {
+    name: 'contact',
+    route: '/contact/',
+    contrast: [
+      { selector: 'p.text-sm.leading-6.text-slate-400', minRatio: 4.5, label: 'contact secondary copy contrast' },
+    ],
+  },
+  {
+    name: 'trust-center',
+    route: '/trust-center/',
+    contrast: [],
+  },
+  {
+    name: 'playground',
+    route: '/playground/',
+    contrast: [
+      { selector: 'a[href="#playground-demo"]', minRatio: 4.5, label: 'playground hero CTA contrast' },
+      { selector: '#playground-demo span.font-body.text-sm.leading-6.text-slate-400', minRatio: 4.5, label: 'playground helper panel contrast', all: true },
+      { selector: '#playground-demo div.mt-4 div.text-sm.text-slate-400 > span', minRatio: 4.5, label: 'playground character counter contrast' },
+    ],
+  },
+]
+
+const mimeTypes = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.xml': 'application/xml; charset=utf-8',
+}
+
+function nowStamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-')
+}
+
+async function ensureOutExists() {
+  try {
+    await access(path.join(outDir, 'index.html'))
+  } catch {
+    throw new Error('Missing out/index.html. Run `npm run build` before accessibility smoke checks.')
+  }
+}
+
+export async function resolveStaticFileFromRoot(staticRoot, urlPathname) {
+  const resolvedRoot = path.resolve(staticRoot)
+  const realRoot = await realpath(staticRoot).catch(() => resolvedRoot)
+  let normalizedPath
+
+  try {
+    normalizedPath = decodeURIComponent(urlPathname.split('?')[0]).replace(/^\/+/, '')
+  } catch {
+    return null
+  }
+
+  const candidate = path.join(staticRoot, normalizedPath)
+
+  const candidatePaths = []
+  if (normalizedPath === '') {
+    candidatePaths.push(path.join(staticRoot, 'index.html'))
+  } else {
+    candidatePaths.push(candidate)
+    if (!path.extname(candidate)) {
+      candidatePaths.push(path.join(candidate, 'index.html'))
+    }
+    if (normalizedPath.endsWith('/')) {
+      candidatePaths.push(path.join(candidate, 'index.html'))
+    }
+  }
+
+  for (const maybePath of candidatePaths) {
+    try {
+      const fileStat = await stat(maybePath)
+      if (fileStat.isFile()) {
+        const realCandidatePath = await realpath(maybePath)
+        const relativePath = path.relative(realRoot, realCandidatePath)
+        if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+          continue
+        }
+
+        return realCandidatePath
+      }
+    } catch {
+      // Try next candidate.
+    }
+  }
+
+  return null
+}
+
+async function resolveStaticFile(urlPathname) {
+  return resolveStaticFileFromRoot(outDir, urlPathname)
+}
+
+async function startStaticServer() {
+  const server = createServer(async (req, res) => {
+    try {
+      if (req.method !== 'GET' && req.method !== 'HEAD') {
+        res.statusCode = 405
+        res.setHeader('Allow', 'GET, HEAD')
+        res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+        res.end('Method Not Allowed')
+        return
+      }
+
+      const filePath = await resolveStaticFile(req.url ?? '/')
+      if (!filePath) {
+        res.statusCode = 404
+        res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+        res.end('Not Found')
+        return
+      }
+
+      const extension = path.extname(filePath).toLowerCase()
+      res.statusCode = 200
+      res.setHeader('Content-Type', mimeTypes[extension] ?? 'application/octet-stream')
+      if (req.method === 'HEAD') {
+        res.end()
+        return
+      }
+      createReadStream(filePath).pipe(res)
+    } catch {
+      res.statusCode = 500
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+      res.end('Internal Server Error')
+    }
+  })
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    server.close()
+    throw new Error('Could not start static server on 127.0.0.1')
+  }
+
+  return { server, port: address.port }
+}
+
+async function assertLandmarksAndHeadings(page, scenarioName) {
+  const result = await page.evaluate(() => {
+    const headingElements = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6'))
+    const headingLevels = headingElements.map((heading) => Number(heading.tagName[1]))
+
+    const headingSkips = []
+    for (let i = 1; i < headingLevels.length; i += 1) {
+      if (headingLevels[i] - headingLevels[i - 1] > 1) {
+        headingSkips.push(`${headingElements[i - 1].tagName}->${headingElements[i].tagName}`)
+      }
+    }
+
+    return {
+      mainCount: document.querySelectorAll('main').length,
+      navCount: document.querySelectorAll('nav').length,
+      footerCount: document.querySelectorAll('footer').length,
+      h1Count: document.querySelectorAll('h1').length,
+      headingSkips,
+    }
+  })
+
+  if (result.mainCount !== 1) {
+    throw new Error(`${scenarioName}: expected exactly one <main>, found ${result.mainCount}`)
+  }
+
+  if (result.navCount < 1) {
+    throw new Error(`${scenarioName}: expected at least one <nav>`)
+  }
+
+  if (result.footerCount < 1) {
+    throw new Error(`${scenarioName}: expected at least one <footer>`)
+  }
+
+  if (result.h1Count < 1) {
+    throw new Error(`${scenarioName}: expected at least one <h1>`)
+  }
+
+  if (result.headingSkips.length > 0) {
+    throw new Error(`${scenarioName}: heading level jumps detected (${result.headingSkips.join(', ')})`)
+  }
+}
+
+async function assertNamedInteractiveControls(page, scenarioName) {
+  const unnamed = await page.evaluate(() => {
+    function visible(element) {
+      const style = getComputedStyle(element)
+      if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
+        return false
+      }
+      return element.getClientRects().length > 0
+    }
+
+    function textFromLabelledBy(element) {
+      const labelledBy = element.getAttribute('aria-labelledby')
+      if (!labelledBy) {
+        return ''
+      }
+
+      return labelledBy
+        .split(/\s+/)
+        .map((id) => document.getElementById(id)?.textContent || '')
+        .join(' ')
+        .trim()
+    }
+
+    const elements = Array.from(document.querySelectorAll('a, button, [role="link"], [role="button"]'))
+    return elements
+      .filter((element) => element instanceof HTMLElement && visible(element))
+      .map((element) => {
+        const ariaLabel = element.getAttribute('aria-label')?.trim() || ''
+        const labelledBy = textFromLabelledBy(element)
+        const text = (element.textContent || '').trim().replace(/\s+/g, ' ')
+        const title = element.getAttribute('title')?.trim() || ''
+        const value = element instanceof HTMLInputElement ? (element.value || '').trim() : ''
+        const name = ariaLabel || labelledBy || text || title || value
+        return { tag: element.tagName, name }
+      })
+      .filter((entry) => entry.name.length === 0)
+      .slice(0, 5)
+  })
+
+  if (unnamed.length > 0) {
+    const sample = unnamed.map((entry) => entry.tag).join(', ')
+    throw new Error(`${scenarioName}: unnamed interactive controls detected (${sample})`)
+  }
+}
+
+async function assertContrast(page, check, scenarioName) {
+  const results = await page.evaluate(({ selector, minRatio, all }) => {
+    function parseColor(input) {
+      const match = input.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/i)
+      if (!match) {
+        return null
+      }
+
+      return {
+        r: Number(match[1]),
+        g: Number(match[2]),
+        b: Number(match[3]),
+        a: match[4] === undefined ? 1 : Number(match[4]),
+      }
+    }
+
+    function srgbToLinear(channel) {
+      const value = channel / 255
+      return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+    }
+
+    function luminance(color) {
+      return 0.2126 * srgbToLinear(color.r) + 0.7152 * srgbToLinear(color.g) + 0.0722 * srgbToLinear(color.b)
+    }
+
+    function contrastRatio(foreground, background) {
+      const fg = luminance(foreground)
+      const bg = luminance(background)
+      const lighter = Math.max(fg, bg)
+      const darker = Math.min(fg, bg)
+      return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    function isTransparent(color) {
+      return color.a === 0
+    }
+
+    function visible(element) {
+      const style = getComputedStyle(element)
+      if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
+        return false
+      }
+      return element.getClientRects().length > 0
+    }
+
+    function findBackground(element) {
+      let current = element
+      while (current) {
+        const background = parseColor(getComputedStyle(current).backgroundColor)
+        if (background && !isTransparent(background)) {
+          return background
+        }
+        current = current.parentElement
+      }
+      return { r: 3, g: 7, b: 18, a: 1 }
+    }
+
+    const elements = Array.from(document.querySelectorAll(selector))
+    const measured = []
+
+    for (const element of elements) {
+      if (!(element instanceof HTMLElement) || !visible(element)) {
+        continue
+      }
+
+      const foreground = parseColor(getComputedStyle(element).color)
+      const background = findBackground(element)
+      if (!foreground || !background) {
+        continue
+      }
+
+      const ratio = contrastRatio(foreground, background)
+      measured.push({ ratio, text: (element.textContent || '').trim().slice(0, 90) })
+      if (!all) {
+        break
+      }
+    }
+
+    const failing = measured.filter((entry) => entry.ratio < minRatio)
+    return { measured, failing }
+  }, check)
+
+  if (results.measured.length === 0) {
+    throw new Error(`${scenarioName}: no visible targets for contrast selector ${check.selector}`)
+  }
+
+  if (results.failing.length > 0) {
+    const detail = results.failing.map((entry) => `${entry.ratio.toFixed(2)} "${entry.text}"`).join('; ')
+    throw new Error(`${scenarioName}: ${check.label} below contrast threshold (${detail})`)
+  }
+}
+
+async function runScenario(context, baseUrl, scenario) {
+  const page = await context.newPage()
+  const response = await page.goto(`${baseUrl}${scenario.route}`, { waitUntil: 'networkidle' })
+
+  if (!response || !response.ok()) {
+    throw new Error(`${scenario.name}: expected 2xx/3xx response but got ${response?.status() ?? 'no response'}`)
+  }
+
+  await assertLandmarksAndHeadings(page, scenario.name)
+  await assertNamedInteractiveControls(page, scenario.name)
+
+  for (const check of scenario.contrast) {
+    await assertContrast(page, check, scenario.name)
+  }
+}
+
+async function expectFocusedRole(page, tagName, message) {
+  const focusedTag = await page.evaluate(() => document.activeElement?.tagName || '')
+  if (focusedTag.toUpperCase() !== tagName.toUpperCase()) {
+    throw new Error(`${message}. Found: ${focusedTag || 'none'}`)
+  }
+}
+
+async function assertConsentBanner(page) {
+  await page.getByRole('button', { name: /decline/i }).first().waitFor({ state: 'visible', timeout: 5000 })
+  await page.getByRole('button', { name: /accept/i }).first().waitFor({ state: 'visible', timeout: 5000 })
+}
+
+async function assertFocusIndicator(page, selector, label) {
+  const status = await page.evaluate((inputSelector) => {
+    const element = document.querySelector(inputSelector)
+    if (!(element instanceof HTMLElement)) {
+      return { exists: false, visible: false, highlighted: false }
+    }
+
+    element.focus()
+    const style = getComputedStyle(element)
+    const outlineWidth = Number.parseFloat(style.outlineWidth || '0')
+    const hasOutline = style.outlineStyle !== 'none' && outlineWidth > 0
+    const hasShadow = style.boxShadow && style.boxShadow !== 'none'
+    const visible = element.getClientRects().length > 0
+
+    return { exists: true, visible, highlighted: hasOutline || hasShadow }
+  }, selector)
+
+  if (!status.exists) {
+    throw new Error(`focus indicator: missing target ${label}`)
+  }
+
+  if (!status.visible) {
+    throw new Error(`focus indicator: target not visible ${label}`)
+  }
+
+  if (!status.highlighted) {
+    throw new Error(`focus indicator: no visible focus style on ${label}`)
+  }
+}
+
+async function assertDesktopKeyboardAndFocus(context, baseUrl) {
+  const page = await context.newPage()
+  await page.goto(`${baseUrl}/`, { waitUntil: 'networkidle' })
+
+  await assertConsentBanner(page)
+
+  await page.keyboard.press('Tab')
+  await page.keyboard.press('Tab')
+  await expectFocusedRole(page, 'A', 'desktop keyboard: expected focus to reach interactive controls')
+
+  await page.getByRole('button', { name: /^use cases$/i }).first().focus()
+  await expectFocusedRole(page, 'BUTTON', 'desktop keyboard: expected Use Cases dropdown trigger to be focusable')
+
+  await assertFocusIndicator(page, 'a[href="/#problem"]', 'desktop primary nav link')
+  await assertFocusIndicator(page, 'button[aria-haspopup="true"]', 'desktop dropdown trigger')
+}
+
+async function assertMobileKeyboardAndFocus(context, baseUrl) {
+  const page = await context.newPage()
+  await page.goto(`${baseUrl}/`, { waitUntil: 'networkidle' })
+
+  await assertConsentBanner(page)
+
+  const menuButton = page.getByRole('button', { name: /open navigation menu/i })
+  await menuButton.focus()
+  await expectFocusedRole(page, 'BUTTON', 'mobile keyboard: expected menu button to be focusable')
+  await page.keyboard.press('Enter')
+
+  const panel = page.locator('[data-visual-smoke="mobile-nav-panel"]')
+  await panel.waitFor({ state: 'visible', timeout: 5000 })
+
+  await page.keyboard.press('Tab')
+  await expectFocusedRole(page, 'A', 'mobile keyboard: expected first menu item to be keyboard reachable')
+
+  await assertFocusIndicator(page, 'button[aria-label*="navigation menu"]', 'mobile menu button')
+}
+
+async function run() {
+  await ensureOutExists()
+
+  const runDir = path.join(artifactRoot, nowStamp())
+  await mkdir(runDir, { recursive: true })
+
+  const { server, port } = await startStaticServer()
+  const baseUrl = `http://127.0.0.1:${port}`
+  const browser = await chromium.launch({ headless: true })
+
+  const report = {
+    runDir,
+    startedAt: new Date().toISOString(),
+    scenarios: [],
+    checks: [],
+    failures: [],
+  }
+
+  try {
+    for (const scenario of scenarios) {
+      const context = await browser.newContext({ viewport: desktopViewport, deviceScaleFactor: 1 })
+      try {
+        await runScenario(context, baseUrl, scenario)
+        report.scenarios.push({ name: scenario.name, route: scenario.route, status: 'pass' })
+        process.stdout.write(`PASS route ${scenario.name}\n`)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        report.scenarios.push({ name: scenario.name, route: scenario.route, status: 'fail', message })
+        report.failures.push(message)
+        process.stderr.write(`FAIL route ${scenario.name}: ${message}\n`)
+      } finally {
+        await context.close()
+      }
+    }
+
+    const desktopContext = await browser.newContext({ viewport: desktopViewport, deviceScaleFactor: 1 })
+    try {
+      await assertDesktopKeyboardAndFocus(desktopContext, baseUrl)
+      report.checks.push({ name: 'desktop-keyboard-and-focus', status: 'pass' })
+      process.stdout.write('PASS keyboard desktop\n')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      report.failures.push(message)
+      report.checks.push({ name: 'desktop-keyboard-and-focus', status: 'fail', message })
+      process.stderr.write(`FAIL keyboard desktop: ${message}\n`)
+    } finally {
+      await desktopContext.close()
+    }
+
+    const mobileContext = await browser.newContext({ viewport: mobileViewport, deviceScaleFactor: 1 })
+    try {
+      await assertMobileKeyboardAndFocus(mobileContext, baseUrl)
+      report.checks.push({ name: 'mobile-keyboard-and-focus', status: 'pass' })
+      process.stdout.write('PASS keyboard mobile\n')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      report.failures.push(message)
+      report.checks.push({ name: 'mobile-keyboard-and-focus', status: 'fail', message })
+      process.stderr.write(`FAIL keyboard mobile: ${message}\n`)
+    } finally {
+      await mobileContext.close()
+    }
+  } finally {
+    await browser.close()
+    server.close()
+    report.finishedAt = new Date().toISOString()
+    await writeFile(path.join(runDir, 'report.json'), JSON.stringify(report, null, 2), 'utf8')
+  }
+
+  process.stdout.write(`\nAccessibility smoke artifacts: ${runDir}\n`)
+
+  if (report.failures.length > 0) {
+    process.stderr.write('\nAccessibility smoke failures:\n')
+    for (const failure of report.failures) {
+      process.stderr.write(`- ${failure}\n`)
+    }
+    process.exitCode = 1
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  run().catch((error) => {
+    process.stderr.write(`Fatal accessibility smoke error: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(1)
+  })
+}

--- a/tests/accessibility-smoke.test.mjs
+++ b/tests/accessibility-smoke.test.mjs
@@ -48,3 +48,15 @@ test('resolveStaticFileFromRoot rejects traversal and symlink escapes', async ()
     }
   })
 })
+
+test('resolveStaticFileFromRoot rejects malformed absolute and scheme-relative targets', async () => {
+  await withTempDir(async (tempDir) => {
+    await writeFile(path.join(tempDir, 'index.html'), '<html></html>', 'utf8')
+
+    const absoluteTarget = await resolveStaticFileFromRoot(tempDir, 'http://evil.test/index.html')
+    const schemeRelativeTarget = await resolveStaticFileFromRoot(tempDir, '//evil.test/%2e%2e/index.html')
+
+    assert.equal(absoluteTarget, null)
+    assert.equal(schemeRelativeTarget, null)
+  })
+})

--- a/tests/accessibility-smoke.test.mjs
+++ b/tests/accessibility-smoke.test.mjs
@@ -1,0 +1,50 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { resolveStaticFileFromRoot } from '../scripts/accessibility-smoke.mjs'
+
+async function withTempDir(run) {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'neutralai-a11y-smoke-'))
+
+  try {
+    await run(tempDir)
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
+}
+
+test('resolveStaticFileFromRoot serves files inside the static export root', async () => {
+  await withTempDir(async (tempDir) => {
+    await mkdir(path.join(tempDir, 'nested'), { recursive: true })
+    await writeFile(path.join(tempDir, 'index.html'), '<html></html>', 'utf8')
+    await writeFile(path.join(tempDir, 'nested', 'index.html'), '<html>nested</html>', 'utf8')
+
+    const home = await resolveStaticFileFromRoot(tempDir, '/')
+    const nested = await resolveStaticFileFromRoot(tempDir, '/nested/')
+
+    assert.equal(home, await realpath(path.join(tempDir, 'index.html')))
+    assert.equal(nested, await realpath(path.join(tempDir, 'nested', 'index.html')))
+  })
+})
+
+test('resolveStaticFileFromRoot rejects traversal and symlink escapes', async () => {
+  await withTempDir(async (tempDir) => {
+    const outsideRoot = await mkdtemp(path.join(os.tmpdir(), 'neutralai-a11y-outside-'))
+
+    try {
+      await writeFile(path.join(tempDir, 'index.html'), '<html></html>', 'utf8')
+      await writeFile(path.join(outsideRoot, 'secret.txt'), 'secret', 'utf8')
+      await symlink(path.join(outsideRoot, 'secret.txt'), path.join(tempDir, 'escape.txt'))
+
+      const traversal = await resolveStaticFileFromRoot(tempDir, '/../secret.txt')
+      const symlinkEscape = await resolveStaticFileFromRoot(tempDir, '/escape.txt')
+
+      assert.equal(traversal, null)
+      assert.equal(symlinkEscape, null)
+    } finally {
+      await rm(outsideRoot, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Problem

Accessibility checks were mostly manual, which made landmark, keyboard navigation, and contrast regressions easy to miss before release.

## What Changed

- Added a new `test:a11y-smoke` Playwright script to run route-level accessibility checks on static build output.
- Added automated checks for landmarks/main ownership, heading structure, interactive control naming, keyboard navigation/focus behavior, and contrast-sensitive selectors.
- Hardened the local static file resolver used by the smoke script against traversal/symlink/malformed URL escapes, with dedicated regression tests.
- Fixed low-contrast copy on contact and playground routes to pass the new checks.
- Documented the new accessibility smoke command in `docs/ai/TESTING_AND_COMMANDS.md`.

## Validation

- [x] `npm run lint` (pass)
- [x] `node --test tests/accessibility-smoke.test.mjs` (pass)
- [x] `npm run build` (pass)
- [x] `npm run test:a11y-smoke` (pass)
- [x] `npm run test:content` (pass)
- [x] `./scripts/codex-security-pre-review.sh` (pass; blocking static-resolver finding addressed)

## Risks / Follow-ups

- The new contrast checks currently use targeted selectors for launch-critical copy; if UI structure changes significantly, selectors may need updates.
- Accessibility smoke currently runs against static export output only; if runtime-only UI is added later, a runtime/browser audit layer should be added.
