### PR TITLE
feat(site): link use-case / compare / security pages to /how-it-works

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -107,6 +107,9 @@ export default function ComparePage() {
               >
                 Talk to Sales
               </Link>
+              <Link href="/how-it-works" className="text-primary-light transition hover:text-primary">
+                How it works
+              </Link>
               <Link href="/presidio-alternative" className="text-primary-light transition hover:text-primary">
                 Presidio alternative
               </Link>

--- a/app/presidio-alternative/page.tsx
+++ b/app/presidio-alternative/page.tsx
@@ -260,6 +260,9 @@ export default function PresidioAlternativePage() {
             NeutralAI is not positioned as a from-scratch recognizer model. It uses proven open-source detection
             foundations and adds the gateway, policy, tokenization, audit, deployment, and UX layers regulated teams
             usually have to build themselves.
+            <Link href="/how-it-works" className="ml-2 font-semibold text-primary-light hover:text-primary">
+              See how those layers fit together.
+            </Link>
           </div>
         </div>
       </section>

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { motion } from 'framer-motion'
 import {
   ArrowRight,
@@ -138,6 +139,13 @@ export default function SecurityPage() {
                 <p className="mt-4 text-slate-400">
                   NeutralAI adds a policy gateway before external model providers so sensitive values can be detected, tokenized, and audited before prompt egress.
                 </p>
+                <Link
+                  href="/how-it-works"
+                  className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-primary-light transition hover:text-primary"
+                >
+                  Walk through the full flow
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
 
                 <div className="mt-6 grid gap-3">
                   {architectureSteps.map((step, index) => (

--- a/app/use-cases/UseCasePage.tsx
+++ b/app/use-cases/UseCasePage.tsx
@@ -107,6 +107,13 @@ export default function UseCasePage({ content }: { content: UseCasePageContent }
               <p className="mt-5 text-lg leading-8 text-slate-400">
                 NeutralAI is positioned between internal users, browser AI tools, application prompts, and external model providers so sensitive values can be removed or tokenized before egress.
               </p>
+              <Link
+                href="/how-it-works"
+                className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-primary-light transition hover:text-primary"
+              >
+                See exactly how the masking flow works
+                <ArrowRight className="h-4 w-4" />
+              </Link>
             </div>
 
             <div className="grid gap-4">

--- a/app/use-cases/page.tsx
+++ b/app/use-cases/page.tsx
@@ -36,6 +36,13 @@ export default function UseCasesIndexPage() {
             <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
               NeutralAI gives finance, healthcare, and legal teams a practical gateway pattern for masking sensitive data before AI prompts reach external model providers.
             </p>
+            <Link
+              href="/how-it-works"
+              className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-primary-light transition hover:text-primary"
+            >
+              See how the gateway works
+              <ArrowRight className="h-4 w-4" />
+            </Link>
           </div>
 
           <div className="mt-12 grid gap-4 lg:grid-cols-3">


### PR DESCRIPTION
Adds contextual links to the new **/how-it-works** page from the pages where visitors evaluate the mechanism.

## Surfaces (7 pages, 5 files)
- Shared use-case template → covers **/use-cases/legal**, **/use-cases/healthcare**, **/use-cases/financial-services** ('See exactly how the masking flow works')
- **/use-cases** index hero ('See how the gateway works')
- **/compare** hero link row ('How it works')
- **/presidio-alternative** build-vs-buy note ('See how those layers fit together')
- **/security** architecture block ('Walk through the full flow')

Additive only — no existing copy changed. Verified: `next build` OK, eslint clean.