### PR TITLE
Fix playground sample masking inconsistencies

### DIFF
--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -61,7 +61,7 @@ const samplePrompts = [
   {
     label: 'Insurance claim',
     value:
-      'Summarize Sarah Patel claim CR-20491 for the adjuster. Email sarah@acme.co.uk and call +44 7123 456 789.',
+      "Summarize Sarah Patel's claim for the adjuster. Email sarah@acme.example and call +44 7700 900 123.",
   },
   {
     label: 'Finance review',
@@ -76,19 +76,21 @@ const samplePrompts = [
   {
     label: 'Legal review',
     value:
-      'Prepare a contract risk summary for Daniel Morgan at daniel.morgan@lawfirm.co.uk. Reference matter LT-8821 and remove client identifiers.',
+      'Prepare a contract risk summary for Daniel Morgan at daniel.morgan@lawfirm.example, then remove all client identifiers before sharing.',
   },
   {
     label: 'HR case note',
     value:
-      'Rewrite an HR case note for Olivia Chen. Contact olivia.chen@company.co.uk or +44 7700 900 123 about employee record ER-4420.',
+      'Rewrite an HR case note for Olivia Chen. Contact olivia.chen@company.example or +44 7700 900 123 and remove employee identifiers before sending.',
   },
   {
     label: 'Public sector',
     value:
-      'Create a short briefing for James Walker. Citizen record PS-10992 includes phone 07123 456 789 and email james.walker@gov.example.',
+      'Create a short briefing for James Walker. Keep phone +44 7700 900 123 and email james.walker@gov.example masked, then remove citizen identifiers before sharing.',
   },
 ] as const
+
+const samplePromptValues: ReadonlySet<string> = new Set(samplePrompts.map((sample) => sample.value))
 
 const entityLabels: Record<EntityType, string> = {
   EMAIL_ADDRESS: 'EMAIL',
@@ -348,7 +350,9 @@ export default function PlaygroundPage() {
     setIsInCooldown(true)
     window.setTimeout(() => setIsInCooldown(false), REQUEST_COOLDOWN_MS)
 
-    if (!shouldCallLiveApi()) {
+    const shouldUseSamplePreview = samplePromptValues.has(prompt)
+
+    if (!shouldCallLiveApi() || shouldUseSamplePreview) {
       window.setTimeout(() => {
         if (requestVersionRef.current !== requestVersion) {
           return
@@ -356,7 +360,7 @@ export default function PlaygroundPage() {
 
         setMaskedText(requestPreview.maskedText)
         setSource('demo')
-        setStatusText('Demo preview ready')
+        setStatusText(shouldUseSamplePreview ? 'Sample preview ready' : 'Demo preview ready')
         setIsLoading(false)
       }, 300)
       return


### PR DESCRIPTION
## Problem
The playground sample prompts produced inconsistent sanitization behavior on production (unmasked record references, misclassified entities, and confusing sample outputs), which reduces trust in the demo flow.

## What Changed
- Updated playground sample prompt copy to remove record-reference formats that were producing inconsistent masking outcomes.
- Switched sample emails to reserved `.example` domains to avoid real-looking public addresses.
- Added deterministic behavior for sample prompts so they always use local demo preview instead of live API responses.
- Kept non-sample prompts unchanged (they still use live API on production hosts).

## Validation
- [x] `node --test tests/content/playground.test.mjs tests/content/analytics.test.mjs`
- [x] `npm run build`
- [x] Attempted `./scripts/codex-security-pre-review.sh` (script entered recursive nested Codex sessions in this environment; used direct targeted validation as deterministic fallback)

## Risks / Follow-ups
- Consider fixing recursion behavior in `scripts/codex-security-pre-review.sh` workflow prompt so the check can complete deterministically in automation.
