### PR TITLE
feat(trust-center): SVG data-flow architecture diagrams (TEN-WEB-02)

### DIFF
--- a/app/components/diagrams/EgressFlowDiagram.tsx
+++ b/app/components/diagrams/EgressFlowDiagram.tsx
@@ -1,0 +1,157 @@
+/**
+ * EgressFlowDiagram — Prompt egress / outbound data-flow
+ *
+ * Shows: User/Client → Gateway → [Detect] → [Mask/Tokenize] → forward sanitized prompt → LLM Provider
+ * with Token Vault (encrypted, TTL) and Audit Trail as connected side components.
+ * Raw PII never leaves the gateway boundary.
+ */
+export default function EgressFlowDiagram() {
+  return (
+    <figure className="w-full overflow-x-auto">
+      <svg
+        role="img"
+        aria-labelledby="egress-title egress-desc"
+        viewBox="0 0 900 480"
+        xmlns="http://www.w3.org/2000/svg"
+        className="w-full min-w-[600px]"
+        style={{ fontFamily: 'var(--font-mono, ui-monospace, monospace)' }}
+      >
+        <title id="egress-title">Prompt Egress Data-Flow Diagram</title>
+        <desc id="egress-desc">
+          A data-flow diagram showing how a user prompt passes through the NeutralAI Gateway. The flow
+          is: User / Client sends a prompt to the Gateway; within the gateway boundary, Presidio NER
+          and pattern matching detect PII entities; detected entities are masked or tokenized and the
+          tokens are stored in an AES-256-GCM encrypted Token Vault with a TTL; an immutable Audit
+          Trail records every detection event; and only the sanitized prompt (with no raw PII) is
+          forwarded to the external LLM Provider.
+        </desc>
+
+        {/* ── Background ─────────────────────────────────────────────── */}
+        <rect width="900" height="480" fill="#030712" rx="12" />
+
+        {/* Subtle grid */}
+        <defs>
+          <pattern id="eg-grid" width="36" height="36" patternUnits="userSpaceOnUse">
+            <path d="M 36 0 L 0 0 0 36" fill="none" stroke="rgba(6,182,212,0.04)" strokeWidth="1" />
+          </pattern>
+          <marker id="eg-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L8,3 z" fill="#06B6D4" />
+          </marker>
+          <marker id="eg-arrow-vault" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L8,3 z" fill="#8B5CF6" />
+          </marker>
+          <marker id="eg-arrow-audit" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L8,3 z" fill="#F97316" />
+          </marker>
+          <linearGradient id="eg-boundary-grad" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor="rgba(6,182,212,0.18)" />
+            <stop offset="100%" stopColor="rgba(6,182,212,0.04)" />
+          </linearGradient>
+        </defs>
+        <rect width="900" height="480" fill="url(#eg-grid)" />
+
+        {/* ── Gateway boundary box ───────────────────────────────────── */}
+        {/* x=210 to x=720, y=40 to y=310 */}
+        <rect x="210" y="40" width="510" height="270" rx="10"
+          fill="rgba(6,182,212,0.03)" stroke="#06B6D4" strokeWidth="1.5"
+          strokeDasharray="6 4" opacity="0.7" />
+        <text x="460" y="58" textAnchor="middle" fill="#22D3EE" fontSize="10" letterSpacing="3" opacity="0.9">
+          NEUTRALAI GATEWAY BOUNDARY — RAW PII DOES NOT CROSS THIS LINE
+        </text>
+
+        {/* ── Node: User / Client ────────────────────────────────────── */}
+        <rect x="20" y="130" width="140" height="60" rx="8"
+          fill="#0F172A" stroke="#334155" strokeWidth="1.5" />
+        <text x="90" y="152" textAnchor="middle" fill="#F8FAFC" fontSize="12" fontWeight="600">User / Client</text>
+        <text x="90" y="170" textAnchor="middle" fill="#94A3B8" fontSize="10">App or extension</text>
+
+        {/* ── Arrow: Client → Gateway ────────────────────────────────── */}
+        <line x1="160" y1="160" x2="226" y2="160"
+          stroke="#06B6D4" strokeWidth="1.5" markerEnd="url(#eg-arrow)" />
+        <text x="193" y="152" textAnchor="middle" fill="#22D3EE" fontSize="9">prompt</text>
+
+        {/* ── Node: Detect (Presidio + NER) ─────────────────────────── */}
+        <rect x="234" y="130" width="148" height="60" rx="8"
+          fill="#0F172A" stroke="#22D3EE" strokeWidth="1.5" />
+        <text x="308" y="152" textAnchor="middle" fill="#F8FAFC" fontSize="12" fontWeight="600">Detect</text>
+        <text x="308" y="168" textAnchor="middle" fill="#94A3B8" fontSize="9">Presidio NER</text>
+        <text x="308" y="180" textAnchor="middle" fill="#94A3B8" fontSize="9">+ Pattern match</text>
+
+        {/* ── Arrow: Detect → Mask ─────────────────────────────────── */}
+        <line x1="382" y1="160" x2="418" y2="160"
+          stroke="#06B6D4" strokeWidth="1.5" markerEnd="url(#eg-arrow)" />
+
+        {/* ── Node: Mask / Tokenize ─────────────────────────────────── */}
+        <rect x="420" y="130" width="148" height="60" rx="8"
+          fill="#0F172A" stroke="#22D3EE" strokeWidth="1.5" />
+        <text x="494" y="152" textAnchor="middle" fill="#F8FAFC" fontSize="12" fontWeight="600">Mask / Tokenize</text>
+        <text x="494" y="168" textAnchor="middle" fill="#94A3B8" fontSize="9">AES-256-GCM vault</text>
+        <text x="494" y="180" textAnchor="middle" fill="#94A3B8" fontSize="9">Reversible token</text>
+
+        {/* ── Arrow: Mask → LLM ─────────────────────────────────────── */}
+        <line x1="568" y1="160" x2="724" y2="160"
+          stroke="#06B6D4" strokeWidth="1.5" markerEnd="url(#eg-arrow)" />
+        <text x="646" y="148" textAnchor="middle" fill="#10B981" fontSize="9">sanitized only</text>
+
+        {/* ── Node: LLM Provider ────────────────────────────────────── */}
+        <rect x="726" y="130" width="140" height="60" rx="8"
+          fill="#0F172A" stroke="#334155" strokeWidth="1.5" />
+        <text x="796" y="152" textAnchor="middle" fill="#F8FAFC" fontSize="12" fontWeight="600">LLM Provider</text>
+        <text x="796" y="170" textAnchor="middle" fill="#94A3B8" fontSize="10">OpenRouter / BYOK</text>
+
+        {/* ── Token Vault side-panel ──────────────────────────────────── */}
+        <rect x="390" y="260" width="208" height="70" rx="8"
+          fill="#130D2B" stroke="#8B5CF6" strokeWidth="1.5" />
+        {/* vault icon row */}
+        <text x="404" y="283" fill="#8B5CF6" fontSize="12">🔐</text>
+        <text x="422" y="280" fill="#A78BFA" fontSize="11" fontWeight="600">Token Vault</text>
+        <text x="398" y="296" fill="#94A3B8" fontSize="9">AES-256-GCM encrypted</text>
+        <text x="398" y="310" fill="#94A3B8" fontSize="9">Tenant-bound · TTL 15 min</text>
+        <text x="398" y="322" fill="#94A3B8" fontSize="9">Governed restore path only</text>
+
+        {/* Arrow: Mask → Vault (store) */}
+        <line x1="494" y1="190" x2="494" y2="258"
+          stroke="#8B5CF6" strokeWidth="1.5" strokeDasharray="5 3" markerEnd="url(#eg-arrow-vault)" />
+        <text x="500" y="228" fill="#8B5CF6" fontSize="9">store token</text>
+
+        {/* ── Audit Trail side-panel ────────────────────────────────── */}
+        <rect x="230" y="260" width="150" height="70" rx="8"
+          fill="#120A00" stroke="#F97316" strokeWidth="1.5" />
+        <text x="244" y="283" fill="#F97316" fontSize="12">📋</text>
+        <text x="262" y="280" fill="#FB923C" fontSize="11" fontWeight="600">Audit Trail</text>
+        <text x="238" y="296" fill="#94A3B8" fontSize="9">Detection events</text>
+        <text x="238" y="310" fill="#94A3B8" fontSize="9">Entity types logged</text>
+        <text x="238" y="322" fill="#94A3B8" fontSize="9">Immutable append-only</text>
+
+        {/* Arrow: Detect → Audit */}
+        <line x1="308" y1="190" x2="308" y2="258"
+          stroke="#F97316" strokeWidth="1.5" strokeDasharray="5 3" markerEnd="url(#eg-arrow-audit)" />
+        <text x="316" y="228" fill="#F97316" fontSize="9">log event</text>
+
+        {/* ── PII-blocked label ─────────────────────────────────────── */}
+        <rect x="588" y="260" width="130" height="70" rx="8"
+          fill="#050F0A" stroke="#10B981" strokeWidth="1.5" />
+        <text x="602" y="280" fill="#10B981" fontSize="12">🚫</text>
+        <text x="620" y="280" fill="#10B981" fontSize="11" fontWeight="600">Raw PII</text>
+        <text x="598" y="295" fill="#94A3B8" fontSize="9">never crosses boundary</text>
+        <text x="598" y="308" fill="#94A3B8" fontSize="9">masked before egress</text>
+        <text x="598" y="321" fill="#94A3B8" fontSize="9">zero retention default</text>
+
+        {/* ── Legend ────────────────────────────────────────────────── */}
+        <line x1="40" y1="410" x2="80" y2="410" stroke="#06B6D4" strokeWidth="1.5" markerEnd="url(#eg-arrow)" />
+        <text x="86" y="414" fill="#94A3B8" fontSize="10">Main flow</text>
+        <line x1="170" y1="410" x2="210" y2="410" stroke="#8B5CF6" strokeWidth="1.5" strokeDasharray="5 3" markerEnd="url(#eg-arrow-vault)" />
+        <text x="216" y="414" fill="#94A3B8" fontSize="10">Token store</text>
+        <line x1="310" y1="410" x2="350" y2="410" stroke="#F97316" strokeWidth="1.5" strokeDasharray="5 3" markerEnd="url(#eg-arrow-audit)" />
+        <text x="356" y="414" fill="#94A3B8" fontSize="10">Audit event</text>
+        <rect x="454" y="404" width="12" height="12" rx="2" fill="none" stroke="#22D3EE" strokeWidth="1.5" strokeDasharray="4 3" />
+        <text x="472" y="414" fill="#94A3B8" fontSize="10">Gateway boundary</text>
+
+        {/* ── Caption ───────────────────────────────────────────────── */}
+        <text x="450" y="460" textAnchor="middle" fill="#475569" fontSize="10">
+          Fig 1 — NeutralAI prompt egress: PII detected, tokenized, and audited inside the gateway boundary before LLM forwarding.
+        </text>
+      </svg>
+    </figure>
+  )
+}

--- a/app/components/diagrams/IngressFlowDiagram.tsx
+++ b/app/components/diagrams/IngressFlowDiagram.tsx
@@ -1,0 +1,162 @@
+/**
+ * IngressFlowDiagram — LLM response / ingress unmask flow
+ *
+ * Shows: LLM Provider → Gateway → [optional token recovery from Vault]
+ *        → unmasked response delivered to User / Client
+ *        with redaction / recovery path clearly labeled.
+ */
+export default function IngressFlowDiagram() {
+  return (
+    <figure className="w-full overflow-x-auto">
+      <svg
+        role="img"
+        aria-labelledby="ingress-title ingress-desc"
+        viewBox="0 0 900 400"
+        xmlns="http://www.w3.org/2000/svg"
+        className="w-full min-w-[600px]"
+        style={{ fontFamily: 'var(--font-mono, ui-monospace, monospace)' }}
+      >
+        <title id="ingress-title">LLM Response Ingress and Unmask Flow Diagram</title>
+        <desc id="ingress-desc">
+          A data-flow diagram showing how an LLM response is processed on the way back to the user.
+          The LLM Provider sends a response containing masked tokens to the NeutralAI Gateway. Inside
+          the gateway boundary, the stream unmasker checks each token. If a token is present, it
+          performs a governed vault lookup against the AES-256-GCM encrypted Token Vault using the
+          tenant-bound context and TTL check. If recovery is authorised, the original PII value is
+          re-inserted and the unmasked response is streamed back to the User. If recovery is not
+          authorised or the token has expired, the masked placeholder is preserved and delivered as-is.
+          The audit trail records all unmask events.
+        </desc>
+
+        {/* ── Background ─────────────────────────────────────────────── */}
+        <rect width="900" height="400" fill="#030712" rx="12" />
+
+        <defs>
+          <pattern id="in-grid" width="36" height="36" patternUnits="userSpaceOnUse">
+            <path d="M 36 0 L 0 0 0 36" fill="none" stroke="rgba(6,182,212,0.04)" strokeWidth="1" />
+          </pattern>
+          <marker id="in-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L8,3 z" fill="#06B6D4" />
+          </marker>
+          <marker id="in-arrow-vault" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L8,3 z" fill="#8B5CF6" />
+          </marker>
+          <marker id="in-arrow-vault-up" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L8,3 z" fill="#10B981" />
+          </marker>
+          <marker id="in-arrow-audit" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L8,3 z" fill="#F97316" />
+          </marker>
+        </defs>
+        <rect width="900" height="400" fill="url(#in-grid)" />
+
+        {/* ── Gateway boundary ─────────────────────────────────────── */}
+        <rect x="210" y="40" width="480" height="220" rx="10"
+          fill="rgba(6,182,212,0.03)" stroke="#06B6D4" strokeWidth="1.5"
+          strokeDasharray="6 4" opacity="0.7" />
+        <text x="450" y="58" textAnchor="middle" fill="#22D3EE" fontSize="10" letterSpacing="3" opacity="0.9">
+          NEUTRALAI GATEWAY BOUNDARY
+        </text>
+
+        {/* ── Node: LLM Provider ─────────────────────────────────────── */}
+        <rect x="20" y="110" width="148" height="60" rx="8"
+          fill="#0F172A" stroke="#334155" strokeWidth="1.5" />
+        <text x="94" y="134" textAnchor="middle" fill="#F8FAFC" fontSize="12" fontWeight="600">LLM Provider</text>
+        <text x="94" y="152" textAnchor="middle" fill="#94A3B8" fontSize="10">OpenRouter / BYOK</text>
+
+        {/* Arrow: LLM → Gateway */}
+        <line x1="168" y1="140" x2="226" y2="140"
+          stroke="#06B6D4" strokeWidth="1.5" markerEnd="url(#in-arrow)" />
+        <text x="197" y="132" textAnchor="middle" fill="#22D3EE" fontSize="9">response</text>
+        <text x="197" y="143" textAnchor="middle" fill="#475569" fontSize="8">(masked tokens)</text>
+
+        {/* ── Node: Stream Unmasker ─────────────────────────────────── */}
+        <rect x="230" y="110" width="148" height="60" rx="8"
+          fill="#0F172A" stroke="#22D3EE" strokeWidth="1.5" />
+        <text x="304" y="132" textAnchor="middle" fill="#F8FAFC" fontSize="12" fontWeight="600">Stream Unmasker</text>
+        <text x="304" y="150" textAnchor="middle" fill="#94A3B8" fontSize="9">Token detection</text>
+        <text x="304" y="162" textAnchor="middle" fill="#94A3B8" fontSize="9">Authorisation check</text>
+
+        {/* Arrow: Unmasker → Vault lookup */}
+        <line x1="378" y1="140" x2="414" y2="140"
+          stroke="#06B6D4" strokeWidth="1.5" markerEnd="url(#in-arrow)" />
+
+        {/* ── Node: Vault Lookup ────────────────────────────────────── */}
+        <rect x="416" y="110" width="148" height="60" rx="8"
+          fill="#0F172A" stroke="#22D3EE" strokeWidth="1.5" />
+        <text x="490" y="132" textAnchor="middle" fill="#F8FAFC" fontSize="12" fontWeight="600">Vault Lookup</text>
+        <text x="490" y="150" textAnchor="middle" fill="#94A3B8" fontSize="9">Tenant-bound context</text>
+        <text x="490" y="162" textAnchor="middle" fill="#94A3B8" fontSize="9">TTL + authz check</text>
+
+        {/* Arrow: Vault Lookup → Response delivery */}
+        <line x1="564" y1="140" x2="724" y2="140"
+          stroke="#06B6D4" strokeWidth="1.5" markerEnd="url(#in-arrow)" />
+
+        {/* ── Node: User / Client ─────────────────────────────────────── */}
+        <rect x="726" y="110" width="148" height="60" rx="8"
+          fill="#0F172A" stroke="#334155" strokeWidth="1.5" />
+        <text x="800" y="132" textAnchor="middle" fill="#F8FAFC" fontSize="12" fontWeight="600">User / Client</text>
+        <text x="800" y="150" textAnchor="middle" fill="#94A3B8" fontSize="10">Unmasked response</text>
+        <text x="800" y="162" textAnchor="middle" fill="#94A3B8" fontSize="10">streamed back</text>
+
+        {/* ── Token Vault side panel ─────────────────────────────────── */}
+        <rect x="390" y="220" width="200" height="68" rx="8"
+          fill="#130D2B" stroke="#8B5CF6" strokeWidth="1.5" />
+        <text x="404" y="241" fill="#8B5CF6" fontSize="12">🔐</text>
+        <text x="422" y="241" fill="#A78BFA" fontSize="11" fontWeight="600">Token Vault</text>
+        <text x="398" y="256" fill="#94A3B8" fontSize="9">AES-256-GCM encrypted</text>
+        <text x="398" y="269" fill="#94A3B8" fontSize="9">Tenant-bound · TTL 15 min</text>
+        <text x="398" y="282" fill="#94A3B8" fontSize="9">Auto-expire on TTL</text>
+
+        {/* Arrow: Vault Lookup ↓ query */}
+        <line x1="490" y1="170" x2="490" y2="218"
+          stroke="#8B5CF6" strokeWidth="1.5" strokeDasharray="5 3" markerEnd="url(#in-arrow-vault)" />
+        <text x="497" y="198" fill="#8B5CF6" fontSize="9">query token</text>
+
+        {/* Arrow: Vault ↑ recover (offset slightly) */}
+        <line x1="474" y1="218" x2="474" y2="172"
+          stroke="#10B981" strokeWidth="1.5" strokeDasharray="5 3" markerEnd="url(#in-arrow-vault-up)" />
+        <text x="432" y="202" fill="#10B981" fontSize="9">recover value</text>
+
+        {/* ── Redaction path label ─────────────────────────────────── */}
+        {/* "if NOT authorised / TTL expired → preserve masked" path */}
+        <rect x="596" y="220" width="168" height="68" rx="8"
+          fill="#050F0A" stroke="#10B981" strokeWidth="1.5" />
+        <text x="610" y="241" fill="#10B981" fontSize="12">✓</text>
+        <text x="628" y="241" fill="#10B981" fontSize="11" fontWeight="600">If authorised</text>
+        <text x="606" y="256" fill="#94A3B8" fontSize="9">Original value re-inserted</text>
+        <text x="606" y="269" fill="#94A3B8" fontSize="9">Audit event written</text>
+        <text x="606" y="282" fill="#94A3B8" fontSize="9">Streamed to client</text>
+
+        {/* ── Redaction-kept note ───────────────────────────────────── */}
+        <rect x="216" y="220" width="168" height="68" rx="8"
+          fill="#12080A" stroke="#F97316" strokeWidth="1.5" />
+        <text x="230" y="241" fill="#F97316" fontSize="12">🛡</text>
+        <text x="248" y="241" fill="#FB923C" fontSize="11" fontWeight="600">If NOT authorised</text>
+        <text x="224" y="256" fill="#94A3B8" fontSize="9">Token TTL expired, or</text>
+        <text x="224" y="269" fill="#94A3B8" fontSize="9">authz check failed</text>
+        <text x="224" y="282" fill="#94A3B8" fontSize="9">Masked placeholder kept</text>
+
+        {/* Arrow: Unmasker ↓ to NOT-authorised box */}
+        <line x1="304" y1="170" x2="304" y2="218"
+          stroke="#F97316" strokeWidth="1.5" strokeDasharray="5 3" markerEnd="url(#in-arrow-audit)" />
+        <text x="312" y="198" fill="#F97316" fontSize="9">authz fail</text>
+
+        {/* ── Legend ────────────────────────────────────────────────── */}
+        <line x1="40" y1="350" x2="80" y2="350" stroke="#06B6D4" strokeWidth="1.5" markerEnd="url(#in-arrow)" />
+        <text x="86" y="354" fill="#94A3B8" fontSize="10">Main flow</text>
+        <line x1="170" y1="350" x2="210" y2="350" stroke="#8B5CF6" strokeWidth="1.5" strokeDasharray="5 3" markerEnd="url(#in-arrow-vault)" />
+        <text x="216" y="354" fill="#94A3B8" fontSize="10">Vault query</text>
+        <line x1="310" y1="350" x2="350" y2="350" stroke="#10B981" strokeWidth="1.5" strokeDasharray="5 3" markerEnd="url(#in-arrow-vault-up)" />
+        <text x="356" y="354" fill="#94A3B8" fontSize="10">Token recovery</text>
+        <line x1="460" y1="350" x2="500" y2="350" stroke="#F97316" strokeWidth="1.5" strokeDasharray="5 3" markerEnd="url(#in-arrow-audit)" />
+        <text x="506" y="354" fill="#94A3B8" fontSize="10">Authz fail / redact</text>
+
+        {/* ── Caption ───────────────────────────────────────────────── */}
+        <text x="450" y="388" textAnchor="middle" fill="#475569" fontSize="10">
+          Fig 2 — NeutralAI response ingress: tokens recovered only via governed vault lookup; expired or unauthorised tokens remain masked.
+        </text>
+      </svg>
+    </figure>
+  )
+}

--- a/app/components/diagrams/VaultLifecycleDiagram.tsx
+++ b/app/components/diagrams/VaultLifecycleDiagram.tsx
@@ -1,0 +1,107 @@
+/**
+ * VaultLifecycleDiagram — Token vault lifecycle panel
+ *
+ * Shows: Tokenize → Store encrypted (AES-256-GCM, TTL) → Recover (governed) → Expire
+ */
+export default function VaultLifecycleDiagram() {
+  return (
+    <figure className="w-full overflow-x-auto">
+      <svg
+        role="img"
+        aria-labelledby="vault-title vault-desc"
+        viewBox="0 0 900 260"
+        xmlns="http://www.w3.org/2000/svg"
+        className="w-full min-w-[560px]"
+        style={{ fontFamily: 'var(--font-mono, ui-monospace, monospace)' }}
+      >
+        <title id="vault-title">Token Vault Lifecycle Diagram</title>
+        <desc id="vault-desc">
+          A four-stage lifecycle diagram for tokens in the NeutralAI Token Vault. Stage one:
+          Tokenize — a PII entity is detected and replaced with a reversible token. Stage two:
+          Store Encrypted — the token and its original value are stored in the AES-256-GCM vault
+          with a fifteen-minute TTL and tenant-bound context. Stage three: Recover — only an
+          authorised governed restore call can retrieve the original value before TTL expiry.
+          Stage four: Expire — after TTL elapses the token and value are automatically purged;
+          no recovery is possible after expiry.
+        </desc>
+
+        {/* ── Background ─────────────────────────────────────────────── */}
+        <rect width="900" height="260" fill="#030712" rx="12" />
+
+        <defs>
+          <pattern id="vl-grid" width="36" height="36" patternUnits="userSpaceOnUse">
+            <path d="M 36 0 L 0 0 0 36" fill="none" stroke="rgba(139,92,246,0.04)" strokeWidth="1" />
+          </pattern>
+          <marker id="vl-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L8,3 z" fill="#8B5CF6" />
+          </marker>
+          <marker id="vl-arrow-expire" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+            <path d="M0,0 L0,6 L8,3 z" fill="#334155" />
+          </marker>
+        </defs>
+        <rect width="900" height="260" fill="url(#vl-grid)" />
+
+        {/* ── Stage labels row ──────────────────────────────────────── */}
+        {/* Stage 1 — Tokenize */}
+        <rect x="30" y="60" width="168" height="100" rx="8"
+          fill="#0F172A" stroke="#8B5CF6" strokeWidth="1.5" />
+        <text x="114" y="84" textAnchor="middle" fill="#A78BFA" fontSize="10" letterSpacing="2">01 / TOKENIZE</text>
+        <text x="114" y="108" textAnchor="middle" fill="#F8FAFC" fontSize="13" fontWeight="600">PII detected</text>
+        <text x="114" y="126" textAnchor="middle" fill="#94A3B8" fontSize="9">Entity replaced with</text>
+        <text x="114" y="139" textAnchor="middle" fill="#94A3B8" fontSize="9">reversible token ID</text>
+        <text x="114" y="152" textAnchor="middle" fill="#A78BFA" fontSize="9">e.g. &lt;EMAIL_abc12&gt;</text>
+
+        {/* Arrow 1→2 */}
+        <line x1="198" y1="110" x2="234" y2="110"
+          stroke="#8B5CF6" strokeWidth="1.5" markerEnd="url(#vl-arrow)" />
+
+        {/* Stage 2 — Store Encrypted */}
+        <rect x="236" y="60" width="168" height="100" rx="8"
+          fill="#130D2B" stroke="#8B5CF6" strokeWidth="2" />
+        <text x="320" y="84" textAnchor="middle" fill="#A78BFA" fontSize="10" letterSpacing="2">02 / STORE</text>
+        <text x="320" y="108" textAnchor="middle" fill="#F8FAFC" fontSize="13" fontWeight="600">AES-256-GCM</text>
+        <text x="320" y="126" textAnchor="middle" fill="#94A3B8" fontSize="9">Tenant-bound context</text>
+        <text x="320" y="139" textAnchor="middle" fill="#94A3B8" fontSize="9">TTL: 15 min default</text>
+        <text x="320" y="152" textAnchor="middle" fill="#A78BFA" fontSize="9">Redis w/ key rotation</text>
+
+        {/* Arrow 2→3 */}
+        <line x1="404" y1="110" x2="440" y2="110"
+          stroke="#8B5CF6" strokeWidth="1.5" markerEnd="url(#vl-arrow)" />
+
+        {/* Stage 3 — Recover */}
+        <rect x="442" y="60" width="168" height="100" rx="8"
+          fill="#0A1F0F" stroke="#10B981" strokeWidth="1.5" />
+        <text x="526" y="84" textAnchor="middle" fill="#10B981" fontSize="10" letterSpacing="2">03 / RECOVER</text>
+        <text x="526" y="108" textAnchor="middle" fill="#F8FAFC" fontSize="13" fontWeight="600">Governed restore</text>
+        <text x="526" y="126" textAnchor="middle" fill="#94A3B8" fontSize="9">Authorised path only</text>
+        <text x="526" y="139" textAnchor="middle" fill="#94A3B8" fontSize="9">Before TTL expiry</text>
+        <text x="526" y="152" textAnchor="middle" fill="#10B981" fontSize="9">Original value re-inserted</text>
+
+        {/* Arrow 3→4 */}
+        <line x1="610" y1="110" x2="646" y2="110"
+          stroke="#334155" strokeWidth="1.5" markerEnd="url(#vl-arrow-expire)" />
+
+        {/* Stage 4 — Expire */}
+        <rect x="648" y="60" width="208" height="100" rx="8"
+          fill="#0F172A" stroke="#334155" strokeWidth="1.5" />
+        <text x="752" y="84" textAnchor="middle" fill="#475569" fontSize="10" letterSpacing="2">04 / EXPIRE</text>
+        <text x="752" y="108" textAnchor="middle" fill="#94A3B8" fontSize="13" fontWeight="600">Auto-purge</text>
+        <text x="752" y="126" textAnchor="middle" fill="#94A3B8" fontSize="9">TTL elapses → token deleted</text>
+        <text x="752" y="139" textAnchor="middle" fill="#94A3B8" fontSize="9">No recovery after expiry</text>
+        <text x="752" y="152" textAnchor="middle" fill="#475569" fontSize="9">Zero-retention by default</text>
+
+        {/* ── Caption ───────────────────────────────────────────────── */}
+        <text x="450" y="210" textAnchor="middle" fill="#475569" fontSize="10">
+          Fig 3 — Token vault lifecycle: tokenize → store encrypted with TTL → governed recovery → automatic expiry and purge.
+        </text>
+
+        {/* ── Key detail strip ──────────────────────────────────────── */}
+        <rect x="30" y="222" width="840" height="26" rx="5"
+          fill="rgba(139,92,246,0.06)" stroke="rgba(139,92,246,0.2)" strokeWidth="1" />
+        <text x="450" y="239" textAnchor="middle" fill="#94A3B8" fontSize="9" letterSpacing="1">
+          VAULT KEY ROTATION SUPPORTED · LEGACY KEY DECRYPTION VIA VAULT_LEGACY_ENCRYPTION_KEYS · FAKEREDIS IN LOCAL DEV MODE
+        </text>
+      </svg>
+    </figure>
+  )
+}

--- a/app/components/diagrams/index.ts
+++ b/app/components/diagrams/index.ts
@@ -1,0 +1,3 @@
+export { default as EgressFlowDiagram } from './EgressFlowDiagram'
+export { default as IngressFlowDiagram } from './IngressFlowDiagram'
+export { default as VaultLifecycleDiagram } from './VaultLifecycleDiagram'

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react'
 import BackButton from '../components/BackButton'
 import { contactLinks, siteConfig } from '../site'
+import { EgressFlowDiagram } from '../components/diagrams'
 
 const securitySections = [
   {
@@ -173,6 +174,31 @@ export default function SecurityPage() {
               </div>
             </div>
           </div>
+        </div>
+      </section>
+
+      {/* ── Egress data-flow diagram ───────────────────────────────────── */}
+      <section className="section">
+        <div className="container-custom">
+          <div className="mb-8 max-w-3xl">
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Data Flow</p>
+            <h2 className="mt-4 font-heading text-3xl font-bold md:text-4xl">How a prompt is sanitized before it leaves.</h2>
+            <p className="mt-4 text-base leading-7 text-slate-400">
+              The gateway intercepts every outbound prompt, runs multi-stage PII detection, tokenizes entities into the encrypted
+              vault, and only forwards the sanitized version to the model provider. Raw PII never crosses the boundary.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-background p-6">
+            <p className="mb-4 font-mono text-[11px] uppercase tracking-[0.22em] text-primary-light">Prompt egress — outbound data-flow</p>
+            <EgressFlowDiagram />
+          </div>
+          <p className="mt-4 text-sm text-slate-500">
+            See the full ingress unmask path and token vault lifecycle on the{' '}
+            <Link href="/trust-center" className="text-primary-light underline-offset-2 hover:underline">
+              Trust Center
+            </Link>
+            .
+          </p>
         </div>
       </section>
 

--- a/app/trust-center/page.tsx
+++ b/app/trust-center/page.tsx
@@ -12,6 +12,11 @@ import {
 } from 'lucide-react'
 import BackButton from '../components/BackButton'
 import { contactLinks, siteConfig } from '../site'
+import {
+  EgressFlowDiagram,
+  IngressFlowDiagram,
+  VaultLifecycleDiagram,
+} from '../components/diagrams'
 
 // Source of truth: neutralai-gateway#750, documents/business/templates/trust_center_content_source_2026q2.md
 export const metadata: Metadata = {
@@ -179,7 +184,41 @@ export default function TrustCenterPage() {
         </div>
       </section>
 
+      {/* ── Data-flow diagrams ─────────────────────────────────────────── */}
       <section className="section bg-background-secondary">
+        <div className="container-custom">
+          <div className="mb-10 max-w-3xl">
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Data Flow</p>
+            <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">Where your data goes — and what stays inside.</h2>
+            <p className="mt-5 text-base leading-7 text-slate-400">
+              Every prompt passes through the NeutralAI gateway boundary before reaching an external model. Raw PII is detected,
+              tokenized, and audited inside that boundary. Only the sanitized version ever leaves.
+            </p>
+          </div>
+
+          <div className="space-y-6">
+            {/* Egress */}
+            <div className="rounded-lg border border-border bg-background p-6">
+              <p className="mb-4 font-mono text-[11px] uppercase tracking-[0.22em] text-primary-light">Prompt egress — outbound</p>
+              <EgressFlowDiagram />
+            </div>
+
+            {/* Ingress */}
+            <div className="rounded-lg border border-border bg-background p-6">
+              <p className="mb-4 font-mono text-[11px] uppercase tracking-[0.22em] text-primary-light">Response ingress — unmask path</p>
+              <IngressFlowDiagram />
+            </div>
+
+            {/* Vault lifecycle */}
+            <div className="rounded-lg border border-[#8B5CF6]/25 bg-background p-6">
+              <p className="mb-4 font-mono text-[11px] uppercase tracking-[0.22em] text-[#A78BFA]">Token vault lifecycle</p>
+              <VaultLifecycleDiagram />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
         <div className="container-custom">
           <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr]">
             <div>


### PR DESCRIPTION
## Summary

- Adds three inline SVG React components as pure server components (no client bundle cost) under `app/components/diagrams/`
- **EgressFlowDiagram** — prompt egress path: User → Detect (Presidio NER + pattern match) → Mask/Tokenize → sanitized forward to LLM Provider; Token Vault (AES-256-GCM, TTL, tenant-bound) and Audit Trail shown as connected side panels; gateway boundary dashed to make the \"raw PII never crosses this line\" story visually explicit
- **IngressFlowDiagram** — LLM response ingress: stream unmasker → governed vault lookup → authorised recovery (value re-inserted) OR unauthorised/TTL-expired path (masked placeholder preserved); both paths drawn
- **VaultLifecycleDiagram** — four-stage panel: Tokenize → Store Encrypted (AES-256-GCM, TTL 15 min) → Recover (governed only) → Expire/auto-purge
- All three embedded in `/trust-center` in a new \"Data Flow\" section (primary); egress diagram also embedded in `/security` with cross-link to trust center
- Each SVG: `role=\"img\"` + `<title>` + `<desc>` for screen-reader accessibility; `viewBox`-based for responsive scaling; `min-w-[560px]` + `overflow-x-auto` for mobile
- Colors match site design system: primary `#06B6D4`/`#22D3EE`, vault accent `#8B5CF6`/`#A78BFA`, audit/warning `#F97316`, success/recovery `#10B981`, borders `#334155`

## Test plan

- [ ] `/trust-center` — scroll to \"Data Flow\" section; confirm all three diagrams render; check SVG labels via screen reader or axe
- [ ] `/security` — confirm egress diagram appears between \"Technical controls\" panel and \"Readiness snapshot\"; cross-link to trust center works
- [ ] Mobile — each diagram scrolls horizontally inside `overflow-x-auto` wrapper; text remains readable
- [ ] Dark mode — all colors are hardcoded against the site's dark background (no light-mode class needed per current site design)
- [ ] Cloudflare preview — confirm static export renders correctly

## Gates

- `npm run build` — ✅ 52/52 pages, TypeScript clean, Turbopack compiled in 8.7s
- `npm run lint` — ✅ ESLint: no issues found

Closes nazifsohtaoglu/neutralai-gateway#1326
[ci fullstack] [ci test]