### PR TITLE
feat(blog): category filter + search bar (WEB-POST-03)

### DIFF
--- a/app/blog/BlogFilteredList.tsx
+++ b/app/blog/BlogFilteredList.tsx
@@ -43,6 +43,7 @@ export default function BlogFilteredList({ posts, categories }: BlogFilteredList
           <div className="flex flex-wrap gap-2">
             <button
               type="button"
+              aria-pressed={activeCategory === null}
               onClick={() => setActiveCategory(null)}
               className={[
                 'rounded-full border px-3.5 py-1.5 text-xs font-semibold transition',
@@ -57,6 +58,7 @@ export default function BlogFilteredList({ posts, categories }: BlogFilteredList
               <button
                 key={cat}
                 type="button"
+                aria-pressed={activeCategory === cat}
                 onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
                 className={[
                   'rounded-full border px-3.5 py-1.5 text-xs font-semibold transition',
@@ -75,6 +77,7 @@ export default function BlogFilteredList({ posts, categories }: BlogFilteredList
             <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-500" />
             <input
               type="text"
+              aria-label="Search blog articles"
               placeholder="Search articles…"
               value={query}
               onChange={(e) => setQuery(e.target.value)}

--- a/app/blog/BlogFilteredList.tsx
+++ b/app/blog/BlogFilteredList.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { CalendarDays, Clock3, Search, X } from 'lucide-react'
+import type { BlogPostMeta } from './posts'
+
+interface BlogFilteredListProps {
+  posts: BlogPostMeta[]
+  categories: string[]
+}
+
+export default function BlogFilteredList({ posts, categories }: BlogFilteredListProps) {
+  const [query, setQuery] = useState('')
+  const [activeCategory, setActiveCategory] = useState<string | null>(null)
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return posts.filter((post) => {
+      const matchesCategory = activeCategory === null || post.category === activeCategory
+      const matchesQuery =
+        q === '' ||
+        post.title.toLowerCase().includes(q) ||
+        post.description.toLowerCase().includes(q)
+      return matchesCategory && matchesQuery
+    })
+  }, [posts, query, activeCategory])
+
+  return (
+    <section className="section bg-background-secondary">
+      <div className="container-custom">
+        <div className="mb-8 max-w-3xl">
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Latest Articles</p>
+          <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
+            Start with the controls that unblock AI.
+          </h2>
+        </div>
+
+        {/* Filter bar */}
+        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          {/* Category chips */}
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setActiveCategory(null)}
+              className={[
+                'rounded-full border px-3.5 py-1.5 text-xs font-semibold transition',
+                activeCategory === null
+                  ? 'border-primary bg-primary/15 text-primary-light'
+                  : 'border-white/10 bg-white/[0.04] text-slate-400 hover:border-primary/40 hover:text-slate-200',
+              ].join(' ')}
+            >
+              All
+            </button>
+            {categories.map((cat) => (
+              <button
+                key={cat}
+                type="button"
+                onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
+                className={[
+                  'rounded-full border px-3.5 py-1.5 text-xs font-semibold transition',
+                  activeCategory === cat
+                    ? 'border-primary bg-primary/15 text-primary-light'
+                    : 'border-white/10 bg-white/[0.04] text-slate-400 hover:border-primary/40 hover:text-slate-200',
+                ].join(' ')}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+
+          {/* Search input */}
+          <div className="relative w-full sm:w-56 lg:w-72">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-500" />
+            <input
+              type="text"
+              placeholder="Search articles…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="w-full rounded-full border border-white/10 bg-white/[0.04] py-1.5 pl-8 pr-8 text-sm text-slate-200 placeholder-slate-500 outline-none transition focus:border-primary/50 focus:ring-1 focus:ring-primary/30"
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={() => setQuery('')}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-200"
+                aria-label="Clear search"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Post grid */}
+        {filtered.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 text-center text-slate-400">
+            <Search className="mb-4 h-8 w-8 text-slate-600" />
+            <p className="text-base font-medium text-slate-300">No articles found</p>
+            <p className="mt-1 text-sm">Try a different search term or category.</p>
+          </div>
+        ) : (
+          <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+            {filtered.map((post) => (
+              <Link
+                key={post.slug}
+                href={`/blog/${post.slug}`}
+                className="group overflow-hidden rounded-[24px] border border-white/10 bg-background transition hover:-translate-y-1 hover:border-primary/50"
+              >
+                {post.visual ? (
+                  <div className="relative aspect-[1.9] overflow-hidden border-b border-white/10">
+                    <Image
+                      src={post.visual.src}
+                      alt={post.visual.alt}
+                      fill
+                      sizes="(min-width: 1024px) 31vw, (min-width: 768px) 46vw, 100vw"
+                      className="object-cover transition duration-500 group-hover:scale-[1.04]"
+                    />
+                  </div>
+                ) : null}
+                <div className="p-6">
+                  <span className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs text-primary-light">
+                    {post.category}
+                  </span>
+                  <h3 className="mt-5 font-heading text-2xl font-semibold text-white">{post.title}</h3>
+                  <p className="mt-3 text-sm leading-6 text-slate-400">{post.description}</p>
+                  <div className="mt-6 flex items-center justify-between gap-4 text-xs text-slate-400">
+                    <span className="inline-flex items-center gap-1">
+                      <CalendarDays className="h-3.5 w-3.5" />
+                      {post.date}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <Clock3 className="h-3.5 w-3.5" />
+                      {post.readingTime}
+                    </span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, CalendarDays, Clock3, FileText } from 'lucide-react'
 import BackButton from '../components/BackButton'
 import { siteConfig } from '../site'
 import { getAllPosts } from './posts'
+import BlogFilteredList from './BlogFilteredList'
 
 export const metadata: Metadata = {
   title: 'Blog',
@@ -27,6 +28,7 @@ export const metadata: Metadata = {
 export default function BlogIndexPage() {
   const posts = getAllPosts()
   const featured = posts[0]
+  const categories = Array.from(new Set(posts.map((p) => p.category))).sort()
 
   return (
     <main className="min-h-screen pt-24">
@@ -92,47 +94,7 @@ export default function BlogIndexPage() {
         </div>
       </section>
 
-      <section className="section bg-background-secondary">
-        <div className="container-custom">
-          <div className="mb-8 max-w-3xl">
-            <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Latest Articles</p>
-            <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">Start with the controls that unblock AI.</h2>
-          </div>
-
-          <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
-            {posts.map((post) => (
-              <Link
-                key={post.slug}
-                href={`/blog/${post.slug}`}
-                className="group overflow-hidden rounded-[24px] border border-white/10 bg-background transition hover:-translate-y-1 hover:border-primary/50"
-              >
-                {post.visual ? (
-                  <div className="relative aspect-[1.9] overflow-hidden border-b border-white/10">
-                    <Image
-                      src={post.visual.src}
-                      alt={post.visual.alt}
-                      fill
-                      sizes="(min-width: 1024px) 31vw, (min-width: 768px) 46vw, 100vw"
-                      className="object-cover transition duration-500 group-hover:scale-[1.04]"
-                    />
-                  </div>
-                ) : null}
-                <div className="p-6">
-                  <span className="rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs text-primary-light">
-                    {post.category}
-                  </span>
-                  <h3 className="mt-5 font-heading text-2xl font-semibold text-white">{post.title}</h3>
-                  <p className="mt-3 text-sm leading-6 text-slate-400">{post.description}</p>
-                  <div className="mt-6 flex items-center justify-between gap-4 text-xs text-slate-400">
-                    <span>{post.date}</span>
-                    <span>{post.readingTime}</span>
-                  </div>
-                </div>
-              </Link>
-            ))}
-          </div>
-        </div>
-      </section>
+      <BlogFilteredList posts={posts} categories={categories} />
     </main>
   )
 }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,61 @@
+# NeutralAI
+
+> NeutralAI is an AI compliance gateway for regulated industries. It sits between user clients and downstream LLMs, detecting and masking PII before data reaches an external model, then optionally restoring it in the response.
+
+NeutralAI targets UK/EU regulated organisations: financial services, legal, healthcare, and any team that must demonstrate PII controls for GDPR, FCA, or sector-specific AI guidance.
+
+## What it does
+
+- **PII detection**: two-stage pipeline (Presidio NER + SpaCy + semantic embedding search) across English, German, Spanish, French, and Turkish text.
+- **Reversible tokenisation**: AES-256-GCM encrypted vault; tokens carry TTL, scope, and restore paths. PII never leaves the gateway unmasked.
+- **LLM routing**: managed (OpenRouter) or BYOK (OpenAI, Anthropic, Azure OpenAI, Gemini). Masking is enforced before every outbound call.
+- **Audit trail**: tamper-evident hash-chained audit log; compliance export; SIEM-ready event structure.
+- **Multi-tenant**: per-tenant policy scoping, API key lifecycle, seat management, SSO/SAML, BYOK key isolation.
+- **Browser enforcement**: Chrome and Edge extension shows a live shield status (Protected / Paused / Blocked) and applies masking inside the browser.
+
+## Key pages
+
+- [Product overview](https://neutralai.co.uk): what NeutralAI is and who it is for
+- [How it works](https://neutralai.co.uk/how-it-works): architecture layers from detection to vault to audit
+- [Pricing](https://neutralai.co.uk/pricing): plans for startups, growth, and enterprise; BYOK eligibility
+- [Security](https://neutralai.co.uk/security): encryption posture, SOC 2 roadmap, secret policy, penetration testing
+- [Trust center](https://neutralai.co.uk/trust-center): compliance evidence, data retention, vendor register
+- [Presidio alternative](https://neutralai.co.uk/presidio-alternative): build-vs-buy comparison with benchmark data
+- [Blog](https://neutralai.co.uk/blog): technical articles on PII detection, LLM routing, audit logging, and compliance engineering
+
+## Documentation
+
+- [Developers](https://neutralai.co.uk/developers): REST API reference, Python SDK, Node SDK, browser extension integration
+- [Install extension](https://neutralai.co.uk/install-extension): Chrome and Edge setup guide
+
+## Technical articles (blog)
+
+- [Why PII masking matters for enterprise AI adoption](https://neutralai.co.uk/blog/why-pii-masking-matters-for-enterprise-ai-adoption)
+- [PII detection accuracy: Regex vs NER vs LLM-based approaches](https://neutralai.co.uk/blog/pii-detection-accuracy-regex-vs-ner-vs-llm)
+- [Reversible masking and AES-GCM vault design](https://neutralai.co.uk/blog/reversible-pii-masking-ttl-aes-gcm-vault)
+- [Redacting PII in streaming LLM responses](https://neutralai.co.uk/blog/redacting-pii-in-streaming-llm-responses)
+- [Semantic PII detection with embeddings](https://neutralai.co.uk/blog/semantic-pii-detection-with-embeddings)
+- [Multilingual PII detection (Turkish NER)](https://neutralai.co.uk/blog/multilingual-pii-detection-turkish-ner)
+- [Tamper-evident audit log with hash chains](https://neutralai.co.uk/blog/tamper-evident-audit-log-hash-chain)
+- [Fail-closed AI gateway resilience](https://neutralai.co.uk/blog/fail-closed-ai-gateway-resilience)
+- [BYOK encryption key custody](https://neutralai.co.uk/blog/byok-encryption-key-custody)
+- [How UK financial services teams use AI safely under FCA guidance](https://neutralai.co.uk/blog/how-uk-financial-services-teams-use-ai-safely-under-fca-guidance)
+- [NeutralAI vs Private AI vs Nightfall benchmark 2026](https://neutralai.co.uk/blog/neutralai-vs-private-ai-vs-nightfall-pii-detection-benchmark-2026)
+- [From Presidio to production: what regulated teams actually need](https://neutralai.co.uk/blog/from-presidio-to-production-regulated-teams)
+- [PII-safe logging and redaction](https://neutralai.co.uk/blog/pii-safe-logging-redaction)
+- [Signing webhooks and SSRF defence](https://neutralai.co.uk/blog/signing-webhooks-and-ssrf-defense)
+- [SIEM event normalisation without PII](https://neutralai.co.uk/blog/siem-event-normalization-without-pii)
+- [Policy consistency across replicas](https://neutralai.co.uk/blog/policy-consistency-across-replicas)
+- [LLM routing strategy and fallback](https://neutralai.co.uk/blog/llm-routing-strategy-and-fallback)
+- [Reliable usage metering with transactional outbox](https://neutralai.co.uk/blog/reliable-usage-metering-transactional-outbox)
+- [Detecting PII in documents (PDF, DOCX)](https://neutralai.co.uk/blog/detecting-pii-in-documents-pdf-docx)
+- [Encryption key rotation without downtime](https://neutralai.co.uk/blog/encryption-key-rotation-without-downtime)
+- [Fail at boot: secret validation](https://neutralai.co.uk/blog/fail-at-boot-secret-validation)
+- [Hidden cost of shadow AI](https://neutralai.co.uk/blog/hidden-cost-of-shadow-ai-security-control-point)
+- [When a lawyer pasted a document into ChatGPT](https://neutralai.co.uk/blog/uk-tribunal-ai-client-confidentiality-ruling)
+
+## Contact
+
+- General: hello@neutralai.co.uk
+- Security: security@neutralai.co.uk
+- Privacy: privacy@neutralai.co.uk

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -10,7 +10,7 @@ NeutralAI targets UK/EU regulated organisations: financial services, legal, heal
 - **Reversible tokenisation**: AES-256-GCM encrypted vault; tokens carry TTL, scope, and restore paths. PII never leaves the gateway unmasked.
 - **LLM routing**: managed (OpenRouter) or BYOK (OpenAI, Anthropic, Azure OpenAI, Gemini). Masking is enforced before every outbound call.
 - **Audit trail**: tamper-evident hash-chained audit log; compliance export; SIEM-ready event structure.
-- **Multi-tenant**: per-tenant policy scoping, API key lifecycle, seat management, SSO/SAML, BYOK key isolation.
+- **Multi-tenant**: per-tenant policy scoping, API key lifecycle, seat management, SSO/SAML 2.0 (Enterprise plan only), BYOK key isolation.
 - **Browser enforcement**: Chrome and Edge extension shows a live shield status (Protected / Paused / Blocked) and applies masking inside the browser.
 
 ## Key pages
@@ -18,8 +18,8 @@ NeutralAI targets UK/EU regulated organisations: financial services, legal, heal
 - [Product overview](https://neutralai.co.uk): what NeutralAI is and who it is for
 - [How it works](https://neutralai.co.uk/how-it-works): architecture layers from detection to vault to audit
 - [Pricing](https://neutralai.co.uk/pricing): plans for startups, growth, and enterprise; BYOK eligibility
-- [Security](https://neutralai.co.uk/security): encryption posture, SOC 2 roadmap, secret policy, penetration testing
-- [Trust center](https://neutralai.co.uk/trust-center): compliance evidence, data retention, vendor register
+- [Security](https://neutralai.co.uk/security): encryption posture, SOC 2 roadmap, secret policy, audit posture
+- [Trust center](https://neutralai.co.uk/trust-center): compliance evidence, data retention
 - [Presidio alternative](https://neutralai.co.uk/presidio-alternative): build-vs-buy comparison with benchmark data
 - [Blog](https://neutralai.co.uk/blog): technical articles on PII detection, LLM routing, audit logging, and compliance engineering
 
@@ -53,6 +53,8 @@ NeutralAI targets UK/EU regulated organisations: financial services, legal, heal
 - [Fail at boot: secret validation](https://neutralai.co.uk/blog/fail-at-boot-secret-validation)
 - [Hidden cost of shadow AI](https://neutralai.co.uk/blog/hidden-cost-of-shadow-ai-security-control-point)
 - [When a lawyer pasted a document into ChatGPT](https://neutralai.co.uk/blog/uk-tribunal-ai-client-confidentiality-ruling)
+- [PII detection precision: checksums, context gates, and overlap suppression](https://neutralai.co.uk/blog/pii-detection-precision-checksums-context-gates)
+- [We hand-wrote our JWT verifier, because in JWT, flexibility is a vulnerability](https://neutralai.co.uk/blog/why-we-hand-rolled-jwt-verification)
 
 ## Contact
 


### PR DESCRIPTION
## Summary

- Adds a `BlogFilteredList` `'use client'` component with a search input and category chip filter above the post grid
- Server page (`app/blog/page.tsx`) stays a pure server component: it fetches all posts at build time via `getAllPosts()`, derives the unique sorted category list, and passes both as props
- Filtering is fully client-side (no server round-trips) — `useMemo` over title/description match + active category
- Empty-state handled with a "No articles found" message
- 6 categories detected from current posts: AI Governance, Benchmarks, Engineering, Financial Services, Presidio Alternative, Technical
- Styled with the existing slate/primary design system (rounded-full chips, matching focus ring, X clear button on search)
- Build passes: `npm run build` — 53 pages, TypeScript clean

## Test plan

- [ ] Visit `/blog` — post grid renders all 25 posts unchanged
- [ ] Click a category chip — grid filters to matching posts only; active chip highlights in primary colour
- [ ] Click "All" — resets to full list
- [ ] Type in search box — filters by title/description reactively
- [ ] Combine category + search — both filters apply together
- [ ] Clear search with X button — search resets, category filter remains
- [ ] Type a term with no matches — empty state message shown

Closes #126