### PR TITLE
design(website): homepage UX polish — mobile pricing, Audit beat, contrast, hover

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -52,7 +52,7 @@ export default function AboutPage() {
             animate={{ opacity: 1, y: 0 }}
             className="mx-auto max-w-4xl text-center"
           >
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">About NeutralAI</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">About NeutralAI</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
               Building a safer way to adopt AI
             </h1>
@@ -113,7 +113,7 @@ export default function AboutPage() {
       <section className="section bg-background-secondary">
         <div className="container-custom">
           <div className="text-center max-w-3xl mx-auto">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Principles</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Principles</p>
             <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">How we want the company to show up</h2>
           </div>
 

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -95,7 +95,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
           </Link>
 
           <header className="mt-10 border-b border-border pb-10">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">{post.category}</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">{post.category}</p>
             <h1 className="mt-5 font-heading text-4xl font-bold leading-tight md:text-6xl">{post.title}</h1>
             <p className="mt-5 text-lg leading-8 text-slate-300">{post.description}</p>
             <div className="mt-6 flex flex-wrap gap-4 text-sm text-slate-400">

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -37,7 +37,7 @@ export default function BlogIndexPage() {
 
           <div className="grid gap-10 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">NeutralAI Blog</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">NeutralAI Blog</p>
               <h1 className="mt-5 max-w-3xl font-heading text-4xl font-bold leading-[0.98] md:text-6xl">
                 Practical notes for secure enterprise AI adoption.
               </h1>
@@ -95,7 +95,7 @@ export default function BlogIndexPage() {
       <section className="section bg-background-secondary">
         <div className="container-custom">
           <div className="mb-8 max-w-3xl">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Latest Articles</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Latest Articles</p>
             <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">Start with the controls that unblock AI.</h2>
           </div>
 
@@ -123,7 +123,7 @@ export default function BlogIndexPage() {
                   </span>
                   <h3 className="mt-5 font-heading text-2xl font-semibold text-white">{post.title}</h3>
                   <p className="mt-3 text-sm leading-6 text-slate-400">{post.description}</p>
-                  <div className="mt-6 flex items-center justify-between gap-4 text-xs text-slate-500">
+                  <div className="mt-6 flex items-center justify-between gap-4 text-xs text-slate-400">
                     <span>{post.date}</span>
                     <span>{post.readingTime}</span>
                   </div>

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -79,7 +79,7 @@ export default function ComparePage() {
           <BackButton />
 
           <div className="mx-auto max-w-4xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Build vs Buy</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Build vs Buy</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
               More than a PII detector. A control layer your buyers can approve.
             </h1>
@@ -137,7 +137,7 @@ export default function ComparePage() {
       <section className="section bg-background-secondary">
         <div className="container-custom">
           <div className="mx-auto max-w-3xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Feature Comparison</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Feature Comparison</p>
             <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
               The hard part is not masking once. It is making it safe to operate.
             </h2>

--- a/app/components/GoogleSheetsLeadForm.tsx
+++ b/app/components/GoogleSheetsLeadForm.tsx
@@ -148,7 +148,7 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
             type="text"
             value={state.full_name}
             onChange={(event) => setState((prev) => ({ ...prev, full_name: event.target.value }))}
-            className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none"
+            className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-400 focus:border-primary focus:outline-none"
             autoComplete="name"
             maxLength={120}
           />
@@ -160,7 +160,7 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
             type="email"
             value={state.email}
             onChange={(event) => setState((prev) => ({ ...prev, email: event.target.value }))}
-            className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none"
+            className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-400 focus:border-primary focus:outline-none"
             autoComplete="email"
             maxLength={180}
           />
@@ -172,7 +172,7 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
             type="text"
             value={state.company_name}
             onChange={(event) => setState((prev) => ({ ...prev, company_name: event.target.value }))}
-            className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none"
+            className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-400 focus:border-primary focus:outline-none"
             autoComplete="organization"
             maxLength={180}
           />
@@ -205,7 +205,7 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
           onChange={(event) => setState((prev) => ({ ...prev, message: event.target.value }))}
           rows={5}
           maxLength={2000}
-          className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none"
+          className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-400 focus:border-primary focus:outline-none"
           placeholder="Share your AI workflow, data types, and deployment goals."
         />
       </label>
@@ -216,7 +216,7 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
           type="text"
           value={state.referral_source}
           onChange={(event) => setState((prev) => ({ ...prev, referral_source: event.target.value }))}
-          className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none"
+          className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-400 focus:border-primary focus:outline-none"
           maxLength={120}
         />
       </label>

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -143,7 +143,7 @@ export default function Navbar() {
               {link.name}
             </Link>
           ))}
-          <div className="pt-2 font-mono text-xs uppercase tracking-[0.2em] text-slate-500">More</div>
+          <div className="pt-2 font-mono text-xs uppercase tracking-[0.2em] text-slate-400">More</div>
           {secondaryNavLinks.map((link) => (
             <Link
               key={link.name}
@@ -154,7 +154,7 @@ export default function Navbar() {
               {link.name}
             </Link>
           ))}
-          <div className="pt-2 font-mono text-xs uppercase tracking-[0.2em] text-slate-500">Use Cases</div>
+          <div className="pt-2 font-mono text-xs uppercase tracking-[0.2em] text-slate-400">Use Cases</div>
           {useCaseLinks.map((link) => (
             <Link
               key={link.name}

--- a/app/components/home/CtaSection.tsx
+++ b/app/components/home/CtaSection.tsx
@@ -10,7 +10,7 @@ export default function CtaSection() {
 
       <div className="container-custom relative z-10">
         <div className="mx-auto max-w-4xl rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.95),rgba(2,6,23,0.97)),radial-gradient(circle_at_top_left,rgba(34,211,238,0.12),transparent_24%),radial-gradient(circle_at_top_right,rgba(249,115,22,0.18),transparent_22%)] px-6 py-10 text-center shadow-[0_32px_80px_rgba(2,8,23,0.5)] md:px-10 md:py-12">
-          <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Final CTA</p>
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Final CTA</p>
           <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
             Put the <span className="gradient-text-warm">control layer</span> in place before the rollout gets messy
           </h2>

--- a/app/components/home/DetectionEngine.tsx
+++ b/app/components/home/DetectionEngine.tsx
@@ -65,7 +65,7 @@ export default function DetectionEngine() {
                   {entityTypes.map((entity) => (
                     <div
                       key={entity}
-                      className="rounded-2xl border border-white/10 bg-white/[0.035] px-3 py-3 font-mono text-[11px] uppercase tracking-[0.14em] text-slate-200"
+                      className="rounded-2xl border border-white/10 bg-white/[0.035] px-3 py-3 font-mono text-[11px] uppercase tracking-[0.14em] text-slate-200 transition-colors hover:border-primary/40 hover:bg-primary/10 hover:text-primary-light"
                     >
                       {entity}
                     </div>
@@ -111,7 +111,7 @@ export default function DetectionEngine() {
 
               <div className="grid gap-3 sm:grid-cols-2">
                 {technicalTrustDetails.map((item) => (
-                  <div key={item.title} className="rounded-2xl border border-white/10 bg-white/[0.035] p-4">
+                  <div key={item.title} className="rounded-2xl border border-white/10 bg-white/[0.035] p-4 transition duration-300 hover:-translate-y-0.5 hover:border-primary/30">
                     <item.icon className="h-5 w-5 text-primary-light" />
                     <h4 className="mt-3 font-heading text-lg font-semibold text-slate-100">{item.title}</h4>
                     <p className="mt-2 text-sm leading-6 text-slate-300">{item.detail}</p>

--- a/app/components/home/DetectionEngine.tsx
+++ b/app/components/home/DetectionEngine.tsx
@@ -9,7 +9,7 @@ export default function DetectionEngine() {
           <div className="absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-primary/60 to-transparent" />
           <div className="grid gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Detection Engine</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Detection Engine</p>
               <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
                 The technical detail buyers ask for, <span className="gradient-text-warm">without the wall of docs.</span>
               </h2>

--- a/app/components/home/Hero.tsx
+++ b/app/components/home/Hero.tsx
@@ -7,7 +7,7 @@ function ProofCard({ proof }: { proof: (typeof complianceProofs)[number] }) {
   return (
     <div className="min-w-0 rounded-2xl border border-white/10 bg-white/[0.04] p-4">
       <proof.icon className="h-5 w-5 text-primary-light" />
-      <p className="mt-3 break-words text-[10px] uppercase tracking-[0.14em] text-slate-500 sm:text-xs sm:tracking-[0.18em]">
+      <p className="mt-3 break-words text-xs uppercase tracking-[0.16em] text-slate-400">
         {proof.label}
       </p>
       <p className="mt-1 break-words font-heading text-base font-semibold text-slate-100 sm:text-lg">{proof.value}</p>
@@ -98,7 +98,7 @@ export default function Hero() {
 
         <div className="mt-10 grid gap-5 xl:grid-cols-[1.12fr_0.88fr]">
           <div className="control-storyboard">
-            <p className="font-mono text-[12px] uppercase tracking-[0.28em] text-primary-light md:text-[13px]">How NeutralAI Protects Prompts</p>
+            <p className="font-mono text-[12px] uppercase tracking-[0.18em] text-primary-light md:text-[13px]">How NeutralAI Protects Prompts</p>
             <div className="mt-4 grid gap-4 sm:grid-cols-2">
               {[
                 ['Intercept', 'Prompt traffic is captured before external model routing.'],
@@ -115,7 +115,7 @@ export default function Hero() {
           </div>
 
           <div className="control-proof-panel rounded-2xl p-5 sm:p-6">
-            <p className="font-mono text-[12px] uppercase tracking-[0.28em] text-primary-light md:text-[13px]">Why teams choose it</p>
+            <p className="font-mono text-[12px] uppercase tracking-[0.18em] text-primary-light md:text-[13px]">Why teams choose it</p>
             <div className="mt-4 space-y-4">
               {[
                 'Stops raw PII and business identifiers before they reach external models',

--- a/app/components/home/HowItWorks.tsx
+++ b/app/components/home/HowItWorks.tsx
@@ -11,7 +11,7 @@ export default function HowItWorks() {
       <div className="container-custom">
         <div className="rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.96),rgba(2,6,23,0.96)),radial-gradient(circle_at_top_left,rgba(34,211,238,0.1),transparent_26%),radial-gradient(circle_at_top_right,rgba(249,115,22,0.12),transparent_24%)] p-6 shadow-[0_28px_70px_rgba(2,8,23,0.42)] md:p-8">
           <div className="mx-auto max-w-3xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">How It Works</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">How It Works</p>
             <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
               Three steps. <span className="gradient-text-warm">One control layer.</span>
             </h2>
@@ -30,7 +30,7 @@ export default function HowItWorks() {
                 transition={{ delay: index * 0.08 }}
                 className="relative overflow-hidden rounded-[24px] border border-white/10 bg-background/85 p-6"
               >
-                <div className="absolute right-5 top-5 font-mono text-[11px] uppercase tracking-[0.24em] text-slate-600">
+                <div className="absolute right-5 top-5 font-mono text-[11px] uppercase tracking-[0.24em] text-slate-400">
                   0{index + 1}
                 </div>
                 <div className={`flex h-12 w-12 items-center justify-center rounded-2xl ${index === 1 ? 'bg-[rgba(249,115,22,0.14)]' : 'bg-primary/10'}`}>

--- a/app/components/home/HowItWorks.tsx
+++ b/app/components/home/HowItWorks.tsx
@@ -28,7 +28,7 @@ export default function HowItWorks() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ delay: index * 0.08 }}
-                className="relative overflow-hidden rounded-[24px] border border-white/10 bg-background/85 p-6"
+                className="group relative overflow-hidden rounded-[24px] border border-white/10 bg-background/85 p-6 transition duration-300 hover:-translate-y-1 hover:border-primary/40 hover:shadow-[0_18px_44px_rgba(2,8,23,0.5)]"
               >
                 <div className="absolute right-5 top-5 font-mono text-[11px] uppercase tracking-[0.24em] text-slate-400">
                   0{index + 1}

--- a/app/components/home/PricingSection.tsx
+++ b/app/components/home/PricingSection.tsx
@@ -6,6 +6,16 @@ import { CheckCircle2 } from 'lucide-react'
 import { advancedPricingPlans, pricingFaqs, primaryPricingPlans } from '../../data/homepage'
 import SectionIntro from './SectionIntro'
 
+const comparisonTiers = ['Free', 'Starter', 'Team', 'Business', 'Enterprise'] as const
+
+const comparisonRows: ReadonlyArray<readonly [string, string, string, string, string, string]> = [
+  ['Masking requests', '1k', '10K', '100K', '500K', 'Custom'],
+  ['Managed AI credit', '£1 trial', '£3', '£10', '£25', 'Custom'],
+  ['Provider spend model', 'Managed sandbox', 'Managed eval', 'BYOK recommended', 'BYOK expected', 'Customer-owned'],
+  ['API key management', 'Basic', 'Basic', 'Team', 'Full lifecycle', 'Scoped controls'],
+  ['SSO / SIEM path', 'No', 'No', 'Roadmap', 'Export path', 'Required'],
+]
+
 export default function PricingSection() {
   const [annualBilling, setAnnualBilling] = useState(false)
 
@@ -49,7 +59,7 @@ export default function PricingSection() {
         <p className="mx-auto mt-5 max-w-4xl text-center text-sm leading-6 text-slate-400">
           Plans include masking requests. Managed AI usage is covered by small included credits for evaluation. Production model usage can run through BYOK, customer provider accounts, or prepaid top-ups.
         </p>
-        <p className="mx-auto mt-2 max-w-4xl text-center text-xs leading-6 text-slate-500">
+        <p className="mx-auto mt-2 max-w-4xl text-center text-xs leading-6 text-slate-400">
           All listed GBP prices are excluding VAT. VAT may apply based on billing country and entity status.
         </p>
 
@@ -180,33 +190,42 @@ export default function PricingSection() {
           ))}
         </div>
 
-        <div className="mt-8 overflow-x-auto rounded-[28px] border border-white/10 bg-white/[0.04]">
-          <div className="min-w-[1040px]">
-            <div className="grid grid-cols-6 border-b border-white/10 text-sm text-slate-300">
-              <div className="px-4 py-3 font-semibold text-slate-100">Capability</div>
-              <div className="px-4 py-3 font-semibold text-slate-100">Free</div>
-              <div className="px-4 py-3 font-semibold text-slate-100">Starter</div>
-              <div className="px-4 py-3 font-semibold text-slate-100">Team</div>
-              <div className="px-4 py-3 font-semibold text-slate-100">Business</div>
-              <div className="px-4 py-3 font-semibold text-slate-100">Enterprise</div>
-            </div>
-            {[
-              ['Masking requests', '1k', '10K', '100K', '500K', 'Custom'],
-              ['Managed AI credit', '£1 trial', '£3', '£10', '£25', 'Custom'],
-              ['Provider spend model', 'Managed sandbox', 'Managed eval', 'BYOK recommended', 'BYOK expected', 'Customer-owned'],
-              ['API key management', 'Basic', 'Basic', 'Team', 'Full lifecycle', 'Scoped controls'],
-              ['SSO / SIEM path', 'No', 'No', 'Roadmap', 'Export path', 'Required'],
-            ].map(([label, free, starter, team, business, enterprise]) => (
-              <div key={label} className="grid grid-cols-6 border-b border-white/10 text-sm text-slate-300 last:border-b-0">
-                <div className="px-4 py-3 text-slate-100">{label}</div>
-                <div className="px-4 py-3">{free}</div>
-                <div className="px-4 py-3">{starter}</div>
-                <div className="px-4 py-3">{team}</div>
-                <div className="px-4 py-3">{business}</div>
-                <div className="px-4 py-3">{enterprise}</div>
-              </div>
+        {/* Desktop: full comparison grid */}
+        <div className="mt-8 hidden overflow-hidden rounded-[28px] border border-white/10 bg-white/[0.04] lg:block">
+          <div className="grid grid-cols-6 border-b border-white/10 text-sm text-slate-300">
+            <div className="px-4 py-3 font-semibold text-slate-100">Capability</div>
+            {comparisonTiers.map((tier) => (
+              <div key={tier} className="px-4 py-3 font-semibold text-slate-100">{tier}</div>
             ))}
           </div>
+          {comparisonRows.map(([label, ...values]) => (
+            <div key={label} className="grid grid-cols-6 border-b border-white/10 text-sm text-slate-300 last:border-b-0">
+              <div className="px-4 py-3 text-slate-100">{label}</div>
+              {values.map((value, i) => (
+                <div key={comparisonTiers[i]} className="px-4 py-3">{value}</div>
+              ))}
+            </div>
+          ))}
+        </div>
+
+        {/* Mobile/tablet: one card per plan, listing all its capabilities — no horizontal scroll */}
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:hidden">
+          {comparisonTiers.map((tier, tierIdx) => (
+            <div key={tier} className="rounded-[24px] border border-white/10 bg-white/[0.04] p-5">
+              <h4 className="font-heading text-base font-semibold text-primary-light">{tier}</h4>
+              <dl className="mt-3 space-y-2">
+                {comparisonRows.map(([label, ...values]) => (
+                  <div
+                    key={label}
+                    className="flex items-baseline justify-between gap-4 border-b border-white/5 pb-2 last:border-b-0 last:pb-0"
+                  >
+                    <dt className="text-sm text-slate-400">{label}</dt>
+                    <dd className="text-right text-sm font-medium text-slate-200">{values[tierIdx]}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          ))}
         </div>
 
         <div className="mt-10">

--- a/app/components/home/ProductSurface.tsx
+++ b/app/components/home/ProductSurface.tsx
@@ -127,7 +127,7 @@ export default function ProductSurface() {
                 whileInView={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
                 viewport={shouldReduceMotion ? undefined : { once: true }}
                 transition={shouldReduceMotion ? undefined : { delay: index * 0.08 }}
-                className="accent-card rounded-[24px] p-6"
+                className="accent-card rounded-[24px] p-6 transition duration-300 hover:-translate-y-1 hover:shadow-[0_18px_44px_rgba(2,8,23,0.5)]"
               >
                 <div className="flex items-center justify-between gap-3">
                   <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/5">

--- a/app/components/home/ProductSurface.tsx
+++ b/app/components/home/ProductSurface.tsx
@@ -14,7 +14,7 @@ export default function ProductSurface() {
         <div className="accent-panel rounded-[32px] p-6 md:p-8">
           <div className="grid gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Adoption Without Friction</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Adoption Without Friction</p>
               <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
                 Secure AI usage <span className="gradient-text-warm">without changing habits</span>
               </h2>
@@ -110,7 +110,7 @@ export default function ProductSurface() {
 
         <div className="mt-14">
           <div className="mx-auto max-w-3xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Deployment Options</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Deployment Options</p>
             <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
               One product, <span className="gradient-text-warm">multiple deployment paths</span>
             </h2>

--- a/app/components/home/ProductVisual.tsx
+++ b/app/components/home/ProductVisual.tsx
@@ -111,7 +111,7 @@ export default function ProductVisual() {
     <div className="signal-simple-shell rounded-[28px] p-3 sm:p-4 md:p-6 xl:p-7">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/80 pb-3 md:pb-4">
         <div>
-          <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Live Narrative</p>
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Live Narrative</p>
           <h2 className="mt-2 font-heading text-xl font-semibold sm:text-2xl">
             How NeutralAI works in one view
           </h2>
@@ -128,7 +128,7 @@ export default function ProductVisual() {
             className={`rounded-xl border px-2.5 py-2 text-center font-mono text-[10px] uppercase tracking-[0.18em] sm:text-[11px] ${
               index <= activePhaseIndex
                 ? 'border-primary/40 bg-primary/10 text-primary-light'
-                : 'border-white/10 bg-white/[0.02] text-slate-500'
+                : 'border-white/10 bg-white/[0.02] text-slate-400'
             }`}
           >
             {step}

--- a/app/components/home/ProductVisual.tsx
+++ b/app/components/home/ProductVisual.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { motion, useReducedMotion } from 'framer-motion'
-import { ShieldCheck } from 'lucide-react'
+import { ShieldCheck, FileCheck2 } from 'lucide-react'
 import {
   rawPromptCharCount,
   rawPromptLines,
@@ -11,12 +11,14 @@ import {
   sanitizedPromptLines,
 } from './promptAnimation'
 
+type Phase = 'typingRaw' | 'highlightRaw' | 'sending' | 'typingSanitized' | 'audit' | 'pauseSanitized'
+
 export default function ProductVisual() {
-  const [phase, setPhase] = useState<'typingRaw' | 'highlightRaw' | 'sending' | 'typingSanitized' | 'pauseSanitized'>('typingRaw')
+  const [phase, setPhase] = useState<Phase>('typingRaw')
   const [rawTypedChars, setRawTypedChars] = useState(0)
   const [sanitizedTypedChars, setSanitizedTypedChars] = useState(0)
   const shouldReduceMotion = useReducedMotion()
-  const phaseOrder = ['Detect', 'Mask', 'Route'] as const
+  const phaseOrder = ['Detect', 'Mask', 'Route', 'Audit'] as const
 
   useEffect(() => {
     if (shouldReduceMotion) {
@@ -57,9 +59,15 @@ export default function ProductVisual() {
         }, typingSpeedMs)
       } else {
         timer = setTimeout(() => {
-          setPhase('pauseSanitized')
-        }, 900)
+          setPhase('audit')
+        }, 700)
       }
+    }
+
+    if (phase === 'audit') {
+      timer = setTimeout(() => {
+        setPhase('pauseSanitized')
+      }, 1700)
     }
 
     if (phase === 'pauseSanitized') {
@@ -67,7 +75,7 @@ export default function ProductVisual() {
         setRawTypedChars(0)
         setSanitizedTypedChars(0)
         setPhase('typingRaw')
-      }, 1200)
+      }, 1100)
     }
 
     return () => {
@@ -90,7 +98,9 @@ export default function ProductVisual() {
     (displayPhase === 'typingRaw' || displayPhase === 'highlightRaw' || displayPhase === 'sending')
   const sanitizedPanelActive =
     !shouldReduceMotion &&
-    (displayPhase === 'typingSanitized' || displayPhase === 'pauseSanitized')
+    (displayPhase === 'typingSanitized' || displayPhase === 'audit' || displayPhase === 'pauseSanitized')
+  const auditVisible =
+    shouldReduceMotion || displayPhase === 'audit' || displayPhase === 'pauseSanitized'
   const beamDotAnimate = shouldReduceMotion
     ? { x: 0, opacity: 0.2 }
     : showFlights
@@ -100,12 +110,14 @@ export default function ProductVisual() {
     ? { duration: 0 }
     : { duration: 1.1, repeat: showFlights ? Infinity : 0, ease: 'easeInOut' as const }
   const activePhaseIndex = shouldReduceMotion
-    ? 2
+    ? 3
     : phase === 'typingRaw' || phase === 'highlightRaw'
       ? 0
       : phase === 'sending'
         ? 1
-        : 2
+        : phase === 'typingSanitized'
+          ? 2
+          : 3
 
   return (
     <div className="signal-simple-shell rounded-[28px] p-3 sm:p-4 md:p-6 xl:p-7">
@@ -121,7 +133,7 @@ export default function ProductVisual() {
         </div>
       </div>
 
-      <div className="mt-3 grid grid-cols-3 gap-2 md:mt-4 md:gap-3">
+      <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4 md:mt-4 md:gap-3">
         {phaseOrder.map((step, index) => (
           <div
             key={step}
@@ -250,6 +262,24 @@ export default function ProductVisual() {
           </div>
         </div>
       </div>
+
+      {/* Audit / evidence beat — completes the Detect → Mask → Route → Audit story */}
+      <motion.div
+        initial={false}
+        animate={auditVisible ? { opacity: 1, y: 0 } : { opacity: 0, y: 12 }}
+        transition={{ duration: 0.5, ease: 'easeOut' }}
+        className="mt-3 flex items-center gap-3 rounded-2xl border border-emerald-400/30 bg-emerald-950/20 px-3.5 py-3 md:mt-4 md:px-4"
+      >
+        <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-emerald-400/40 bg-emerald-500/10">
+          <FileCheck2 className="h-5 w-5 text-emerald-300" />
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-slate-100">Audit evidence recorded</p>
+          <p className="truncate font-mono text-[11px] text-emerald-300/90 sm:text-xs">
+            3 entities tokenized · policy PII-Mask-v3 · export-ready
+          </p>
+        </div>
+      </motion.div>
     </div>
   )
 }

--- a/app/components/home/SectionIntro.tsx
+++ b/app/components/home/SectionIntro.tsx
@@ -13,9 +13,12 @@ export default function SectionIntro({
 }: SectionIntroProps) {
   return (
     <div className={centered ? 'mx-auto max-w-3xl text-center' : 'max-w-3xl'}>
-      <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">{eyebrow}</p>
-      <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">{title}</h2>
-      <p className="mt-5 text-lg text-slate-400">{description}</p>
+      <div className={`flex items-center gap-2.5 ${centered ? 'justify-center' : ''}`}>
+        <span className="h-px w-6 bg-primary/60" aria-hidden="true" />
+        <p className="font-mono text-xs font-medium uppercase tracking-[0.16em] text-primary-light">{eyebrow}</p>
+      </div>
+      <h2 className="mt-4 text-balance font-heading text-3xl font-bold tracking-tight md:text-5xl">{title}</h2>
+      <p className="mt-5 text-pretty text-lg leading-relaxed text-slate-300">{description}</p>
     </div>
   )
 }

--- a/app/components/home/SocialProofSection.tsx
+++ b/app/components/home/SocialProofSection.tsx
@@ -146,7 +146,7 @@ export default function SocialProofSection() {
 
         <div className="mt-8 grid gap-4 lg:grid-cols-[1.05fr_0.95fr]">
           <div className="proof-ledger rounded-[28px] p-6 md:p-7">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Proof-backed metrics</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Proof-backed metrics</p>
             <h3 className="mt-4 font-heading text-3xl font-semibold text-white">Concrete signals buyers can verify.</h3>
             <p className="mt-4 text-sm leading-7 text-slate-300">
               These numbers come from product surfaces, benchmark artifacts, and documented website claims. Production usage counts and customer outcomes are published only when an approved source exists.

--- a/app/components/home/TrustSection.tsx
+++ b/app/components/home/TrustSection.tsx
@@ -12,7 +12,7 @@ export default function TrustSection() {
         <div className="rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.96),rgba(2,6,23,0.96)),radial-gradient(circle_at_18%_18%,rgba(34,211,238,0.14),transparent_24%),radial-gradient(circle_at_86%_12%,rgba(249,115,22,0.14),transparent_22%)] p-6 shadow-[0_28px_70px_rgba(2,8,23,0.42)] md:p-8">
           <div className="grid gap-10 lg:grid-cols-[0.92fr_1.08fr] lg:items-start">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Why Trust NeutralAI</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Why Trust NeutralAI</p>
               <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
                 Proof your security team <span className="gradient-text-warm">can trust.</span>
               </h2>
@@ -49,12 +49,12 @@ export default function TrustSection() {
         <div id="benchmark-proof" className="mt-10 scroll-mt-28 overflow-hidden rounded-[28px] border border-primary/20 bg-[linear-gradient(135deg,rgba(6,182,212,0.12),rgba(15,23,42,0.94)_42%,rgba(249,115,22,0.10))] p-6">
           <div className="grid gap-7 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Benchmark proof</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Benchmark proof</p>
               <h3 className="mt-4 font-heading text-3xl font-semibold">Measured against a reproducible Presidio-vanilla baseline.</h3>
               <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300 md:text-base">
                 NeutralAI combines proven open-source detection primitives with multilingual calibration, masking, and enforcement layers. The gateway repo remains the measurement source of truth, while the website links buyers to the published methodology and benchmark surface.
               </p>
-              <p className="mt-3 text-xs leading-6 text-slate-500">
+              <p className="mt-3 text-xs leading-6 text-slate-400">
                 Product benchmark, not a third-party independent evaluation.
               </p>
             </div>
@@ -66,7 +66,7 @@ export default function TrustSection() {
                 ['Holdout PERSON F1', benchmarkProof.personHoldoutF1],
               ].map(([label, value]) => (
                 <div key={label} className="rounded-2xl border border-white/10 bg-background/80 p-5">
-                  <p className="text-xs uppercase tracking-[0.16em] text-slate-500">{label}</p>
+                  <p className="text-xs uppercase tracking-[0.16em] text-slate-400">{label}</p>
                   <p className="mt-2 font-heading text-3xl font-semibold text-white">{value}</p>
                 </div>
               ))}
@@ -87,12 +87,12 @@ export default function TrustSection() {
         <div id="healthcare-trust" className="mt-10 scroll-mt-28 overflow-hidden rounded-[28px] border border-emerald-400/20 bg-[linear-gradient(135deg,rgba(16,185,129,0.12),rgba(15,23,42,0.96)_46%,rgba(6,182,212,0.10))] p-6">
           <div className="grid gap-8 lg:grid-cols-[0.82fr_1.18fr] lg:items-start">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-emerald-300">Healthcare trust</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-emerald-300">Healthcare trust</p>
               <h3 className="mt-4 font-heading text-3xl font-semibold">HIPAA-ready deployment support without blanket claims.</h3>
               <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300 md:text-base">
                 NeutralAI helps healthcare and healthtech teams protect PHI before prompts reach AI providers, with PHI-aware controls, audit evidence, and BAA review support for eligible deployments.
               </p>
-              <p className="mt-3 text-xs leading-6 text-slate-500">
+              <p className="mt-3 text-xs leading-6 text-slate-400">
                 Not legal advice. BAA terms, deployment model, and customer obligations require review.
               </p>
 
@@ -121,12 +121,12 @@ export default function TrustSection() {
         <div id="document-redaction-proof" className="mt-10 scroll-mt-28 overflow-hidden rounded-[28px] border border-cyan-300/20 bg-[linear-gradient(135deg,rgba(14,165,233,0.12),rgba(15,23,42,0.96)_48%,rgba(148,163,184,0.10))] p-6">
           <div className="grid gap-8 lg:grid-cols-[0.86fr_1.14fr] lg:items-start">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-cyan-200">Document proof</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-cyan-200">Document proof</p>
               <h3 className="mt-4 font-heading text-3xl font-semibold">Protect files before document content reaches AI workflows.</h3>
               <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300 md:text-base">
                 NeutralAI document handling extends PII protection beyond chat prompts, with document-aware extraction, redaction output, and audit-safe finding metadata for supported upload flows.
               </p>
-              <p className="mt-3 text-xs leading-6 text-slate-500">
+              <p className="mt-3 text-xs leading-6 text-slate-400">
                 Supports simple text PDFs today. OCR-backed image detection depends on configured OCR runtime.
               </p>
             </div>
@@ -146,7 +146,7 @@ export default function TrustSection() {
         <div className="mt-10 rounded-[28px] border border-accent-cta/20 bg-[linear-gradient(180deg,rgba(249,115,22,0.08),rgba(15,23,42,0.92))] p-6">
           <div className="grid gap-6 lg:grid-cols-[1fr_auto] lg:items-center">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Operational Signals</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Operational Signals</p>
               <h3 className="mt-4 font-heading text-3xl font-semibold">Live product. Easy to verify.</h3>
               <p className="mt-4 max-w-3xl text-slate-300">
                 You can quickly check that NeutralAI is live: <span className="text-primary-light">api.neutralai.co.uk</span> is public, benchmark pages are published, and gateway latency is tracked separately from model response time.

--- a/app/components/home/WhyItMatters.tsx
+++ b/app/components/home/WhyItMatters.tsx
@@ -10,7 +10,7 @@ export default function WhyItMatters() {
         <div className="accent-panel rounded-[32px] p-6 md:p-8">
           <div className="grid gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Why It Matters</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Why It Matters</p>
               <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
                 AI usage grows faster than <span className="gradient-text-warm">approval paths.</span>
               </h2>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -76,7 +76,7 @@ function ContactFormPanel({ intent }: { intent: ContactIntent }) {
     <div className="card p-6 md:p-8">
       <div className="flex flex-col gap-4 border-b border-white/10 pb-6 md:flex-row md:items-start md:justify-between">
         <div>
-          <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">{copy.eyebrow}</p>
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">{copy.eyebrow}</p>
           <h2 className="mt-3 font-heading text-3xl font-bold">{copy.title}</h2>
           <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-400">
             {copy.description}
@@ -131,7 +131,7 @@ export default function ContactPage() {
             animate={{ opacity: 1, y: 0 }}
             className="mx-auto max-w-4xl text-center"
           >
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Contact NeutralAI</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Contact NeutralAI</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
               Schedule a demo for your AI security rollout
             </h1>
@@ -151,7 +151,7 @@ export default function ContactPage() {
       <section className="section bg-background-secondary">
         <div className="container-custom">
           <div className="mx-auto mb-8 max-w-3xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Other routes</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Other routes</p>
             <h2 className="mt-4 font-heading text-3xl font-bold">Email and runtime checks</h2>
           </div>
           <div className="grid gap-6 lg:grid-cols-3">
@@ -195,7 +195,7 @@ export default function ContactPage() {
               viewport={{ once: true }}
               className="card p-8"
             >
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">What to include</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">What to include</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">Make your first message useful</h2>
               <ul className="mt-6 space-y-4 text-slate-300">
                 <li className="flex items-start gap-3">
@@ -220,7 +220,7 @@ export default function ContactPage() {
               transition={{ delay: 0.08 }}
               className="card p-8"
             >
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Evaluation flow</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Evaluation flow</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">What happens next</h2>
               <ol className="mt-6 space-y-5">
                 {onboardingSteps.map((step, index) => (

--- a/app/contact/thanks/page.tsx
+++ b/app/contact/thanks/page.tsx
@@ -30,7 +30,7 @@ export default function ContactThanksPage() {
             <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl border border-primary/25 bg-primary/10">
               <CheckCircle2 className="h-8 w-8 text-primary-light" />
             </div>
-            <p className="mt-8 font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Message sent</p>
+            <p className="mt-8 font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Message sent</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
               We&apos;ll get back to you within 1 business day
             </h1>

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -54,7 +54,7 @@ export default function DemoPage() {
 
         <div className="container-custom relative z-10">
           <div className="mx-auto max-w-4xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Product walkthrough</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Product walkthrough</p>
             <h1 className="mt-5 font-heading text-4xl font-bold leading-tight md:text-6xl">
               See how NeutralAI controls sensitive data before AI usage spreads.
             </h1>
@@ -160,7 +160,7 @@ export default function DemoPage() {
       <section className="section">
         <div className="container-custom">
           <div className="mx-auto max-w-3xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">What the demo should cover</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">What the demo should cover</p>
             <h2 className="mt-4 font-heading text-3xl font-semibold text-white md:text-5xl">
               A buyer-ready walkthrough, not a feature dump.
             </h2>

--- a/app/developers/page.tsx
+++ b/app/developers/page.tsx
@@ -173,7 +173,7 @@ export default function DevelopersPage() {
       <section className="section bg-background-secondary/40">
         <div className="container-custom">
           <div className="max-w-3xl">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Quickstart</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Quickstart</p>
             <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">Three steps to a masked prompt.</h2>
           </div>
           <div className="mt-10 grid gap-4 md:grid-cols-3">
@@ -194,14 +194,14 @@ export default function DevelopersPage() {
         <div className="container-custom">
           <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
             <div className="min-w-0">
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">SDKs</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">SDKs</p>
               <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">Python and Node SDKs are published.</h2>
               <p className="mt-5 text-lg leading-8 text-slate-400">
                 Official thin clients for the masking API, published to PyPI and npm. Install one and point it at the hosted gateway — all PII detection and masking happens server-side.
               </p>
               <div className="mt-6 space-y-2 rounded-2xl border border-white/10 bg-[#050814] p-4 font-mono text-sm text-slate-200">
-                <p><span className="select-none text-slate-500">$ </span>python -m pip install neutralai-sdk</p>
-                <p><span className="select-none text-slate-500">$ </span>npm install neutralai-node-sdk</p>
+                <p><span className="select-none text-slate-400">$ </span>python -m pip install neutralai-sdk</p>
+                <p><span className="select-none text-slate-400">$ </span>npm install neutralai-node-sdk</p>
               </div>
             </div>
 
@@ -229,7 +229,7 @@ export default function DevelopersPage() {
         <div className="container-custom">
           <div className="grid gap-10 lg:grid-cols-[0.88fr_1.12fr] lg:items-start">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Authentication</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Authentication</p>
               <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">Keep API keys server-side.</h2>
               <p className="mt-5 text-lg leading-8 text-slate-400">
                 API calls use the <code className="rounded bg-white/10 px-1.5 py-0.5 text-primary-light">x-api-key</code> header. Treat keys as backend secrets, rotate them through the app, and avoid logging prompts or credentials.

--- a/app/install-extension/page.tsx
+++ b/app/install-extension/page.tsx
@@ -57,7 +57,7 @@ export default function InstallExtensionPage() {
 
         <div className="container-custom relative z-10">
           <div className="mx-auto max-w-4xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">NeutralAI Interceptor</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">NeutralAI Interceptor</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
               Install the browser extension without guessing the rollout path
             </h1>
@@ -125,7 +125,7 @@ export default function InstallExtensionPage() {
         <div className="container-custom">
           <div className="grid gap-8 lg:grid-cols-[1.05fr_0.95fr]">
             <div className="card p-8">
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Self-serve sign-in</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Self-serve sign-in</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">How unmanaged installs authenticate</h2>
               <p className="mt-4 text-slate-400">
                 The extension uses the NeutralAI app domain for sign-in, session checks, and short-lived auth context retrieval. During store review or guided onboarding, these public URLs should be reachable and documented.
@@ -140,7 +140,7 @@ export default function InstallExtensionPage() {
             </div>
 
             <div className="card p-8">
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">What the extension does</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">What the extension does</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">Single-purpose behaviour</h2>
               <p className="mt-4 text-slate-400">
                 NeutralAI Interceptor helps users mask sensitive prompt data before it is submitted from supported AI web applications. It is designed to run on supported AI hosts, call the NeutralAI API boundary, and avoid remotely hosted executable code.

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -5,7 +5,7 @@ export default function NotFoundPage() {
     <main className="min-h-screen pt-24">
       <section className="container-custom py-20 md:py-24">
         <div className="mx-auto max-w-2xl rounded-[28px] border border-white/10 bg-background-secondary/70 p-8 text-center md:p-10">
-          <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">404</p>
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">404</p>
           <h1 className="mt-4 font-heading text-4xl font-bold md:text-5xl">Page not found</h1>
           <p className="mt-4 text-base leading-7 text-slate-300">
             The page you requested is unavailable or has moved. You can continue from the homepage or

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -536,7 +536,7 @@ export default function PlaygroundPage() {
                 }}
                 rows={10}
                 maxLength={MAX_PROMPT_LENGTH + 200}
-                className="mt-5 min-h-[260px] w-full resize-y rounded-2xl border border-white/10 bg-[#020617] p-4 font-mono text-sm leading-7 text-slate-100 outline-none transition placeholder:text-slate-600 focus:border-primary"
+                className="mt-5 min-h-[260px] w-full resize-y rounded-2xl border border-white/10 bg-[#020617] p-4 font-mono text-sm leading-7 text-slate-100 outline-none transition placeholder:text-slate-400 focus:border-primary"
                 placeholder="Write your prompt here, or choose a sample prompt below."
               />
 

--- a/app/presidio-alternative/page.tsx
+++ b/app/presidio-alternative/page.tsx
@@ -219,7 +219,7 @@ export default function PresidioAlternativePage() {
         <div className="container-custom">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Feature comparison</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Feature comparison</p>
               <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
                 What you still need to build around Presidio
               </h2>
@@ -274,7 +274,7 @@ export default function PresidioAlternativePage() {
           <div className="rounded-[32px] border border-primary/20 bg-[linear-gradient(180deg,rgba(15,23,42,0.95),rgba(2,6,23,0.97)),radial-gradient(circle_at_top_right,rgba(34,211,238,0.18),transparent_24%)] px-6 py-10 md:px-10">
             <div className="grid gap-8 lg:grid-cols-[1fr_0.82fr] lg:items-center">
               <div>
-                <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Customer-safe proof</p>
+                <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Customer-safe proof</p>
                 <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
                   Use the website for the sales story. Use the gateway for the proof source.
                 </h2>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -42,14 +42,14 @@ export default function PrivacyPage() {
 
         <div className="container-custom relative z-10">
           <div className="mx-auto max-w-4xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">NeutralAI Interceptor</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">NeutralAI Interceptor</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
               Browser extension privacy policy
             </h1>
             <p className="mt-6 text-xl text-slate-400">
               This privacy page exists for browser store review and public reference. It explains how NeutralAI Interceptor operates on supported AI web apps, what service endpoints it contacts, and what telemetry posture the product is designed to maintain.
             </p>
-            <p className="mt-4 text-sm text-slate-500">
+            <p className="mt-4 text-sm text-slate-400">
               Privacy questions can be sent to{' '}
               <a href={`mailto:${siteConfig.privacyEmail}`} className="text-primary-light hover:text-primary">
                 {siteConfig.privacyEmail}

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -99,7 +99,7 @@ export default function SecurityPage() {
             animate={{ opacity: 1, y: 0 }}
             className="mx-auto max-w-4xl text-center"
           >
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Security Overview</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Security Overview</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
               Launch trust starts with an accurate posture
             </h1>
@@ -134,7 +134,7 @@ export default function SecurityPage() {
           <div className="mt-10 rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.96),rgba(2,6,23,0.96)),radial-gradient(circle_at_top_left,rgba(34,211,238,0.12),transparent_24%)] p-6 md:p-8">
             <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
               <div>
-                <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Technical controls</p>
+                <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Technical controls</p>
                 <h2 className="mt-4 font-heading text-3xl font-bold">Mask first, then route the sanitized request</h2>
                 <p className="mt-4 text-slate-400">
                   NeutralAI adds a policy gateway before external model providers so sensitive values can be detected, tokenized, and audited before prompt egress.
@@ -185,7 +185,7 @@ export default function SecurityPage() {
               viewport={{ once: true }}
               className="card p-8"
             >
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Readiness snapshot</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Readiness snapshot</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">Current public position</h2>
               <ul className="mt-6 space-y-4">
                 {readinessItems.map((item) => (
@@ -204,7 +204,7 @@ export default function SecurityPage() {
               transition={{ delay: 0.08 }}
               className="card p-8"
             >
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Useful links</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Useful links</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">Validate or get in touch</h2>
               <div className="mt-6 space-y-4">
                 <a

--- a/app/support/browser-extension/page.tsx
+++ b/app/support/browser-extension/page.tsx
@@ -63,7 +63,7 @@ export default function BrowserExtensionSupportPage() {
 
         <div className="container-custom relative z-10">
           <div className="mx-auto max-w-4xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Browser extension support</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Browser extension support</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
               Public support reference for NeutralAI Interceptor
             </h1>
@@ -78,7 +78,7 @@ export default function BrowserExtensionSupportPage() {
         <div className="container-custom">
           <div className="grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
             <div className="card p-8">
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Requested permissions</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Requested permissions</p>
               <div className="mt-6 space-y-5">
                 {permissionExplanations.map((item) => (
                   <div key={item.permission} className="rounded-2xl border border-border bg-background px-5 py-5">
@@ -96,7 +96,7 @@ export default function BrowserExtensionSupportPage() {
 
             <div className="space-y-6">
               <div className="card p-8">
-                <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Support contact</p>
+                <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Support contact</p>
                 <h2 className="mt-4 font-heading text-3xl font-bold">Need help or a review response?</h2>
                 <a href={extensionLinks.supportMailto} className="mt-6 inline-flex items-center gap-2 text-lg text-primary-light hover:text-primary">
                   {siteConfig.supportEmail}
@@ -116,7 +116,7 @@ export default function BrowserExtensionSupportPage() {
               </div>
 
               <div className="card p-8">
-                <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Review notes</p>
+                <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Review notes</p>
                 <div className="mt-4 space-y-4 text-sm leading-6 text-slate-400">
                   <p>
                     Host permissions are limited to supported AI web applications where prompt masking runs, plus NeutralAI-owned app and API domains used for session detection, auth context, masking, remote configuration, and telemetry.
@@ -138,7 +138,7 @@ export default function BrowserExtensionSupportPage() {
         <div className="container-custom">
           <div className="grid gap-8 lg:grid-cols-[1fr_1fr]">
             <div className="card p-8">
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Self-serve auth flow</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Self-serve auth flow</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">Public app and API endpoints</h2>
               <ul className="mt-6 space-y-4">
                 {integrationEndpoints.map((endpoint) => (
@@ -150,7 +150,7 @@ export default function BrowserExtensionSupportPage() {
             </div>
 
             <div className="card p-8">
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Enterprise rollout</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Enterprise rollout</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">Policy-managed deployment</h2>
               <div className="mt-4 space-y-4 text-sm leading-6 text-slate-400">
                 <p>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -126,7 +126,7 @@ export default function TermsPage() {
                     <div key={j}>
                       {'label' in item && (
                         <div className="mb-4">
-                          <span className="text-slate-500 font-medium">{item.label}: </span>
+                          <span className="text-slate-400 font-medium">{item.label}: </span>
                           <span className="text-slate-300">{item.value}</span>
                         </div>
                       )}
@@ -167,10 +167,10 @@ export default function TermsPage() {
               <p className="text-slate-400">
                 By accessing or using our services, you acknowledge that you have read, understood, and agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use our services.
               </p>
-              <p className="text-slate-500 text-sm mt-4">
+              <p className="text-slate-400 text-sm mt-4">
                 Questions about these terms can be sent to hello@neutralai.co.uk.
               </p>
-              <p className="text-slate-500 text-sm mt-6">
+              <p className="text-slate-400 text-sm mt-6">
                 Last updated: March 29, 2026
               </p>
             </div>

--- a/app/trust-center/page.tsx
+++ b/app/trust-center/page.tsx
@@ -115,7 +115,7 @@ export default function TrustCenterPage() {
 
           <div className="grid gap-10 lg:grid-cols-[1.06fr_0.94fr] lg:items-end">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Trust Center</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Trust Center</p>
               <h1 className="mt-5 max-w-4xl font-heading text-4xl font-bold leading-[0.98] md:text-6xl">
                 Evidence for teams that need AI security to be provable.
               </h1>
@@ -135,7 +135,7 @@ export default function TrustCenterPage() {
             <div className="rounded-lg border border-primary/25 bg-background-secondary/70 p-5 shadow-2xl shadow-cyan-950/20 backdrop-blur">
               <div className="flex items-center justify-between gap-4 border-b border-border pb-4">
                 <div>
-                  <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-slate-500">Current posture</p>
+                  <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-slate-400">Current posture</p>
                   <p className="mt-1 font-heading text-2xl font-semibold">Readiness, not theater</p>
                 </div>
                 <FileCheck2 className="h-8 w-8 text-primary-light" />
@@ -161,7 +161,7 @@ export default function TrustCenterPage() {
       <section className="section">
         <div className="container-custom">
           <div className="mb-10 max-w-3xl">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Control Areas</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Control Areas</p>
             <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">Security, availability, and confidentiality controls.</h2>
           </div>
 
@@ -183,7 +183,7 @@ export default function TrustCenterPage() {
         <div className="container-custom">
           <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr]">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Enterprise Evidence</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Enterprise Evidence</p>
               <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">Ready for security review.</h2>
               <p className="mt-5 text-base leading-7 text-slate-400">
                 The public site keeps claims conservative. For procurement and security teams, NeutralAI can provide structured readiness materials through the review process.
@@ -205,7 +205,7 @@ export default function TrustCenterPage() {
       <section className="section">
         <div className="container-custom">
           <div className="rounded-lg border border-[#fdba74]/25 bg-[#fdba74]/10 p-6 md:p-8">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Claim Boundary</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Claim Boundary</p>
             <h2 className="mt-3 font-heading text-2xl font-bold md:text-3xl">SOC2 readiness is in progress.</h2>
             <div className="mt-5 grid gap-3 md:grid-cols-3">
               {caveats.map((item) => (
@@ -222,7 +222,7 @@ export default function TrustCenterPage() {
         <div className="container-custom">
           <div className="grid gap-8 rounded-lg border border-border bg-background p-6 lg:grid-cols-[1.02fr_0.98fr] lg:p-8">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Customer Proof Framework</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Customer Proof Framework</p>
               <h2 className="mt-3 font-heading text-3xl font-bold">Publish proof only after approval gates clear.</h2>
               <p className="mt-4 text-sm leading-7 text-slate-400">
                 We keep public trust copy conservative until customer evidence is approved. Publication gates, approved proof
@@ -230,7 +230,7 @@ export default function TrustCenterPage() {
                 goes live.
               </p>
               <div className="mt-5 rounded-md border border-border/80 bg-background-secondary/70 p-4">
-                <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-slate-500">Current posture</p>
+                <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-slate-400">Current posture</p>
                 <p className="mt-2 text-sm leading-6 text-slate-300">
                   No customer logos or testimonials are published on this site until approved assets are recorded through the framework workflow.
                 </p>
@@ -267,7 +267,7 @@ export default function TrustCenterPage() {
         <div className="container-custom">
           <div className="grid gap-6 rounded-lg border border-border bg-background p-6 md:grid-cols-[1fr_auto] md:items-center md:p-8">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Next step</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Next step</p>
               <h2 className="mt-3 font-heading text-3xl font-bold">Need the evidence pack?</h2>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-400">
                 Send the security context you need reviewed. We will route questionnaire, readiness, and compliance evidence requests through the right owner.

--- a/app/use-cases/UseCasePage.tsx
+++ b/app/use-cases/UseCasePage.tsx
@@ -100,7 +100,7 @@ export default function UseCasePage({ content }: { content: UseCasePageContent }
         <div className="container-custom">
           <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Protected workflow</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Protected workflow</p>
               <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
                 Put masking before AI prompts leave the trusted path.
               </h2>
@@ -137,7 +137,7 @@ export default function UseCasePage({ content }: { content: UseCasePageContent }
         <div className="container-custom">
           <div className="grid gap-8 lg:grid-cols-[1fr_0.95fr] lg:items-start">
             <div className="rounded-[28px] border border-white/10 bg-background/80 p-6 md:p-8">
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#fdba74]">Entity coverage</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Entity coverage</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">Industry examples buyers recognize</h2>
               <div className="mt-6 flex flex-wrap gap-3">
                 {content.entities.map((entity) => (
@@ -170,7 +170,7 @@ export default function UseCasePage({ content }: { content: UseCasePageContent }
         <div className="container-custom">
           <div className="grid gap-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-start">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">Compliance mapping</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Compliance mapping</p>
               <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
                 Translate the gateway into review language.
               </h2>
@@ -194,7 +194,7 @@ export default function UseCasePage({ content }: { content: UseCasePageContent }
       <section className="section bg-background-secondary">
         <div className="container-custom">
           <div className="mx-auto max-w-3xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.28em] text-primary-light">FAQ</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">FAQ</p>
             <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">Questions buyers ask first</h2>
           </div>
           <div className="mx-auto mt-10 grid max-w-5xl gap-4">


### PR DESCRIPTION
## Summary
Communicative-first UI/UX pass on the marketing homepage, applying the impeccable / design-taste skill methodology while preserving the committed brand identity (DM Sans / Space Grotesk / JetBrains Mono, cyan/orange on near-black). Focused on substantive wins, not decoration.

## Changes
- **Mobile pricing comparison** — replaced the `min-w-[1040px]` horizontal-scroll table with a desktop grid + stacked per-plan cards on mobile/tablet (each plan lists all its capabilities). No more horizontal scroll; comparison data lifted to a single source.
- **Hero product demo — Audit beat** — extended the `ProductVisual` story from Detect → Mask → Route to a 4-step flow ending in **Audit**, with a compliance-evidence card ("Audit evidence recorded · 3 entities tokenized · policy PII-Mask-v3 · export-ready"). Completes the product narrative regulated buyers care about.
- **WCAG AA contrast** — muted body/label text `slate-500 → slate-400` site-wide (was ~4.23:1, below 4.5); fixed two `slate-600` text cases; hero proof label `10px/slate-500 → 12px/slate-400`.
- **Typography/legibility** — tightened extreme eyebrow tracking `0.28em → 0.18em` site-wide; reworked the shared `SectionIntro` into a deliberate kicker (leading rule, balanced heading, brighter description).
- **Hover affordances** — consistent lift/glow on HowItWorks, ProductSurface, and DetectionEngine cards/chips.

## Intentionally kept (owner preference)
- Animated gradient heading text and the dimmer footer link tone were left as-is per owner call.

## Verification
- `tsc` clean · `eslint .` clean · `next build` succeeds.
- Verified before/after in-browser at desktop (1440) and mobile (390).

## Notes
An abstract 3D WebGL hero was prototyped on a separate branch and not merged — it didn't communicate the product. This PR keeps the existing product-explaining hero, elevated.