### PR TITLE
feat(contact): lead form segmentation, inline validation & 24h SLA — TEN-WEB-05

### DIFF
--- a/app/components/GoogleSheetsLeadForm.tsx
+++ b/app/components/GoogleSheetsLeadForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FormEvent, useMemo, useState } from 'react'
+import { FormEvent, useMemo, useRef, useState } from 'react'
 import { getLeadAttribution } from '../lib/analytics'
 import { getReferralSnapshot, referralSnapshotToFieldMap } from '../lib/referral'
 import { siteConfig } from '../site'
@@ -12,12 +12,24 @@ type FormState = {
   email: string
   company_name: string
   company_size: string
+  compliance_requirement: string
   message: string
   referral_source: string
   website_intent: string
   lead_source: string
   company_website: string
 }
+
+type FieldErrors = Partial<Record<keyof FormState, string>>
+
+const COMPLIANCE_OPTIONS = [
+  { value: '', label: 'Select compliance requirement' },
+  { value: 'GDPR', label: 'GDPR — EU data protection' },
+  { value: 'HIPAA', label: 'HIPAA — US healthcare' },
+  { value: 'FCA', label: 'FCA / Financial services' },
+  { value: 'SOC2', label: 'SOC 2 — security controls' },
+  { value: 'Other', label: 'Other / Not sure yet' },
+] as const
 
 const GOOGLE_SHEETS_EXEC_PATH_REGEX = /^\/macros\/s\/[a-z0-9_-]+\/exec\/?$/i
 
@@ -27,12 +39,58 @@ function buildInitialState(intent: string, leadSource: string): FormState {
     email: '',
     company_name: '',
     company_size: '',
+    compliance_requirement: '',
     message: '',
     referral_source: '',
     website_intent: intent,
     lead_source: leadSource,
     company_website: '',
   }
+}
+
+function validateEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())
+}
+
+function validateForm(state: FormState): FieldErrors {
+  const errors: FieldErrors = {}
+
+  if (!state.full_name.trim()) {
+    errors.full_name = 'Full name is required.'
+  }
+
+  if (!state.email.trim()) {
+    errors.email = 'Work email is required.'
+  } else if (!validateEmail(state.email)) {
+    errors.email = 'Please enter a valid email address.'
+  }
+
+  if (!state.company_name.trim()) {
+    errors.company_name = 'Company name is required.'
+  }
+
+  if (!state.company_size) {
+    errors.company_size = 'Please select a company size.'
+  }
+
+  if (!state.compliance_requirement) {
+    errors.compliance_requirement = 'Please select your main compliance requirement.'
+  }
+
+  if (!state.message.trim()) {
+    errors.message = 'Please describe how we can help.'
+  }
+
+  return errors
+}
+
+function FieldError({ id, message }: { id: string; message: string | undefined }) {
+  if (!message) return null
+  return (
+    <p id={id} role="alert" className="mt-1 text-xs text-red-400">
+      {message}
+    </p>
+  )
 }
 
 function MissingConfigNotice() {
@@ -76,6 +134,9 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
   const endpoint = resolveLeadCaptureEndpoint(siteConfig.leadCapture.googleSheetsEndpoint)
   const [status, setStatus] = useState<SubmitStatus>('idle')
   const [state, setState] = useState<FormState>(() => buildInitialState(intent, leadSource))
+  const [errors, setErrors] = useState<FieldErrors>({})
+  const [touched, setTouched] = useState<Partial<Record<keyof FormState, boolean>>>({})
+  const formRef = useRef<HTMLFormElement>(null)
 
   const isSubmitting = status === 'submitting'
 
@@ -93,11 +154,45 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
 
   const submissionEndpoint = endpoint
 
+  function markTouched(field: keyof FormState) {
+    setTouched((prev) => ({ ...prev, [field]: true }))
+  }
+
+  function getFieldError(field: keyof FormState): string | undefined {
+    return touched[field] ? errors[field] : undefined
+  }
+
+  const inputClass = (field: keyof FormState) =>
+    `w-full rounded-xl border ${
+      getFieldError(field)
+        ? 'border-red-500/70 focus:border-red-400'
+        : 'border-white/10 focus:border-primary'
+    } bg-background px-4 py-3 text-slate-100 placeholder:text-slate-400 focus:outline-none`
+
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
 
     if (state.company_website.trim()) {
       window.location.assign('/contact/thanks/')
+      return
+    }
+
+    // Mark all required fields as touched and run full validation
+    const requiredFields: Array<keyof FormState> = [
+      'full_name', 'email', 'company_name', 'company_size', 'compliance_requirement', 'message',
+    ]
+    setTouched(Object.fromEntries(requiredFields.map((f) => [f, true])))
+
+    const validationErrors = validateForm(state)
+    setErrors(validationErrors)
+
+    if (Object.keys(validationErrors).length > 0) {
+      // Focus the first invalid field
+      const firstKey = requiredFields.find((f) => validationErrors[f])
+      if (firstKey) {
+        const el = formRef.current?.querySelector<HTMLElement>(`[id="${firstKey}"]`)
+        el?.focus()
+      }
       return
     }
 
@@ -139,92 +234,174 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
   }
 
   return (
-    <form className="space-y-4" onSubmit={handleSubmit}>
+    <form ref={formRef} className="space-y-4" onSubmit={handleSubmit} noValidate aria-label="Contact request form">
       <div className="grid gap-4 md:grid-cols-2">
-        <label className="space-y-2 text-sm">
-          <span className="text-slate-300">Full name</span>
+        {/* Full name */}
+        <div className="space-y-1 text-sm">
+          <label htmlFor="full_name" className="text-slate-300">
+            Full name <span className="text-red-400" aria-hidden="true">*</span>
+          </label>
           <input
-            required
+            id="full_name"
             type="text"
             value={state.full_name}
-            onChange={(event) => setState((prev) => ({ ...prev, full_name: event.target.value }))}
-            className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-400 focus:border-primary focus:outline-none"
+            onChange={(e) => setState((prev) => ({ ...prev, full_name: e.target.value }))}
+            onBlur={() => { markTouched('full_name'); setErrors(validateForm(state)) }}
+            className={inputClass('full_name')}
             autoComplete="name"
             maxLength={120}
+            placeholder="Jane Smith"
+            aria-required="true"
+            aria-invalid={!!getFieldError('full_name')}
+            aria-describedby={getFieldError('full_name') ? 'err-full_name' : undefined}
           />
-        </label>
-        <label className="space-y-2 text-sm">
-          <span className="text-slate-300">Work email</span>
+          <FieldError id="err-full_name" message={getFieldError('full_name')} />
+        </div>
+
+        {/* Work email */}
+        <div className="space-y-1 text-sm">
+          <label htmlFor="email" className="text-slate-300">
+            Work email <span className="text-red-400" aria-hidden="true">*</span>
+          </label>
           <input
-            required
+            id="email"
             type="email"
             value={state.email}
-            onChange={(event) => setState((prev) => ({ ...prev, email: event.target.value }))}
-            className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-400 focus:border-primary focus:outline-none"
+            onChange={(e) => setState((prev) => ({ ...prev, email: e.target.value }))}
+            onBlur={() => { markTouched('email'); setErrors(validateForm(state)) }}
+            className={inputClass('email')}
             autoComplete="email"
             maxLength={180}
+            placeholder="jane@company.com"
+            aria-required="true"
+            aria-invalid={!!getFieldError('email')}
+            aria-describedby={getFieldError('email') ? 'err-email' : undefined}
           />
-        </label>
-        <label className="space-y-2 text-sm">
-          <span className="text-slate-300">Company name</span>
+          <FieldError id="err-email" message={getFieldError('email')} />
+        </div>
+
+        {/* Company name */}
+        <div className="space-y-1 text-sm">
+          <label htmlFor="company_name" className="text-slate-300">
+            Company name <span className="text-red-400" aria-hidden="true">*</span>
+          </label>
           <input
-            required
+            id="company_name"
             type="text"
             value={state.company_name}
-            onChange={(event) => setState((prev) => ({ ...prev, company_name: event.target.value }))}
-            className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-400 focus:border-primary focus:outline-none"
+            onChange={(e) => setState((prev) => ({ ...prev, company_name: e.target.value }))}
+            onBlur={() => { markTouched('company_name'); setErrors(validateForm(state)) }}
+            className={inputClass('company_name')}
             autoComplete="organization"
             maxLength={180}
+            placeholder="Acme Corp"
+            aria-required="true"
+            aria-invalid={!!getFieldError('company_name')}
+            aria-describedby={getFieldError('company_name') ? 'err-company_name' : undefined}
           />
-        </label>
-        <label className="space-y-2 text-sm">
-          <span className="text-slate-300">Company size</span>
+          <FieldError id="err-company_name" message={getFieldError('company_name')} />
+        </div>
+
+        {/* Company size */}
+        <div className="space-y-1 text-sm">
+          <label htmlFor="company_size" className="text-slate-300">
+            Company size <span className="text-red-400" aria-hidden="true">*</span>
+          </label>
           <select
-            required
+            id="company_size"
             value={state.company_size}
-            onChange={(event) => setState((prev) => ({ ...prev, company_size: event.target.value }))}
-            className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 focus:border-primary focus:outline-none"
+            onChange={(e) => setState((prev) => ({ ...prev, company_size: e.target.value }))}
+            onBlur={() => { markTouched('company_size'); setErrors(validateForm(state)) }}
+            className={inputClass('company_size')}
+            aria-required="true"
+            aria-invalid={!!getFieldError('company_size')}
+            aria-describedby={getFieldError('company_size') ? 'err-company_size' : undefined}
           >
-            <option value="" disabled>
-              Select
-            </option>
-            <option value="1-10">1-10</option>
-            <option value="11-50">11-50</option>
-            <option value="51-200">51-200</option>
-            <option value="201-1000">201-1000</option>
+            <option value="" disabled>Select</option>
+            <option value="1-10">1–10</option>
+            <option value="11-50">11–50</option>
+            <option value="51-200">51–200</option>
+            <option value="201-1000">201–1000</option>
             <option value="1000+">1000+</option>
           </select>
-        </label>
+          <FieldError id="err-company_size" message={getFieldError('company_size')} />
+        </div>
       </div>
 
-      <label className="space-y-2 text-sm">
-        <span className="text-slate-300">How can we help?</span>
+      {/* Compliance requirement — full width */}
+      <div className="space-y-1 text-sm">
+        <label htmlFor="compliance_requirement" className="text-slate-300">
+          Main compliance requirement{' '}
+          <span className="text-red-400" aria-hidden="true">*</span>
+        </label>
+        <p id="compliance_requirement_hint" className="text-xs text-slate-500">
+          Helps us route you to the right specialist and tailor the demo scope.
+        </p>
+        <select
+          id="compliance_requirement"
+          value={state.compliance_requirement}
+          onChange={(e) => setState((prev) => ({ ...prev, compliance_requirement: e.target.value }))}
+          onBlur={() => { markTouched('compliance_requirement'); setErrors(validateForm(state)) }}
+          className={inputClass('compliance_requirement')}
+          aria-required="true"
+          aria-invalid={!!getFieldError('compliance_requirement')}
+          aria-describedby={[
+            'compliance_requirement_hint',
+            getFieldError('compliance_requirement') ? 'err-compliance_requirement' : '',
+          ].filter(Boolean).join(' ')}
+        >
+          {COMPLIANCE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value} disabled={opt.value === ''}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <FieldError id="err-compliance_requirement" message={getFieldError('compliance_requirement')} />
+      </div>
+
+      {/* Message */}
+      <div className="space-y-1 text-sm">
+        <label htmlFor="message" className="text-slate-300">
+          How can we help? <span className="text-red-400" aria-hidden="true">*</span>
+        </label>
         <textarea
-          required
+          id="message"
           value={state.message}
-          onChange={(event) => setState((prev) => ({ ...prev, message: event.target.value }))}
+          onChange={(e) => setState((prev) => ({ ...prev, message: e.target.value }))}
+          onBlur={() => { markTouched('message'); setErrors(validateForm(state)) }}
           rows={5}
           maxLength={2000}
-          className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-400 focus:border-primary focus:outline-none"
+          className={inputClass('message')}
           placeholder="Share your AI workflow, data types, and deployment goals."
+          aria-required="true"
+          aria-invalid={!!getFieldError('message')}
+          aria-describedby={getFieldError('message') ? 'err-message' : undefined}
         />
-      </label>
+        <FieldError id="err-message" message={getFieldError('message')} />
+      </div>
 
-      <label className="space-y-2 text-sm">
-        <span className="text-slate-300">Referral source (optional)</span>
+      {/* Referral source */}
+      <div className="space-y-1 text-sm">
+        <label htmlFor="referral_source" className="text-slate-300">
+          Referral source{' '}
+          <span className="text-slate-500 text-xs font-normal">(optional)</span>
+        </label>
         <input
+          id="referral_source"
           type="text"
           value={state.referral_source}
-          onChange={(event) => setState((prev) => ({ ...prev, referral_source: event.target.value }))}
+          onChange={(e) => setState((prev) => ({ ...prev, referral_source: e.target.value }))}
           className="w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-400 focus:border-primary focus:outline-none"
           maxLength={120}
+          placeholder="How did you hear about us?"
         />
-      </label>
+      </div>
 
+      {/* Honeypot */}
       <input
         type="text"
         value={state.company_website}
-        onChange={(event) => setState((prev) => ({ ...prev, company_website: event.target.value }))}
+        onChange={(e) => setState((prev) => ({ ...prev, company_website: e.target.value }))}
         className="hidden"
         tabIndex={-1}
         autoComplete="off"
@@ -233,20 +410,26 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
 
       <input type="hidden" name="website_intent" value={state.website_intent} />
       <input type="hidden" name="lead_source" value={state.lead_source} />
+      <input type="hidden" name="compliance_requirement" value={state.compliance_requirement} />
 
       {status === 'failed' ? (
-        <p className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+        <p role="alert" className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
           Form could not be submitted right now. Please try again or email {siteConfig.salesEmail}.
         </p>
       ) : null}
 
-      <button
-        type="submit"
-        disabled={isSubmitting}
-        className="btn btn-cta w-full disabled:cursor-not-allowed disabled:opacity-70 sm:w-auto"
-      >
-        {submitButtonLabel}
-      </button>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="btn btn-cta w-full disabled:cursor-not-allowed disabled:opacity-70 sm:w-auto"
+        >
+          {submitButtonLabel}
+        </button>
+        <p className="text-xs text-slate-500">
+          We respond within 24 hours.
+        </p>
+      </div>
     </form>
   )
 }

--- a/app/contact/thanks/page.tsx
+++ b/app/contact/thanks/page.tsx
@@ -32,10 +32,10 @@ export default function ContactThanksPage() {
             </div>
             <p className="mt-8 font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Message sent</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
-              We&apos;ll get back to you within 1 business day
+              We&apos;ll get back to you within 24 hours
             </h1>
             <p className="mt-6 text-xl text-slate-400">
-              Thanks for reaching out. The team will review your workflow, company context, and deployment needs before replying.
+              Thanks for reaching out. The team will review your workflow, compliance context, and deployment needs before replying.
             </p>
             <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
               <a href="/contact" className="btn btn-secondary px-8 py-4">


### PR DESCRIPTION
## Summary

- **Compliance segmentation dropdown** — new required \"Main compliance requirement\" select (GDPR, HIPAA, FCA/Financial, SOC 2, Other) added to `GoogleSheetsLeadForm`. The selected value is captured as `compliance_requirement` in `FormState` and sent to the Google Sheet submission endpoint alongside all existing fields. A hint line below the label explains the routing purpose to the user.
- **Intent-based routing** — existing `website_intent` / `lead_source` fields are preserved and continue to flow through unchanged. The `compliance_requirement` field now gives sales the second dimension needed to pre-segment leads before first response. Inbox routing per compliance value is trivial to add in the Apps Script layer once Sales confirms the mapping; no frontend change needed for that step.
- **\"We respond within 24 hours.\"** — SLA promise added inline next to the submit button. The thanks page headline updated from \"within 1 business day\" → \"within 24 hours\" to keep the promise consistent across the funnel.
- **Client-side validation** — replaced browser-native constraint validation (`required` attribute) with controlled per-field validation: errors show on blur for each field and a full sweep runs on submit. Focus jumps to the first invalid field. `FieldError` renders a `role="alert"` `<p>` linked via `aria-describedby` on the input.
- **Accessibility** — all fields use explicit `<label htmlFor>` + `id` pairing (previously used implicit wrapping label pattern), `aria-required`, `aria-invalid`, `aria-describedby` for errors and hints, `role="alert"` on error and failure messages.
- **Placeholders** — helpful placeholder text added to text inputs (Full name, Work email, Company name, Referral source).

## What's deferred (needs external infra)

**Nurture sequence (2-email if no reply in 48h)** is out of scope for this static marketing site. The contact form posts to a Google Apps Script endpoint that writes to a Google Sheet — there is no email automation layer, CRM, or background scheduler in this repo. To implement the nurture sequence:

1. Choose an email provider / CRM that can trigger workflows from a Google Sheet row (e.g. HubSpot, Mailchimp, Customer.io, SendGrid + Zapier/Make).
2. Wire a \"48h no-reply\" trigger in that provider using the `email` and `compliance_requirement` columns.
3. Write two email templates: (a) a compliance-specific follow-up referencing the selected framework; (b) a final check-in.

This is fully deliverable once the email provider is chosen — no further frontend work is required, as the `compliance_requirement` field is already captured in the submission.

## Test plan

- [ ] Load `/contact` — compliance dropdown renders with all 5 options, placeholder option is disabled
- [ ] Submit with all fields empty — all required fields show inline errors, focus jumps to Full name
- [ ] Enter invalid email format, blur — \"Please enter a valid email address.\" appears inline
- [ ] Fill compliance dropdown, blur away — error clears
- [ ] Fill all fields correctly — submit succeeds, redirects to `/contact/thanks`
- [ ] Thanks page shows \"within 24 hours\" in the headline
- [ ] Mobile: form fields stack single-column, compliance select is full-width, SLA text wraps cleanly below button
- [ ] Screen reader: aria-invalid / aria-describedby linkage verified with browser accessibility inspector

Closes nazifsohtaoglu/neutralai-gateway#1329