### PR TITLE
Improve product visual motion, reduced-motion handling, and mobile framing

### DIFF
--- a/app/components/home/ProductVisual.tsx
+++ b/app/components/home/ProductVisual.tsx
@@ -90,6 +90,14 @@ export default function ProductVisual() {
   const sanitizedPanelActive =
     !shouldReduceMotion &&
     (displayPhase === 'typingSanitized' || displayPhase === 'pauseSanitized')
+  const beamDotAnimate = shouldReduceMotion
+    ? { x: 0, opacity: 0.2 }
+    : showFlights
+      ? { x: ['-64%', '64%'], opacity: [0.35, 1, 0.35] }
+      : { x: '-64%', opacity: 0.2 }
+  const beamDotTransition = shouldReduceMotion
+    ? { duration: 0 }
+    : { duration: 1.1, repeat: showFlights ? Infinity : 0, ease: 'easeInOut' as const }
 
   return (
     <div className="signal-simple-shell rounded-[28px] p-3 sm:p-4 md:p-6 xl:p-7">
@@ -165,12 +173,8 @@ export default function ProductVisual() {
             <div className="beam-wrapper">
               <div className="beam-line" />
               <motion.div
-                animate={
-                  showFlights
-                    ? { x: ['-64%', '64%'], opacity: [0.35, 1, 0.35] }
-                    : { x: '-64%', opacity: 0.2 }
-                }
-                transition={{ duration: 1.1, repeat: showFlights ? Infinity : 0, ease: 'easeInOut' }}
+                animate={beamDotAnimate}
+                transition={beamDotTransition}
                 className="beam-dot"
               />
               <motion.div

--- a/app/components/home/ProductVisual.tsx
+++ b/app/components/home/ProductVisual.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 import { ShieldCheck } from 'lucide-react'
 import {
   rawPromptCharCount,
@@ -15,8 +15,13 @@ export default function ProductVisual() {
   const [phase, setPhase] = useState<'typingRaw' | 'highlightRaw' | 'sending' | 'typingSanitized' | 'pauseSanitized'>('typingRaw')
   const [rawTypedChars, setRawTypedChars] = useState(0)
   const [sanitizedTypedChars, setSanitizedTypedChars] = useState(0)
+  const shouldReduceMotion = useReducedMotion()
 
   useEffect(() => {
+    if (shouldReduceMotion) {
+      return
+    }
+
     const typingSpeedMs = 34
     let timer: ReturnType<typeof setTimeout> | undefined
 
@@ -69,116 +74,153 @@ export default function ProductVisual() {
         clearTimeout(timer)
       }
     }
-  }, [phase, rawTypedChars, sanitizedTypedChars])
+  }, [phase, rawTypedChars, sanitizedTypedChars, shouldReduceMotion])
 
-  const rawHighlightVisible = phase !== 'typingRaw' && rawTypedChars === rawPromptCharCount
-  const showFlights = phase === 'sending'
+  const displayPhase = shouldReduceMotion ? 'pauseSanitized' : phase
+  const displayRawTypedChars = shouldReduceMotion ? rawPromptCharCount : rawTypedChars
+  const displaySanitizedTypedChars = shouldReduceMotion
+    ? sanitizedPromptCharCount
+    : sanitizedTypedChars
+  const rawHighlightVisible =
+    shouldReduceMotion || (displayPhase !== 'typingRaw' && displayRawTypedChars === rawPromptCharCount)
+  const showFlights = !shouldReduceMotion && displayPhase === 'sending'
+  const rawPanelActive =
+    !shouldReduceMotion &&
+    (displayPhase === 'typingRaw' || displayPhase === 'highlightRaw' || displayPhase === 'sending')
+  const sanitizedPanelActive =
+    !shouldReduceMotion &&
+    (displayPhase === 'typingSanitized' || displayPhase === 'pauseSanitized')
 
   return (
-    <div className="signal-simple-shell rounded-[30px] p-4 md:p-6 xl:p-7">
+    <div className="signal-simple-shell rounded-[28px] p-3 sm:p-4 md:p-6 xl:p-7">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/80 pb-3 md:pb-4">
         <div>
           <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Live Narrative</p>
-          <h2 className="mt-2 font-heading text-2xl font-semibold">How NeutralAI works in one view</h2>
+          <h2 className="mt-2 font-heading text-xl font-semibold sm:text-2xl">
+            How NeutralAI works in one view
+          </h2>
         </div>
         <div className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs text-primary-light">
-          api.neutralai.co.uk
+          {shouldReduceMotion ? 'Reduced motion mode' : 'api.neutralai.co.uk'}
         </div>
       </div>
 
-      <div className="relative mt-5 overflow-hidden md:mt-6">
-        <div className="pointer-events-none absolute inset-0 z-20 hidden md:block">
-          <motion.div
-            className="token-flight token-flight-danger"
-            style={{ top: '37%', left: '10%' }}
-            animate={showFlights ? { x: [0, 42, 96, 148], opacity: [0, 1, 1, 0] } : { x: 0, opacity: 0 }}
-            transition={{ duration: 1.3, ease: 'easeInOut' }}
-          >
-            emma@client.com
-          </motion.div>
-          <motion.div
-            className="token-flight token-flight-danger"
-            style={{ top: '51%', left: '10%' }}
-            animate={showFlights ? { x: [0, 42, 96, 148], opacity: [0, 1, 1, 0] } : { x: 0, opacity: 0 }}
-            transition={{ duration: 1.3, delay: 0.18, ease: 'easeInOut' }}
-          >
-            POL-44918
-          </motion.div>
-          <motion.div
-            className="token-flight token-flight-danger"
-            style={{ top: '65%', left: '10%' }}
-            animate={showFlights ? { x: [0, 42, 96, 148], opacity: [0, 1, 1, 0] } : { x: 0, opacity: 0 }}
-            transition={{ duration: 1.3, delay: 0.36, ease: 'easeInOut' }}
-          >
-            +44 07...
-          </motion.div>
-        </div>
-
-        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_118px_minmax(0,1.16fr)] md:items-stretch md:gap-3 xl:grid-cols-[minmax(0,1.03fr)_132px_minmax(0,1.2fr)] xl:gap-4">
-        <motion.div
-          animate={{ y: [0, -4, 0] }}
-          transition={{ duration: 4.4, repeat: Infinity, ease: 'easeInOut' }}
-          className="grid min-w-0 grid-rows-[auto_1fr] rounded-[22px] border border-red-500/20 bg-red-950/10 p-3 md:p-4"
-        >
-          <p className="text-sm font-semibold text-slate-100">Raw input</p>
-          <div className="prompt-editor-shell mt-3 min-w-0 font-mono text-sm text-slate-300 md:mt-4 md:text-[15px]">
-            <div className="mb-4 flex gap-2">
-              <span className="h-2.5 w-2.5 rounded-full bg-slate-700" />
-              <span className="h-2.5 w-2.5 rounded-full bg-slate-700" />
-              <span className="h-2.5 w-2.5 rounded-full bg-slate-700" />
-            </div>
-            <div className="space-y-3 leading-7 md:leading-8">
-              {renderPromptLines({
-                lines: rawPromptLines,
-                typedChars: rawTypedChars,
-                highlightTokens: rawHighlightVisible,
-                showCaret: phase === 'typingRaw',
-              })}
-            </div>
-          </div>
-        </motion.div>
-
-          <div className="flex items-center justify-center py-2 md:py-0">
-          <div className="beam-wrapper">
-            <div className="beam-line" />
+      <div className="relative mt-4 overflow-hidden md:mt-6">
+        {!shouldReduceMotion ? (
+          <div className="pointer-events-none absolute inset-0 z-20 hidden md:block">
             <motion.div
-              animate={showFlights ? { x: ['-64%', '64%'], opacity: [0.35, 1, 0.35] } : { x: '-64%', opacity: 0.2 }}
-              transition={{ duration: 1.1, repeat: showFlights ? Infinity : 0, ease: 'easeInOut' }}
-              className="beam-dot"
-            />
-            <motion.div
-              animate={showFlights ? { scale: [1, 1.08, 1], boxShadow: ['0 0 0 rgba(34,211,238,0.0)', '0 0 30px rgba(34,211,238,0.2)', '0 0 0 rgba(34,211,238,0.0)'] } : { scale: 1 }}
-              transition={{ duration: 1.1, repeat: showFlights ? Infinity : 0, ease: 'easeInOut' }}
-              className="gateway-core"
+              className="token-flight token-flight-danger"
+              style={{ top: '37%', left: '10%' }}
+              animate={showFlights ? { x: [0, 42, 96, 148], opacity: [0, 1, 1, 0] } : { x: 0, opacity: 0 }}
+              transition={{ duration: 1.3, ease: 'easeInOut' }}
             >
-              <ShieldCheck className="h-8 w-8 text-primary-light" />
-              <p className="mt-3 font-heading text-base font-semibold text-slate-50">NeutralAI</p>
+              emma@client.com
+            </motion.div>
+            <motion.div
+              className="token-flight token-flight-danger"
+              style={{ top: '51%', left: '10%' }}
+              animate={showFlights ? { x: [0, 42, 96, 148], opacity: [0, 1, 1, 0] } : { x: 0, opacity: 0 }}
+              transition={{ duration: 1.3, delay: 0.18, ease: 'easeInOut' }}
+            >
+              POL-44918
+            </motion.div>
+            <motion.div
+              className="token-flight token-flight-danger"
+              style={{ top: '65%', left: '10%' }}
+              animate={showFlights ? { x: [0, 42, 96, 148], opacity: [0, 1, 1, 0] } : { x: 0, opacity: 0 }}
+              transition={{ duration: 1.3, delay: 0.36, ease: 'easeInOut' }}
+            >
+              +44 07...
             </motion.div>
           </div>
-        </div>
+        ) : null}
 
-        <motion.div
-          animate={{ y: [0, 4, 0] }}
-          transition={{ duration: 4.8, repeat: Infinity, ease: 'easeInOut' }}
-          className="grid min-w-0 grid-rows-[auto_1fr] rounded-[22px] border border-emerald-500/20 bg-emerald-950/10 p-3 md:p-4"
-        >
-          <p className="text-sm font-semibold text-slate-100">Sanitized prompt</p>
-          <div className="prompt-editor-shell prompt-editor-shell-safe mt-3 min-w-0 font-mono text-sm text-slate-300 md:mt-4 md:text-[15px]">
-            <div className="mb-4 flex gap-2">
-              <span className="h-2.5 w-2.5 rounded-full bg-emerald-800/70" />
-              <span className="h-2.5 w-2.5 rounded-full bg-emerald-800/70" />
-              <span className="h-2.5 w-2.5 rounded-full bg-emerald-800/70" />
-            </div>
-            <div className="space-y-3 leading-7 md:leading-8">
-              {renderPromptLines({
-                lines: sanitizedPromptLines,
-                typedChars: sanitizedTypedChars,
-                highlightTokens: true,
-                showCaret: phase === 'typingSanitized',
-              })}
+        <div className="grid gap-2 sm:gap-3 md:grid-cols-[minmax(0,1fr)_118px_minmax(0,1.16fr)] md:items-stretch md:gap-3 xl:grid-cols-[minmax(0,1.03fr)_132px_minmax(0,1.2fr)] xl:gap-4">
+          <div
+            className={`grid min-w-0 grid-rows-[auto_1fr] rounded-[20px] border p-2.5 transition-all duration-500 sm:p-3 md:rounded-[22px] md:p-4 ${
+              rawPanelActive
+                ? 'border-red-400/35 bg-red-950/20 ring-1 ring-red-300/30'
+                : 'border-red-500/20 bg-red-950/10'
+            }`}
+          >
+            <p className="text-sm font-semibold text-slate-100">Raw input</p>
+            <div className="prompt-editor-shell mt-2 min-w-0 font-mono text-xs text-slate-300 sm:mt-3 sm:text-sm md:mt-4 md:text-[15px]">
+              <div className="mb-3 flex gap-2 md:mb-4">
+                <span className="h-2 w-2 rounded-full bg-slate-700 sm:h-2.5 sm:w-2.5" />
+                <span className="h-2 w-2 rounded-full bg-slate-700 sm:h-2.5 sm:w-2.5" />
+                <span className="h-2 w-2 rounded-full bg-slate-700 sm:h-2.5 sm:w-2.5" />
+              </div>
+              <div className="space-y-2.5 leading-6 sm:space-y-3 sm:leading-7 md:leading-8">
+                {renderPromptLines({
+                  lines: rawPromptLines,
+                  typedChars: displayRawTypedChars,
+                  highlightTokens: rawHighlightVisible,
+                  showCaret: !shouldReduceMotion && displayPhase === 'typingRaw',
+                })}
+              </div>
             </div>
           </div>
-        </motion.div>
+
+          <div className="flex items-center justify-center py-1 sm:py-2 md:py-0">
+            <div className="beam-wrapper">
+              <div className="beam-line" />
+              <motion.div
+                animate={
+                  showFlights
+                    ? { x: ['-64%', '64%'], opacity: [0.35, 1, 0.35] }
+                    : { x: '-64%', opacity: 0.2 }
+                }
+                transition={{ duration: 1.1, repeat: showFlights ? Infinity : 0, ease: 'easeInOut' }}
+                className="beam-dot"
+              />
+              <motion.div
+                animate={
+                  showFlights
+                    ? {
+                        scale: [1, 1.08, 1],
+                        boxShadow: [
+                          '0 0 0 rgba(34,211,238,0.0)',
+                          '0 0 30px rgba(34,211,238,0.2)',
+                          '0 0 0 rgba(34,211,238,0.0)',
+                        ],
+                      }
+                    : { scale: 1 }
+                }
+                transition={{ duration: 1.1, repeat: showFlights ? Infinity : 0, ease: 'easeInOut' }}
+                className="gateway-core"
+              >
+                <ShieldCheck className="h-7 w-7 text-primary-light md:h-8 md:w-8" />
+                <p className="mt-2 hidden font-heading text-sm font-semibold text-slate-50 sm:block md:mt-3 md:text-base">
+                  NeutralAI
+                </p>
+              </motion.div>
+            </div>
+          </div>
+
+          <div
+            className={`grid min-w-0 grid-rows-[auto_1fr] rounded-[20px] border p-2.5 transition-all duration-500 sm:p-3 md:rounded-[22px] md:p-4 ${
+              sanitizedPanelActive
+                ? 'border-emerald-400/35 bg-emerald-950/22 ring-1 ring-emerald-300/30'
+                : 'border-emerald-500/20 bg-emerald-950/10'
+            }`}
+          >
+            <p className="text-sm font-semibold text-slate-100">Sanitized prompt</p>
+            <div className="prompt-editor-shell prompt-editor-shell-safe mt-2 min-w-0 font-mono text-xs text-slate-300 sm:mt-3 sm:text-sm md:mt-4 md:text-[15px]">
+              <div className="mb-3 flex gap-2 md:mb-4">
+                <span className="h-2 w-2 rounded-full bg-emerald-800/70 sm:h-2.5 sm:w-2.5" />
+                <span className="h-2 w-2 rounded-full bg-emerald-800/70 sm:h-2.5 sm:w-2.5" />
+                <span className="h-2 w-2 rounded-full bg-emerald-800/70 sm:h-2.5 sm:w-2.5" />
+              </div>
+              <div className="space-y-2.5 leading-6 sm:space-y-3 sm:leading-7 md:leading-8">
+                {renderPromptLines({
+                  lines: sanitizedPromptLines,
+                  typedChars: displaySanitizedTypedChars,
+                  highlightTokens: true,
+                  showCaret: !shouldReduceMotion && displayPhase === 'typingSanitized',
+                })}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -334,7 +334,7 @@ body {
 }
 
 .prompt-editor-shell {
-  min-height: clamp(236px, 24vw, 292px);
+  min-height: clamp(178px, 28vw, 236px);
   width: 100%;
   min-width: 0;
   overflow: hidden;
@@ -413,8 +413,8 @@ body {
 
 .beam-wrapper {
   position: relative;
-  width: clamp(104px, 12vw, 148px);
-  height: clamp(104px, 12vw, 148px);
+  width: clamp(72px, 14vw, 148px);
+  height: clamp(72px, 14vw, 148px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -469,8 +469,8 @@ body {
 .gateway-core {
   position: relative;
   z-index: 1;
-  width: clamp(82px, 8.8vw, 110px);
-  height: clamp(82px, 8.8vw, 110px);
+  width: clamp(72px, 8.8vw, 110px);
+  height: clamp(72px, 8.8vw, 110px);
   border-radius: 9999px;
   border: 1px solid rgba(34, 211, 238, 0.22);
   background:
@@ -489,6 +489,12 @@ body {
 @media (min-width: 1280px) {
   .prompt-editor-shell {
     min-height: 308px;
+  }
+}
+
+@media (min-width: 768px) {
+  .prompt-editor-shell {
+    min-height: clamp(236px, 24vw, 292px);
   }
 }
 
@@ -551,6 +557,43 @@ body {
 
 .ambient-orbit {
   animation: ambient-orbit 18s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .animate-pulse,
+  .gradient-text-warm,
+  .gradient-text-signal,
+  .typing-caret,
+  .token-flight,
+  .marquee-track,
+  .scan-line,
+  .ambient-orbit,
+  .pipeline-particle-one,
+  .pipeline-particle-two,
+  .pipeline-particle-three,
+  .pipeline-core::before,
+  .pipeline-core::after,
+  .spotlight-card::after,
+  .signal-card-elevated::after,
+  .accent-panel::before,
+  .accent-card::before {
+    animation: none !important;
+  }
+
+  .typing-caret,
+  .token-flight,
+  .scan-line,
+  .ambient-orbit {
+    display: none !important;
+  }
+
+  .marquee-track {
+    transform: translateX(0) !important;
+  }
 }
 
 /* Animated border */

--- a/scripts/visual-smoke.mjs
+++ b/scripts/visual-smoke.mjs
@@ -19,6 +19,14 @@ const scenarios = [
   { name: 'home-desktop', route: '/', viewport: { width: 1440, height: 900 } },
   { name: 'home-tablet', route: '/', viewport: { width: 1024, height: 1366 } },
   { name: 'home-mobile', route: '/', viewport: { width: 390, height: 844 }, checkMobileNav: true, checkPrimaryMedia: true },
+  {
+    name: 'home-mobile-reduced-motion',
+    route: '/',
+    viewport: { width: 390, height: 844 },
+    checkPrimaryMedia: true,
+    checkReducedMotion: true,
+    reducedMotion: 'reduce',
+  },
   { name: 'pricing-desktop', route: '/#pricing', viewport: { width: 1440, height: 900 } },
   { name: 'contact-desktop', route: '/contact/', viewport: { width: 1440, height: 900 } },
   { name: 'demo-desktop', route: '/demo/', viewport: { width: 1440, height: 900 } },
@@ -187,6 +195,32 @@ async function assertMobileMenuPlacement(page, scenarioName) {
   }
 }
 
+async function assertReducedMotionExperience(page, scenarioName) {
+  const reducedMotionBadge = page.getByText('Reduced motion mode', { exact: true })
+  if ((await reducedMotionBadge.count()) === 0) {
+    throw new Error(`${scenarioName}: expected reduced motion badge in product visual`)
+  }
+
+  const typingCarets = page.locator('.typing-caret')
+  if ((await typingCarets.count()) > 0) {
+    throw new Error(`${scenarioName}: typing caret should be hidden for reduced motion users`)
+  }
+
+  const marqueeAnimationName = await page.evaluate(() => {
+    const marqueeTrack = document.querySelector('.marquee-track')
+    if (!marqueeTrack) {
+      return null
+    }
+    return window.getComputedStyle(marqueeTrack).animationName
+  })
+
+  if (marqueeAnimationName && marqueeAnimationName !== 'none') {
+    throw new Error(
+      `${scenarioName}: marquee animation should be disabled in reduced motion mode (animation=${marqueeAnimationName})`
+    )
+  }
+}
+
 async function run() {
   await ensureOutExists()
   const runDir = path.join(artifactRoot, nowStamp())
@@ -203,6 +237,7 @@ async function run() {
       const context = await browser.newContext({
         viewport: scenario.viewport,
         deviceScaleFactor: 1,
+        reducedMotion: scenario.reducedMotion ?? 'no-preference',
       })
 
       try {
@@ -222,6 +257,10 @@ async function run() {
         if (scenario.checkMobileNav) {
           await assertMobileMenuPlacement(page, scenario.name)
           await assertNoHorizontalOverflow(page, `${scenario.name} (with menu open)`)
+        }
+
+        if (scenario.checkReducedMotion) {
+          await assertReducedMotionExperience(page, scenario.name)
         }
 
         const screenshotFile = path.join(runDir, `${scenario.name}.png`)


### PR DESCRIPTION
## Problem
The hero product visual felt strong but still needed explicit reduced-motion behavior, tighter mobile framing, and motion that reinforces product state transitions rather than decorative looping.

## What Changed
- Added reduced-motion-aware behavior in `ProductVisual` using `useReducedMotion` and stable rendered states.
- Replaced decorative infinite card bobbing with state-driven emphasis between Raw and Sanitized panels.
- Reduced mobile visual footprint by tightening shell spacing, editor min-heights, and core sizing while preserving readability.
- Added global `prefers-reduced-motion: reduce` rules for typing caret, token flights, marquee, ambient effects, and sheen-like loops.
- Extended visual smoke checks with a `home-mobile-reduced-motion` scenario and assertions for reduced-motion rendering.

## Validation
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:a11y-smoke`
- [x] `npm run test:visual-smoke`
- [x] `./scripts/codex-security-pre-review.sh` (initial run completed with no blocking findings; follow-up rerun hung in script internals after validations, then was terminated)

## Risks / Follow-ups
- Reduced-motion CSS now disables a broader set of decorative animations globally; if any route depends on one of those animations for comprehension, we should scope selectors further in a follow-up.
