### PR TITLE
Harden accessibility smoke coverage for navbar keyboard flows

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -89,7 +89,7 @@ export default function Navbar() {
             <Link 
               key={link.name} 
               href={link.href}
-              className="whitespace-nowrap text-sm text-slate-300 transition-colors hover:text-primary 2xl:text-base"
+              className="whitespace-nowrap rounded-md px-1 py-1 text-sm text-slate-300 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 2xl:text-base"
             >
               {link.name}
             </Link>
@@ -99,7 +99,10 @@ export default function Navbar() {
         </div>
 
         <div className="hidden flex-shrink-0 items-center gap-4 xl:flex">
-          <Link href="/contact" className="whitespace-nowrap text-sm text-slate-300 transition-colors hover:text-white 2xl:text-base">
+          <Link
+            href="/contact"
+            className="whitespace-nowrap rounded-md px-1 py-1 text-sm text-slate-300 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 2xl:text-base"
+          >
             Contact
           </Link>
           <Link
@@ -114,7 +117,7 @@ export default function Navbar() {
         </div>
 
         <button 
-          className="xl:hidden text-slate-300"
+          className="xl:hidden rounded-md text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
           aria-label={isOpen ? 'Close navigation menu' : 'Open navigation menu'}
           aria-expanded={isOpen}
           onClick={() => setIsOpen(!isOpen)}
@@ -134,7 +137,7 @@ export default function Navbar() {
             <Link 
               key={link.name} 
               href={link.href}
-              className="block py-3 text-slate-300 hover:text-primary transition-colors"
+              className="block rounded-md px-1 py-3 text-slate-300 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
               onClick={() => setIsOpen(false)}
             >
               {link.name}
@@ -145,7 +148,7 @@ export default function Navbar() {
             <Link
               key={link.name}
               href={link.href}
-              className="block py-3 text-slate-300 hover:text-primary transition-colors"
+              className="block rounded-md px-1 py-3 text-slate-300 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
               onClick={() => setIsOpen(false)}
             >
               {link.name}
@@ -156,7 +159,7 @@ export default function Navbar() {
             <Link
               key={link.name}
               href={link.href}
-              className="block py-3 text-slate-300 hover:text-primary transition-colors"
+              className="block rounded-md px-1 py-3 text-slate-300 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
               onClick={() => setIsOpen(false)}
             >
               {link.name}
@@ -164,7 +167,7 @@ export default function Navbar() {
           ))}
           <Link
             href="/contact"
-            className="block py-3 text-slate-300 hover:text-primary transition-colors"
+            className="block rounded-md px-1 py-3 text-slate-300 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
             onClick={() => setIsOpen(false)}
           >
             Contact

--- a/scripts/accessibility-smoke.mjs
+++ b/scripts/accessibility-smoke.mjs
@@ -383,6 +383,43 @@ async function expectFocusedRole(page, tagName, message) {
   }
 }
 
+async function readFocusedElement(page) {
+  return page.evaluate(() => {
+    const active = document.activeElement
+    if (!active) {
+      return { tag: '', name: '' }
+    }
+
+    const ariaLabel = active.getAttribute?.('aria-label')?.trim() || ''
+    const text = (active.textContent || '').trim().replace(/\s+/g, ' ')
+    return { tag: active.tagName, name: ariaLabel || text }
+  })
+}
+
+async function expectFocusedLinkWithName(page, expectedName, message) {
+  const focused = await readFocusedElement(page)
+  if (focused.tag.toUpperCase() !== 'A') {
+    throw new Error(`${message}. Found focused tag: ${focused.tag || 'none'}`)
+  }
+
+  if (!expectedName.test(focused.name)) {
+    throw new Error(`${message}. Found focused link name: "${focused.name || 'unknown'}"`)
+  }
+}
+
+async function tabUntilFocusedLink(page, expectedName, maxTabs, message) {
+  for (let i = 0; i < maxTabs; i += 1) {
+    await page.keyboard.press('Tab')
+    const focused = await readFocusedElement(page)
+    if (focused.tag.toUpperCase() === 'A' && expectedName.test(focused.name)) {
+      return
+    }
+  }
+
+  const focused = await readFocusedElement(page)
+  throw new Error(`${message}. Found: ${focused.tag || 'none'} "${focused.name || ''}"`)
+}
+
 async function assertConsentBanner(page) {
   await page.getByRole('button', { name: /decline/i }).first().waitFor({ state: 'visible', timeout: 5000 })
   await page.getByRole('button', { name: /accept/i }).first().waitFor({ state: 'visible', timeout: 5000 })
@@ -428,11 +465,21 @@ async function assertDesktopKeyboardAndFocus(context, baseUrl) {
   await page.keyboard.press('Tab')
   await expectFocusedRole(page, 'A', 'desktop keyboard: expected focus to reach interactive controls')
 
-  await page.getByRole('button', { name: /^use cases$/i }).first().focus()
+  const useCasesButton = page.getByRole('button', { name: /^use cases$/i }).first()
+  await useCasesButton.focus()
   await expectFocusedRole(page, 'BUTTON', 'desktop keyboard: expected Use Cases dropdown trigger to be focusable')
+  await page.getByRole('link', { name: /^all use cases$/i }).first().waitFor({ state: 'visible', timeout: 5000 })
+  await tabUntilFocusedLink(page, /^all use cases$/i, 4, 'desktop keyboard: expected Use Cases dropdown link to be keyboard reachable')
+
+  const moreButton = page.getByRole('button', { name: /^more$/i }).first()
+  await moreButton.focus()
+  await expectFocusedRole(page, 'BUTTON', 'desktop keyboard: expected More dropdown trigger to be focusable')
+  await page.getByRole('link', { name: /^blog$/i }).first().waitFor({ state: 'visible', timeout: 5000 })
+  await tabUntilFocusedLink(page, /^blog$/i, 4, 'desktop keyboard: expected More dropdown link to be keyboard reachable')
 
   await assertFocusIndicator(page, 'a[href="/#problem"]', 'desktop primary nav link')
   await assertFocusIndicator(page, 'button[aria-haspopup="true"]', 'desktop dropdown trigger')
+  await assertFocusIndicator(page, 'a[href^="/use-cases"]', 'desktop dropdown link')
 }
 
 async function assertMobileKeyboardAndFocus(context, baseUrl) {
@@ -450,7 +497,10 @@ async function assertMobileKeyboardAndFocus(context, baseUrl) {
   await panel.waitFor({ state: 'visible', timeout: 5000 })
 
   await page.keyboard.press('Tab')
-  await expectFocusedRole(page, 'A', 'mobile keyboard: expected first menu item to be keyboard reachable')
+  await expectFocusedLinkWithName(page, /^problem$/i, 'mobile keyboard: expected first menu item to be keyboard reachable')
+  await tabUntilFocusedLink(page, /^blog$/i, 12, 'mobile keyboard: expected grouped More links to be keyboard reachable')
+  await tabUntilFocusedLink(page, /^all use cases$/i, 12, 'mobile keyboard: expected grouped Use Cases links to be keyboard reachable')
+  await tabUntilFocusedLink(page, /^get started free$/i, 20, 'mobile keyboard: expected mobile CTA to be keyboard reachable')
 
   await assertFocusIndicator(page, 'button[aria-label*="navigation menu"]', 'mobile menu button')
 }


### PR DESCRIPTION
## Problem

Accessibility checks existed, but keyboard reachability assertions did not fully cover grouped dropdown/mobile navigation flows that can regress silently.

## What Changed

- Added focus-visible ring styles to desktop/mobile navbar links and mobile menu toggle for clearer keyboard focus indicators.
- Expanded `test:a11y-smoke` keyboard checks to validate:
  - desktop dropdown triggers and dropdown link reachability (`Use Cases`, `More`)
  - mobile grouped menu reachability (`More`, `Use Cases`) and mobile CTA keyboard reachability
- Added explicit focus indicator assertion for a desktop dropdown link target.

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:a11y-smoke`
- [x] `npm run test:content`
- [x] `npm run test:visual-smoke` (via `./scripts/codex-security-pre-review.sh`)
- [x] `./scripts/codex-security-pre-review.sh`

## Risks / Follow-ups

- Focus ring styling slightly increases visual emphasis in navbar states; visual smoke passed, but manual QA in final staging is still recommended.

Closes #72
