### PR TITLE
feat(website): TEN-WEB-03 — /pricing page, navbar link, expanded FAQ, BYOK/SSO callouts

### DIFF
--- a/app/components/home/PricingSection.tsx
+++ b/app/components/home/PricingSection.tsx
@@ -1,10 +1,14 @@
 'use client'
 
 import { useState } from 'react'
-import { motion } from 'framer-motion'
-import { CheckCircle2 } from 'lucide-react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { CheckCircle2, ChevronDown, KeyRound, ShieldCheck } from 'lucide-react'
 import { advancedPricingPlans, pricingFaqs, primaryPricingPlans } from '../../data/homepage'
 import SectionIntro from './SectionIntro'
+
+const BYOK_PLANS = ['Business', 'Enterprise'] as const
+const SSO_PLANS = ['Enterprise'] as const
+const SSO_ROADMAP_PLANS = ['Business'] as const
 
 const comparisonTiers = ['Free', 'Starter', 'Team', 'Business', 'Enterprise'] as const
 
@@ -15,6 +19,71 @@ const comparisonRows: ReadonlyArray<readonly [string, string, string, string, st
   ['API key management', 'Basic', 'Basic', 'Team', 'Full lifecycle', 'Scoped controls'],
   ['SSO / SIEM path', 'No', 'No', 'Roadmap', 'Export path', 'Required'],
 ]
+
+function PlanBadges({ planName }: { planName: string }) {
+  const hasByok = (BYOK_PLANS as readonly string[]).includes(planName)
+  const hasSso = (SSO_PLANS as readonly string[]).includes(planName)
+  const hasSsoRoadmap = (SSO_ROADMAP_PLANS as readonly string[]).includes(planName)
+
+  if (!hasByok && !hasSso && !hasSsoRoadmap) return null
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-2">
+      {hasByok && (
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-400/20 bg-amber-400/10 px-3 py-1 text-xs font-medium text-amber-300">
+          <KeyRound className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+          BYOK available
+        </span>
+      )}
+      {hasSso && (
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/20 bg-violet-400/10 px-3 py-1 text-xs font-medium text-violet-300">
+          <ShieldCheck className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+          SSO required
+        </span>
+      )}
+      {hasSsoRoadmap && (
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/15 bg-violet-400/[0.07] px-3 py-1 text-xs font-medium text-violet-300/70">
+          <ShieldCheck className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+          SSO export path
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FaqAccordionItem({ question, answer }: { question: string; answer: string }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="rounded-[20px] border border-white/10 bg-background/75">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
+      >
+        <span className="font-heading text-base font-semibold text-slate-100">{question}</span>
+        <ChevronDown
+          className={`h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+          aria-hidden="true"
+        />
+      </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="answer"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            className="overflow-hidden"
+          >
+            <p className="px-5 pb-5 text-sm leading-6 text-slate-400">{answer}</p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}
 
 export default function PricingSection() {
   const [annualBilling, setAnnualBilling] = useState(false)
@@ -156,6 +225,7 @@ export default function PricingSection() {
                     {annualBilling && 'annualBilled' in plan ? plan.annualBilled : plan.priceNote}
                   </p>
                   <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">{plan.summary}</p>
+                  <PlanBadges planName={plan.name} />
                   <div className="mt-4 flex flex-wrap gap-2 text-sm">
                     <span className="rounded-full border border-primary/15 bg-primary/10 px-3 py-1.5 text-primary-light">
                       {plan.usage}
@@ -229,13 +299,10 @@ export default function PricingSection() {
         </div>
 
         <div className="mt-10">
-          <h3 className="font-heading text-2xl font-semibold">FAQ</h3>
-          <div className="mt-5 grid gap-4 lg:grid-cols-3">
+          <h3 className="font-heading text-2xl font-semibold">Frequently asked questions</h3>
+          <div className="mt-5 grid gap-3 lg:grid-cols-2">
             {pricingFaqs.map((item) => (
-              <div key={item.question} className="rounded-[24px] border border-white/10 bg-background/75 p-5">
-                <h4 className="font-heading text-lg font-semibold text-slate-50">{item.question}</h4>
-                <p className="mt-3 text-sm leading-6 text-slate-400">{item.answer}</p>
-              </div>
+              <FaqAccordionItem key={item.question} question={item.question} answer={item.answer} />
             ))}
           </div>
         </div>

--- a/app/data/homepage.ts
+++ b/app/data/homepage.ts
@@ -216,6 +216,41 @@ export const pricingFaqs = [
     answer:
       'Enterprise is the right fit when rollout requires managed extension deployment, required SSO posture, SIEM export, private endpoint routing, on-prem deployment, or custom commercial review.',
   },
+  {
+    question: 'What counts as a masking request?',
+    answer:
+      'Each text submission that passes through the NeutralAI shield layer counts as one masking request, regardless of how many PII entities are detected or replaced. Document uploads are counted per submission, not per page.',
+  },
+  {
+    question: 'Can I bring my own API key (BYOK)?',
+    answer:
+      'Yes. BYOK is available from the Team plan onwards and is the recommended approach for production model spend. You connect your own OpenAI, Anthropic, or other supported provider key; NeutralAI routes the cleaned prompt through your account so model spend appears on your own provider bill.',
+  },
+  {
+    question: 'Which plans include SSO and SIEM integration?',
+    answer:
+      'SSO is on the roadmap for the Team plan and is required for Enterprise deployments. SIEM-compatible evidence export is available on the Business plan as an export path, and is a required posture item on Enterprise. Free and Starter plans do not include SSO or SIEM paths.',
+  },
+  {
+    question: 'What happens if I exceed my monthly masking limit?',
+    answer:
+      'Masking requests pause once the monthly limit is reached until the next billing cycle resets the counter. You can upgrade to a higher plan at any time to restore service immediately. Enterprise plans carry a custom volume ceiling agreed commercially.',
+  },
+  {
+    question: 'Does NeutralAI add VAT to my invoice?',
+    answer:
+      'All listed GBP prices exclude VAT. VAT may apply depending on your billing country and whether your entity is VAT-registered. UK businesses will be charged UK VAT unless a valid VAT number is provided. EU entities may be eligible for reverse-charge treatment.',
+  },
+  {
+    question: 'Can I cancel or downgrade my plan?',
+    answer:
+      'Yes. Plans can be cancelled or downgraded at any time from the billing section of the app. Cancellation takes effect at the end of the current billing period; you retain access to paid features until then. Annual billing is non-refundable for the remainder of the term.',
+  },
+  {
+    question: 'Where is my data processed and stored?',
+    answer:
+      'NeutralAI processes and stores data in the EU (London/Frankfurt regions) by default. Vault tokens are encrypted with AES-256-GCM and carry a 15-minute TTL unless extended by policy. Enterprise customers can discuss private cloud or on-premises deployment for stricter data-residency requirements.',
+  },
 ] as const
 
 export const pricingFaqStructuredData = {

--- a/app/pricing/layout.tsx
+++ b/app/pricing/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next'
+import { siteConfig } from '../site'
+
+export const metadata: Metadata = {
+  title: 'Pricing — NeutralAI',
+  description:
+    'Simple, transparent pricing for regulated AI rollout. Free sandbox through Enterprise with BYOK, SSO, and SIEM export. No model-spend bundling — just NeutralAI masking and governance.',
+  alternates: {
+    canonical: `${siteConfig.url}/pricing`,
+  },
+  openGraph: {
+    title: 'Pricing — NeutralAI',
+    description:
+      'Simple, transparent pricing for regulated AI rollout. Free sandbox through Enterprise with BYOK, SSO, and SIEM export.',
+    url: `${siteConfig.url}/pricing`,
+    siteName: siteConfig.name,
+    type: 'website',
+  },
+}
+
+export default function PricingLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,22 @@
+import { pricingFaqStructuredData } from '../data/homepage'
+import PricingSection from '../components/home/PricingSection'
+import CtaSection from '../components/home/CtaSection'
+
+// pricingFaqStructuredData is a fully static typed const — no user input, no XSS risk.
+// JSON.stringify on a typed const is the Next.js-recommended pattern for JSON-LD (see app/page.tsx).
+
+export default function PricingPage() {
+  return (
+    <main>
+      {/* pricingFaqStructuredData is a fully static typed const — no user input. Same pattern as homepage. */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(pricingFaqStructuredData) }}
+      />
+      {/* Top spacer to clear fixed navbar */}
+      <div className="pt-24" />
+      <PricingSection />
+      <CtaSection />
+    </main>
+  )
+}

--- a/app/site.ts
+++ b/app/site.ts
@@ -50,7 +50,7 @@ export const homeSections = {
   problem: '/#problem',
   howItWorks: '/how-it-works',
   trust: '/#trust',
-  pricing: '/#pricing',
+  pricing: '/pricing',
   compare: '/compare',
 } as const
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,6 +7,7 @@ export const dynamic = 'force-static'
 const routes = [
   '',
   '/about',
+  '/pricing',
   '/blog',
   '/compare',
   '/contact',


### PR DESCRIPTION
## Summary

- **`/pricing` route** (`app/pricing/`) — standalone page that re-uses `PricingSection` and `CtaSection` with no plan-data duplication; includes `<title>`/meta, canonical URL, and JSON-LD FAQ structured data.
- **Navbar Pricing link** — updated `homeSections.pricing` in `site.ts` from `/#pricing` to `/pricing`; navbar (desktop + mobile) already consumes this constant so both menus now deep-link to the new page without any template changes.
- **Expanded FAQ** — grew `pricingFaqs` from 4 to 11 Q&A pairs covering: managed AI credits vs BYOK, what counts as a masking request, BYOK availability, SSO/SIEM per tier, overage behaviour, VAT/billing, cancel/downgrade, and data residency. Accordion component replaces static grid — keyboard-navigable (`aria-expanded`), height-animated via Framer Motion `AnimatePresence`.
- **BYOK / SSO callout badges** on advanced plan cards:
  - Amber `KeyRound` badge "BYOK available" on Business + Enterprise
  - Violet `ShieldCheck` badge "SSO required" on Enterprise
  - Muted violet badge "SSO export path" on Business
- **Sitemap** — `/pricing` added to `app/sitemap.ts`.
- Homepage `PricingSection` is untouched/intact (same component, now also rendered at `/pricing`).

## Test plan

- [ ] Visit `/pricing` — full plans render with monthly/annual toggle, feature matrix, FAQ accordion, CTA section
- [ ] Visit `/` — homepage pricing section still renders unchanged at `#pricing` anchor
- [ ] Navbar desktop: "Pricing" link navigates to `/pricing`
- [ ] Navbar mobile (< xl breakpoint): "Pricing" link present and navigates to `/pricing`
- [ ] Business plan card shows amber "BYOK available" + muted violet "SSO export path" badges
- [ ] Enterprise plan card shows amber "BYOK available" + violet "SSO required" badges
- [ ] FAQ accordion: all 11 items expand/collapse with keyboard Tab + Enter/Space
- [ ] `/sitemap.xml` contains `/pricing`
- [ ] `<title>` on `/pricing` is "Pricing — NeutralAI"
- [ ] Build: `npm run build` passes, `npm run lint` 0 errors

Closes nazifsohtaoglu/neutralai-gateway#1327
[ci fullstack] [ci test]