### PR TITLE
feat(trust-center): self-service security pack gated download

### DIFF
--- a/app/components/AnalyticsProvider.tsx
+++ b/app/components/AnalyticsProvider.tsx
@@ -29,12 +29,24 @@ function safeDestination(element: HTMLElement) {
 }
 
 function getEventProperties(element: HTMLElement, pathname: string): AnalyticsProperties {
-  return {
+  const props: AnalyticsProperties = {
     label: element.dataset.analyticsLabel || element.textContent?.trim().replace(/\s+/g, ' ').slice(0, 80) || 'unknown',
     placement: element.dataset.analyticsPlacement || 'unspecified',
     destination: element.dataset.analyticsDestination || safeDestination(element),
     page_path: pathname,
   }
+
+  // Funnel: cta_click — cta_id identifies the specific call-to-action
+  if (element.dataset.analyticsCtaId) {
+    props.cta_id = element.dataset.analyticsCtaId
+  }
+
+  // Funnel: pricing_plan_click — plan identifies which pricing tier was selected
+  if (element.dataset.analyticsPlan) {
+    props.plan = element.dataset.analyticsPlan
+  }
+
+  return props
 }
 
 export default function AnalyticsProvider() {

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -108,9 +108,10 @@ export default function Navbar() {
           <Link
             href={siteConfig.signupUrl}
             className="btn btn-cta whitespace-nowrap px-5 py-3 text-sm 2xl:text-base"
-            data-analytics-event="CTA Click"
+            data-analytics-event="cta_click"
             data-analytics-label="Get Started Free"
             data-analytics-placement="navbar_desktop"
+            data-analytics-cta-id="nav_get_started"
           >
             Get Started Free
           </Link>
@@ -176,9 +177,10 @@ export default function Navbar() {
             href={siteConfig.signupUrl}
             className="btn btn-cta w-full mt-4"
             onClick={() => setIsOpen(false)}
-            data-analytics-event="CTA Click"
+            data-analytics-event="cta_click"
             data-analytics-label="Get Started Free"
             data-analytics-placement="navbar_mobile"
+            data-analytics-cta-id="nav_get_started"
           >
             Get Started Free
           </Link>

--- a/app/components/SecurityPackForm.tsx
+++ b/app/components/SecurityPackForm.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { FormEvent, useState } from 'react'
+import { CheckCircle2, Download, Loader2 } from 'lucide-react'
+import { siteConfig } from '../site'
+
+const GOOGLE_SHEETS_EXEC_PATH_REGEX = /^\/macros\/s\/[a-z0-9_-]+\/exec\/?$/i
+
+function resolveEndpoint(raw: string): string | null {
+  if (!raw) return null
+  try {
+    const parsed = new URL(raw)
+    if (parsed.protocol !== 'https:' || parsed.hostname !== 'script.google.com') return null
+    if (parsed.username || parsed.password || parsed.search || parsed.hash) return null
+    if (!GOOGLE_SHEETS_EXEC_PATH_REGEX.test(parsed.pathname)) return null
+    return parsed.toString()
+  } catch {
+    return null
+  }
+}
+
+type Status = 'idle' | 'submitting' | 'success' | 'error'
+
+export default function SecurityPackForm() {
+  const endpoint = resolveEndpoint(siteConfig.leadCapture.googleSheetsEndpoint)
+  const [status, setStatus] = useState<Status>('idle')
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [company, setCompany] = useState('')
+  const [honeypot, setHoneypot] = useState('')
+
+  if (status === 'success') {
+    return (
+      <div className="rounded-2xl border border-accent-success/30 bg-accent-success/10 p-6 text-center">
+        <CheckCircle2 className="mx-auto h-8 w-8 text-accent-success" />
+        <p className="mt-3 text-base font-semibold text-white">Security pack ready</p>
+        <p className="mt-1 text-sm text-slate-300">
+          Download the summary below. Detailed evidence and questionnaire prefill is sent to your email.
+        </p>
+        <a
+          href="/security-pack"
+          className="btn btn-cta mt-5 inline-flex items-center gap-2"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Download className="h-4 w-4" />
+          Open security summary
+        </a>
+      </div>
+    )
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault()
+    if (honeypot.trim()) return
+
+    if (!name.trim() || !email.trim() || !company.trim()) return
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) return
+
+    setStatus('submitting')
+
+    const payload = {
+      full_name: name.trim(),
+      email: email.trim(),
+      company_name: company.trim(),
+      website_intent: 'website_security_pack_download',
+      lead_source: 'trust_center_security_pack',
+      message: 'Security pack download request',
+    }
+
+    try {
+      if (endpoint) {
+        await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+      }
+      setStatus('success')
+    } catch {
+      setStatus('success')
+    }
+  }
+
+  const inputClass =
+    'w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none text-sm'
+
+  return (
+    <form onSubmit={handleSubmit} className="grid gap-4">
+      <input
+        name="company_website"
+        value={honeypot}
+        onChange={(e) => setHoneypot(e.target.value)}
+        className="hidden"
+        tabIndex={-1}
+        aria-hidden="true"
+        autoComplete="off"
+      />
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="block">
+          <span className="sr-only">Full name</span>
+          <input
+            type="text"
+            placeholder="Full name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            className={inputClass}
+            autoComplete="name"
+          />
+        </label>
+        <label className="block">
+          <span className="sr-only">Work email</span>
+          <input
+            type="email"
+            placeholder="Work email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className={inputClass}
+            autoComplete="email"
+          />
+        </label>
+      </div>
+      <label className="block">
+        <span className="sr-only">Company</span>
+        <input
+          type="text"
+          placeholder="Company name"
+          value={company}
+          onChange={(e) => setCompany(e.target.value)}
+          required
+          className={inputClass}
+          autoComplete="organization"
+        />
+      </label>
+
+      {status === 'error' && (
+        <p className="text-sm text-red-400">Something went wrong — please try again or email {siteConfig.securityEmail}.</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="btn btn-cta flex items-center justify-center gap-2"
+      >
+        {status === 'submitting' ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Preparing pack…
+          </>
+        ) : (
+          <>
+            <Download className="h-4 w-4" />
+            Get security pack
+          </>
+        )}
+      </button>
+    </form>
+  )
+}

--- a/app/components/SecurityPackForm.tsx
+++ b/app/components/SecurityPackForm.tsx
@@ -3,6 +3,8 @@
 import { FormEvent, useState } from 'react'
 import { CheckCircle2, Download, Loader2 } from 'lucide-react'
 import { siteConfig } from '../site'
+import { getLeadAttribution } from '../lib/analytics'
+import { getReferralSnapshot, referralSnapshotToFieldMap } from '../lib/referral'
 
 const GOOGLE_SHEETS_EXEC_PATH_REGEX = /^\/macros\/s\/[a-z0-9_-]+\/exec\/?$/i
 
@@ -35,7 +37,7 @@ export default function SecurityPackForm() {
         <CheckCircle2 className="mx-auto h-8 w-8 text-accent-success" />
         <p className="mt-3 text-base font-semibold text-white">Security pack ready</p>
         <p className="mt-1 text-sm text-slate-300">
-          Download the summary below. Detailed evidence and questionnaire prefill is sent to your email.
+          Download the summary below. Our security team will follow up by email with detailed evidence and questionnaire prefill.
         </p>
         <a
           href="/security-pack"
@@ -59,26 +61,43 @@ export default function SecurityPackForm() {
 
     setStatus('submitting')
 
-    const payload = {
+    const payload: Record<string, string> = {
       full_name: name.trim(),
       email: email.trim(),
       company_name: company.trim(),
+      company_website: '',
       website_intent: 'website_security_pack_download',
       lead_source: 'trust_center_security_pack',
       message: 'Security pack download request',
+      website_page_url: typeof window !== 'undefined' ? window.location.href : '',
+    }
+
+    Object.entries(getLeadAttribution()).forEach(([key, value]) => {
+      payload[key] = String(value)
+    })
+
+    const referralSnapshot = getReferralSnapshot()
+    if (referralSnapshot) {
+      Object.entries(referralSnapshotToFieldMap(referralSnapshot)).forEach(([key, value]) => {
+        payload[key] = value
+      })
     }
 
     try {
       if (endpoint) {
-        await fetch(endpoint, {
+        const response = await fetch(endpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
         })
+        if (!response.ok) {
+          setStatus('error')
+          return
+        }
       }
       setStatus('success')
     } catch {
-      setStatus('success')
+      setStatus('error')
     }
   }
 

--- a/app/components/analytics/ScrollDepthTracker.tsx
+++ b/app/components/analytics/ScrollDepthTracker.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { useScrollDepth } from '../../hooks/useScrollDepth'
+
+/**
+ * Mounts the scroll-depth tracking hook as a side-effect only component.
+ * Renders null — include it once in a layout or page to track scroll milestones.
+ * Fires `scroll_depth` PostHog events at 25 / 50 / 75 / 90 / 100 % once per page view.
+ */
+export default function ScrollDepthTracker() {
+  useScrollDepth()
+  return null
+}

--- a/app/components/home/CtaSection.tsx
+++ b/app/components/home/CtaSection.tsx
@@ -32,7 +32,7 @@ export default function CtaSection() {
             <a
               href={contactLinks.enterprise}
               className="btn btn-secondary w-full px-8 py-4 text-lg sm:w-auto"
-              data-analytics-event="CTA Click"
+              data-analytics-event="cta_click"
               data-analytics-label="Talk to Sales"
               data-analytics-placement="homepage_final_cta"
             >
@@ -44,7 +44,7 @@ export default function CtaSection() {
             <a
               href={contactLinks.enterprise}
               className="text-primary-light hover:text-primary"
-              data-analytics-event="CTA Click"
+              data-analytics-event="cta_click"
               data-analytics-label="Contact NeutralAI"
               data-analytics-placement="homepage_final_cta"
             >

--- a/app/components/home/CtaSection.tsx
+++ b/app/components/home/CtaSection.tsx
@@ -21,9 +21,10 @@ export default function CtaSection() {
             <a
               href={siteConfig.signupUrl}
               className="btn btn-cta w-full px-8 py-4 text-lg sm:w-auto"
-              data-analytics-event="CTA Click"
+              data-analytics-event="cta_click"
               data-analytics-label="Try Free"
               data-analytics-placement="homepage_final_cta"
+              data-analytics-cta-id="final_cta_start_free_trial"
             >
               Try Free
               <ArrowRight className="h-5 w-5" />

--- a/app/components/home/Hero.tsx
+++ b/app/components/home/Hero.tsx
@@ -41,9 +41,10 @@ export default function Hero() {
               <a
                 href={siteConfig.signupUrl}
                 className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto"
-                data-analytics-event="CTA Click"
+                data-analytics-event="cta_click"
                 data-analytics-label="Try Free"
                 data-analytics-placement="homepage_hero"
+                data-analytics-cta-id="hero_start_free_trial"
               >
                 Try Free
                 <ArrowRight className="h-5 w-5" />
@@ -51,9 +52,10 @@ export default function Hero() {
               <a
                 href={siteConfig.demoUrl}
                 className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto"
-                data-analytics-event="CTA Click"
+                data-analytics-event="cta_click"
                 data-analytics-label="Book Demo"
                 data-analytics-placement="homepage_hero"
+                data-analytics-cta-id="hero_book_demo"
               >
                 Book Demo
               </a>

--- a/app/components/home/Hero.tsx
+++ b/app/components/home/Hero.tsx
@@ -64,7 +64,7 @@ export default function Hero() {
               <a
                 href="/install-extension"
                 className="text-primary-light transition-colors hover:text-primary"
-                data-analytics-event="CTA Click"
+                data-analytics-event="cta_click"
                 data-analytics-label="Install Browser Extension"
                 data-analytics-placement="homepage_hero"
               >

--- a/app/components/home/PricingSection.tsx
+++ b/app/components/home/PricingSection.tsx
@@ -183,9 +183,11 @@ export default function PricingSection() {
               <a
                 href={plan.href}
                 className={`btn mt-8 w-full ${plan.featured ? 'btn-cta' : 'btn-secondary'}`}
-                data-analytics-event="CTA Click"
+                data-analytics-event="pricing_plan_click"
                 data-analytics-label={`${plan.name} ${plan.cta}`}
                 data-analytics-placement="homepage_pricing_primary"
+                data-analytics-cta-id="pricing_start_trial"
+                data-analytics-plan={plan.name.toLowerCase()}
               >
                 {plan.cta}
               </a>
@@ -249,9 +251,10 @@ export default function PricingSection() {
                 <a
                   href={plan.href}
                   className="btn btn-secondary w-full"
-                  data-analytics-event="CTA Click"
+                  data-analytics-event="pricing_plan_click"
                   data-analytics-label={`${plan.name} ${plan.cta}`}
                   data-analytics-placement="homepage_pricing_advanced"
+                  data-analytics-plan={plan.name.toLowerCase()}
                 >
                   {plan.cta}
                 </a>

--- a/app/hooks/useScrollDepth.ts
+++ b/app/hooks/useScrollDepth.ts
@@ -1,28 +1,35 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import { usePathname } from 'next/navigation'
-import { trackAnalyticsEvent } from '../lib/analytics'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { hasAnalyticsConsent, trackAnalyticsEvent } from '../lib/analytics'
 
 const MILESTONES = [25, 50, 75, 90, 100] as const
 type Milestone = (typeof MILESTONES)[number]
 
 export function useScrollDepth() {
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   // Track which milestones have fired for the current page view
   const firedRef = useRef<Set<Milestone>>(new Set())
-  // Reset fired milestones when the path changes
-  const prevPathRef = useRef<string>(pathname)
+  // Reset fired milestones when the path or query string changes
+  const prevPageKeyRef = useRef<string>(`${pathname}?${searchParams.toString()}`)
 
   useEffect(() => {
-    if (prevPathRef.current !== pathname) {
+    const pageKey = `${pathname}?${searchParams.toString()}`
+    if (prevPageKeyRef.current !== pageKey) {
       firedRef.current = new Set()
-      prevPathRef.current = pathname
+      prevPageKeyRef.current = pageKey
     }
-  }, [pathname])
+  }, [pathname, searchParams])
 
   useEffect(() => {
     function handleScroll() {
+      // Only mark milestones and fire events after analytics consent is given.
+      // If consent is not yet accepted, skip silently — milestones won't be
+      // recorded in firedRef so they'll fire correctly once consent is granted.
+      if (!hasAnalyticsConsent()) return
+
       const scrollTop = window.scrollY
       const docHeight = document.documentElement.scrollHeight - window.innerHeight
       if (docHeight <= 0) return
@@ -34,7 +41,7 @@ export function useScrollDepth() {
           firedRef.current.add(milestone)
           trackAnalyticsEvent('scroll_depth', {
             depth: milestone,
-            path: pathname,
+            page_path: pathname,
           })
         }
       }
@@ -45,5 +52,5 @@ export function useScrollDepth() {
     handleScroll()
 
     return () => window.removeEventListener('scroll', handleScroll)
-  }, [pathname])
+  }, [pathname, searchParams])
 }

--- a/app/hooks/useScrollDepth.ts
+++ b/app/hooks/useScrollDepth.ts
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { usePathname } from 'next/navigation'
+import { trackAnalyticsEvent } from '../lib/analytics'
+
+const MILESTONES = [25, 50, 75, 90, 100] as const
+type Milestone = (typeof MILESTONES)[number]
+
+export function useScrollDepth() {
+  const pathname = usePathname()
+  // Track which milestones have fired for the current page view
+  const firedRef = useRef<Set<Milestone>>(new Set())
+  // Reset fired milestones when the path changes
+  const prevPathRef = useRef<string>(pathname)
+
+  useEffect(() => {
+    if (prevPathRef.current !== pathname) {
+      firedRef.current = new Set()
+      prevPathRef.current = pathname
+    }
+  }, [pathname])
+
+  useEffect(() => {
+    function handleScroll() {
+      const scrollTop = window.scrollY
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight
+      if (docHeight <= 0) return
+
+      const pct = Math.min(100, Math.round((scrollTop / docHeight) * 100))
+
+      for (const milestone of MILESTONES) {
+        if (pct >= milestone && !firedRef.current.has(milestone)) {
+          firedRef.current.add(milestone)
+          trackAnalyticsEvent('scroll_depth', {
+            depth: milestone,
+            path: pathname,
+          })
+        }
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    // Fire immediately in case page is already scrolled (e.g. after navigation)
+    handleScroll()
+
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [pathname])
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import Navbar from './components/Navbar'
 import Footer from './components/Footer'
 import AnalyticsProvider from './components/AnalyticsProvider'
 import ReferralProvider from './components/ReferralProvider'
+import ScrollDepthTracker from './components/analytics/ScrollDepthTracker'
 import { siteConfig } from './site'
 
 const dmSans = DM_Sans({
@@ -154,6 +155,9 @@ export default function RootLayout({
         </Suspense>
         <Suspense fallback={null}>
           <AnalyticsProvider />
+        </Suspense>
+        <Suspense fallback={null}>
+          <ScrollDepthTracker />
         </Suspense>
       </body>
     </html>

--- a/app/security-pack/page.tsx
+++ b/app/security-pack/page.tsx
@@ -1,0 +1,217 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import {
+  CheckCircle2,
+  FileText,
+  KeyRound,
+  Lock,
+  ShieldCheck,
+  Activity,
+} from 'lucide-react'
+import { siteConfig } from '../site'
+
+export const metadata: Metadata = {
+  title: 'NeutralAI Security Pack',
+  description: 'NeutralAI security summary: encryption posture, SOC2 readiness status, common questionnaire answers, and compliance evidence for enterprise review.',
+  robots: { index: false, follow: false },
+}
+
+const encryptionControls = [
+  { label: 'Vault encryption', value: 'AES-256-GCM with per-tenant key derivation' },
+  { label: 'Transport', value: 'TLS 1.2+ enforced; HSTS preload on production domains' },
+  { label: 'Key management', value: 'Tenant BYOK supported; legacy key rotation supported via VAULT_LEGACY_ENCRYPTION_KEYS' },
+  { label: 'Token TTL', value: 'Default 15 minutes; configurable per tenant policy' },
+  { label: 'Secrets at rest', value: 'Validated at boot; plaintext-placeholder secrets rejected in production' },
+] as const
+
+const soc2Controls = [
+  { domain: 'Security (CC)', status: 'Mapped', note: 'Access control, encryption, incident response, change management' },
+  { domain: 'Availability (A)', status: 'Mapped', note: 'Health checks, readiness endpoints, rollback procedures, latency evidence' },
+  { domain: 'Confidentiality (C)', status: 'Mapped', note: 'Data minimisation, masked-only egress, zero-retention operating pattern' },
+  { domain: 'Processing Integrity (PI)', status: 'Partial', note: 'PII detection accuracy benchmarked; holdout guardrail in place' },
+  { domain: 'Privacy (P)', status: 'Partial', note: 'GDPR data-subject workflow in design; DPA template available on request' },
+] as const
+
+const qaAnswers = [
+  {
+    q: 'Do you have a SOC 2 certification?',
+    a: 'No formal audit has completed. SOC 2 controls are mapped across Security, Availability, and Confidentiality. The readiness report is available for enterprise review under NDA.',
+  },
+  {
+    q: 'Where is customer data stored and processed?',
+    a: 'Production runs on Hetzner Cloud (EU). Prompt data is masked before any egress to external LLM providers. Vault tokens are encrypted at rest with AES-256-GCM. Retention defaults to session scope unless tenants configure longer periods.',
+  },
+  {
+    q: 'What PII is logged?',
+    a: 'Audit events log event type, tenant, timestamp, and masked identifiers — never raw PII. PII masking is enforced before audit write. SIEM-ready event structure is available.',
+  },
+  {
+    q: 'Do you support BYOK (Bring Your Own Key)?',
+    a: 'Yes. Growth and Enterprise plans support BYOK for LLM provider API keys (OpenAI, Anthropic, Azure OpenAI, Gemini). Vault encryption keys can be rotated without downtime.',
+  },
+  {
+    q: 'What happens if the gateway is unavailable?',
+    a: 'Fail-closed is the default: if PII detection fails at boot, the service does not start. If the gateway becomes unavailable mid-session, the browser extension enters a documented fail mode (block / local_mask / allow, configurable per tenant policy).',
+  },
+  {
+    q: 'Is multi-tenancy enforced at the data layer?',
+    a: 'Yes. Every database row carrying sensitive data has a tenant_id foreign key. Vault tokens are tenant-scoped. API keys are tenant-bound. SSO configs are tenant-isolated with DNS TXT domain verification.',
+  },
+  {
+    q: 'Do you have a penetration testing programme?',
+    a: 'A pen-test readiness assessment has been completed internally. Third-party external pen test is on the roadmap before enterprise GA. Results will be shared under NDA upon request.',
+  },
+  {
+    q: 'What is your incident response SLA?',
+    a: 'Initial acknowledgement within 4 business hours for P0 security incidents. Escalation, containment, post-incident review, and customer communication workflows are documented in the internal runbook.',
+  },
+] as const
+
+export default function SecurityPackPage() {
+  return (
+    <main className="min-h-screen pt-24">
+      <section className="relative overflow-hidden py-16 md:py-20">
+        <div className="absolute inset-0 grid-bg opacity-20" />
+        <div className="container-custom relative z-10">
+          <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
+            <ShieldCheck className="h-3.5 w-3.5" />
+            Security pack — not for public distribution
+          </div>
+          <h1 className="mt-5 font-heading text-4xl font-bold md:text-6xl">
+            NeutralAI Security Summary
+          </h1>
+          <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+            Prepared for enterprise security review. This document covers encryption posture, SOC 2 control mapping, common procurement questionnaire answers, and evidence availability. For detailed artefacts or NDA-scoped review, contact{' '}
+            <a href={`mailto:${siteConfig.securityEmail}`} className="text-primary-light hover:text-primary">
+              {siteConfig.securityEmail}
+            </a>.
+          </p>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container-custom space-y-12">
+
+          {/* Encryption posture */}
+          <div>
+            <div className="flex items-center gap-3 mb-5">
+              <KeyRound className="h-5 w-5 text-primary-light" />
+              <h2 className="font-heading text-2xl font-bold">Encryption posture</h2>
+            </div>
+            <div className="overflow-hidden rounded-2xl border border-white/10">
+              {encryptionControls.map((row, i) => (
+                <div key={row.label} className={`grid md:grid-cols-[1fr_2fr] gap-2 px-5 py-4 text-sm ${i < encryptionControls.length - 1 ? 'border-b border-white/10' : ''}`}>
+                  <span className="font-medium text-white">{row.label}</span>
+                  <span className="text-slate-300">{row.value}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* SOC 2 readiness */}
+          <div>
+            <div className="flex items-center gap-3 mb-2">
+              <FileText className="h-5 w-5 text-primary-light" />
+              <h2 className="font-heading text-2xl font-bold">SOC 2 readiness</h2>
+            </div>
+            <p className="mb-5 text-sm text-slate-400">
+              No formal audit has completed. Controls are mapped; this is a readiness summary, not a certification claim.
+            </p>
+            <div className="overflow-hidden rounded-2xl border border-white/10">
+              {soc2Controls.map((row, i) => (
+                <div key={row.domain} className={`grid md:grid-cols-[1fr_auto_2fr] gap-3 items-center px-5 py-4 text-sm ${i < soc2Controls.length - 1 ? 'border-b border-white/10' : ''}`}>
+                  <span className="font-medium text-white">{row.domain}</span>
+                  <span className={`rounded-full px-2.5 py-0.5 text-xs font-semibold w-fit ${row.status === 'Mapped' ? 'bg-accent-success/15 text-accent-success border border-accent-success/25' : 'bg-[#fdba74]/10 text-[#fdba74] border border-[#fdba74]/25'}`}>
+                    {row.status}
+                  </span>
+                  <span className="text-slate-300">{row.note}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Access controls */}
+          <div>
+            <div className="flex items-center gap-3 mb-5">
+              <Lock className="h-5 w-5 text-primary-light" />
+              <h2 className="font-heading text-2xl font-bold">Access controls</h2>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {[
+                'SSO / SAML 2.0 via BoxyHQ Jackson (enterprise plan)',
+                'MFA enforced at the identity-provider layer for SSO tenants',
+                'JWT-based session tokens; no long-lived session cookies',
+                'DNS TXT domain verification before SSO activation',
+                'Per-tenant API key lifecycle; nai_-prefixed keys rate-limited by tenant',
+                'Admin RBAC: Owner / Admin / Member roles with scoped endpoints',
+              ].map((item) => (
+                <div key={item} className="flex items-start gap-2 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-slate-300">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary-light" />
+                  <span>{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Availability */}
+          <div>
+            <div className="flex items-center gap-3 mb-5">
+              <Activity className="h-5 w-5 text-primary-light" />
+              <h2 className="font-heading text-2xl font-bold">Availability posture</h2>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {[
+                { label: 'Health endpoint', value: 'GET /health — checked by load balancer and uptime monitor' },
+                { label: 'Readiness endpoint', value: 'GET /ready — checks DB, Redis, and Qdrant connectivity' },
+                { label: 'Fail-closed default', value: 'Service refuses to start if secrets fail boot validation' },
+                { label: 'Extension fail mode', value: 'block / local_mask / allow — configurable per tenant policy' },
+                { label: 'Database backup', value: 'Daily encrypted pg_dump offsite (Hetzner Storage Box)' },
+                { label: 'Rollback', value: 'Alembic down-revision available; deployment rollback documented in SOP' },
+              ].map((row) => (
+                <div key={row.label} className="rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm">
+                  <span className="font-medium text-white">{row.label}: </span>
+                  <span className="text-slate-300">{row.value}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Questionnaire prefill */}
+          <div>
+            <div className="flex items-center gap-3 mb-5">
+              <ShieldCheck className="h-5 w-5 text-primary-light" />
+              <h2 className="font-heading text-2xl font-bold">Common questionnaire answers</h2>
+            </div>
+            <div className="space-y-4">
+              {qaAnswers.map((item) => (
+                <div key={item.q} className="rounded-2xl border border-white/10 bg-white/[0.02] px-5 py-5">
+                  <p className="font-medium text-white">{item.q}</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-300">{item.a}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Footer CTA */}
+          <div className="rounded-2xl border border-primary/20 bg-primary/10 px-6 py-8 text-center">
+            <p className="text-sm text-slate-300">
+              Need detailed artefacts, the full readiness report, or help completing a security questionnaire?
+            </p>
+            <a
+              href={`mailto:${siteConfig.securityEmail}?subject=Security%20review%20request`}
+              className="btn btn-cta mt-4 inline-flex"
+            >
+              Contact security team
+            </a>
+            <div className="mt-5">
+              <Link href="/trust-center" className="text-sm text-primary-light hover:text-primary">
+                ← Back to trust center
+              </Link>
+            </div>
+          </div>
+
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/security-pack/page.tsx
+++ b/app/security-pack/page.tsx
@@ -75,7 +75,7 @@ export default function SecurityPackPage() {
         <div className="container-custom relative z-10">
           <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
             <ShieldCheck className="h-3.5 w-3.5" />
-            Security pack — not for public distribution
+            Security pack
           </div>
           <h1 className="mt-5 font-heading text-4xl font-bold md:text-6xl">
             NeutralAI Security Summary

--- a/app/trust-center/page.tsx
+++ b/app/trust-center/page.tsx
@@ -11,6 +11,7 @@ import {
   Siren,
 } from 'lucide-react'
 import BackButton from '../components/BackButton'
+import SecurityPackForm from '../components/SecurityPackForm'
 import { contactLinks, siteConfig } from '../site'
 import {
   EgressFlowDiagram,
@@ -304,17 +305,15 @@ export default function TrustCenterPage() {
 
       <section className="section bg-background-secondary">
         <div className="container-custom">
-          <div className="grid gap-6 rounded-lg border border-border bg-background p-6 md:grid-cols-[1fr_auto] md:items-center md:p-8">
-            <div>
-              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Next step</p>
-              <h2 className="mt-3 font-heading text-3xl font-bold">Need the evidence pack?</h2>
+          <div className="rounded-2xl border border-border bg-background p-6 md:p-8">
+            <div className="mb-6">
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Self-service</p>
+              <h2 className="mt-3 font-heading text-3xl font-bold">Get the security pack</h2>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-400">
-                Send the security context you need reviewed. We will route questionnaire, readiness, and compliance evidence requests through the right owner.
+                Download the security summary instantly — encryption posture, SOC 2 control mapping, and prefilled questionnaire answers. For detailed artefacts or NDA-scoped review, the security team follows up by email.
               </p>
             </div>
-            <a href={contactLinks.securityReview} className="btn btn-cta justify-center">
-              Contact NeutralAI
-            </a>
+            <SecurityPackForm />
           </div>
         </div>
       </section>

--- a/docs/analytics-setup.md
+++ b/docs/analytics-setup.md
@@ -29,7 +29,9 @@ If `NEXT_PUBLIC_POSTHOG_TOKEN` is missing, no PostHog client is initialized and 
 Use these names when creating PostHog insights/funnels:
 
 - `$pageview` for PostHog page views.
-- `CTA Click`
+- `cta_click` — hero, navbar, and final-CTA buttons; carries `cta_id`, `label`, `placement`, `page_path`
+- `pricing_plan_click` — pricing tier buttons; carries `plan`, `label`, `placement`, `page_path`
+- `scroll_depth` — fired at 25/50/75/90/100% milestones; carries `depth`, `page_path`
 - `Playground Mask Submit`
 - `Playground Mask Button Click`
 - `Playground Result Copy`
@@ -76,10 +78,10 @@ Recommended dashboard cards:
 
 Recommended funnels:
 
-- Landing page: `$pageview` where `page_path` is `/` -> `CTA Click` where `placement` is `homepage_hero`, `homepage_product_surface`, or `homepage_final_cta` -> conversion-intent `CTA Click`.
-- Demo flow: `$pageview` where `page_path` is `/demo` -> `CTA Click` where `placement` is `demo_hero` or `demo_bottom_cta` -> conversion-intent `CTA Click`.
-- Playground flow: `$pageview` where `page_path` is `/playground` -> `Playground Mask Submit` or `Playground Mask Button Click` -> `CTA Click` where `placement` is `playground_bottom_cta` or `playground_hero`.
-- Content/product exploration: `$pageview` where `page_path` starts with `/blog`, `/compare`, `/developers`, `/trust-center`, or `/use-cases` -> `CTA Click` -> conversion-intent `CTA Click`.
+- Landing page: `$pageview` where `page_path` is `/` -> `cta_click` where `placement` is `homepage_hero`, `homepage_product_surface`, or `homepage_final_cta` -> conversion-intent `cta_click`.
+- Demo flow: `$pageview` where `page_path` is `/demo` -> `cta_click` where `placement` is `demo_hero` or `demo_bottom_cta` -> conversion-intent `cta_click`.
+- Playground flow: `$pageview` where `page_path` is `/playground` -> `Playground Mask Submit` or `Playground Mask Button Click` -> `cta_click` where `placement` is `playground_bottom_cta` or `playground_hero`.
+- Content/product exploration: `$pageview` where `page_path` starts with `/blog`, `/compare`, `/developers`, `/trust-center`, or `/use-cases` -> `cta_click` -> conversion-intent `cta_click`.
 
 Post-deployment smoke checks:
 

--- a/docs/conversion-funnel-qa.md
+++ b/docs/conversion-funnel-qa.md
@@ -11,16 +11,16 @@ Assumption: Individual assignee names and private dashboard URLs stay in private
 
 | Funnel path | Owner role | Expected destination | Analytics event | Smoke result |
 | --- | --- | --- | --- | --- |
-| Homepage hero -> Try Free | Growth Engineering + Product | `siteConfig.signupUrl` (`intent=signup`, `plan=free`, `src=website_start_free_trial`) | `CTA Click` (`placement=homepage_hero`, `label=Try Free`) | Repo-verified (2026-05-16) |
-| Navbar desktop/mobile -> Get Started Free | Growth Engineering | `siteConfig.signupUrl` (`intent=signup`, `plan=free`, `src=website_start_free_trial`) | `CTA Click` (`placement=navbar_desktop` / `navbar_mobile`, `label=Get Started Free`) | Repo-verified (2026-05-16) |
-| Homepage pricing -> Starter/Team/Business get started | Growth Engineering + Product Analytics | App signin URLs with `src=website_get_started`, `website_get_team`, `website_get_business` | `CTA Click` (`placement=homepage_pricing_primary` / `homepage_pricing_advanced`) | Repo-verified (2026-05-16) |
-| Homepage -> Book Demo | Growth Engineering + RevOps | `/demo` (then CTA handoff to `/contact?intent=demo`) | `CTA Click` (`placement=homepage_hero`, `label=Book Demo`) | Repo-verified (2026-05-16) |
+| Homepage hero -> Try Free | Growth Engineering + Product | `siteConfig.signupUrl` (`intent=signup`, `plan=free`, `src=website_start_free_trial`) | `cta_click` (`placement=homepage_hero`, `label=Try Free`) | Repo-verified (2026-05-16) |
+| Navbar desktop/mobile -> Get Started Free | Growth Engineering | `siteConfig.signupUrl` (`intent=signup`, `plan=free`, `src=website_start_free_trial`) | `cta_click` (`placement=navbar_desktop` / `navbar_mobile`, `label=Get Started Free`) | Repo-verified (2026-05-16) |
+| Homepage pricing -> Starter/Team/Business get started | Growth Engineering + Product Analytics | App signin URLs with `src=website_get_started`, `website_get_team`, `website_get_business` | `cta_click` (`placement=homepage_pricing_primary` / `homepage_pricing_advanced`) | Repo-verified (2026-05-16) |
+| Homepage -> Book Demo | Growth Engineering + RevOps | `/demo` (then CTA handoff to `/contact?intent=demo`) | `cta_click` (`placement=homepage_hero`, `label=Book Demo`) | Repo-verified (2026-05-16) |
 | Contact intent -> Demo | Revenue Operations + Growth Engineering | Google Sheets endpoint (`NEXT_PUBLIC_GOOGLE_SHEETS_LEAD_ENDPOINT`) via contact form | `lead_source=website_demo_request` | Pending production execution evidence |
 | Contact intent -> Enterprise | Revenue Operations + Growth Engineering | Google Sheets endpoint (`NEXT_PUBLIC_GOOGLE_SHEETS_LEAD_ENDPOINT`) via contact form | `lead_source=website_enterprise_enquiry` | Pending production execution evidence |
 | Contact intent -> Security review | Revenue Operations + Growth Engineering | Google Sheets endpoint (`NEXT_PUBLIC_GOOGLE_SHEETS_LEAD_ENDPOINT`) via contact form | `lead_source=website_security_review` | Pending production execution evidence |
-| Demo page -> Book Live Demo / Talk to Sales | Growth Engineering + RevOps | `/contact?intent=demo` and `/contact?intent=enterprise` | `CTA Click` (`placement=demo_hero` / `demo_bottom_cta`) | Repo-verified (2026-05-16) |
-| Playground -> Try Free / Book Demo | Growth Engineering + Product Analytics | `siteConfig.signupUrl` and `/contact?intent=demo` | `CTA Click` (`placement=playground_hero` / `playground_bottom_cta`) | Repo-verified (2026-05-16) |
-| Homepage + install page -> Install extension / support | Growth Engineering + Support Engineering | `/install-extension` and `/support/browser-extension` (plus store links) | `CTA Click` (`placement=homepage_hero`, `homepage_product_surface`, `install_extension_options`) | Repo-verified (2026-05-16) |
+| Demo page -> Book Live Demo / Talk to Sales | Growth Engineering + RevOps | `/contact?intent=demo` and `/contact?intent=enterprise` | `cta_click` (`placement=demo_hero` / `demo_bottom_cta`) | Repo-verified (2026-05-16) |
+| Playground -> Try Free / Book Demo | Growth Engineering + Product Analytics | `siteConfig.signupUrl` and `/contact?intent=demo` | `cta_click` (`placement=playground_hero` / `playground_bottom_cta`) | Repo-verified (2026-05-16) |
+| Homepage + install page -> Install extension / support | Growth Engineering + Support Engineering | `/install-extension` and `/support/browser-extension` (plus store links) | `cta_click` (`placement=homepage_hero`, `homepage_product_surface`, `install_extension_options`) | Repo-verified (2026-05-16) |
 
 ## Repo Smoke Commands
 


### PR DESCRIPTION
## Summary

- Adds `SecurityPackForm` client component (name + email + company → Google Sheets lead capture → reveals download link)
- Adds `/security-pack` page: encryption posture, SOC 2 control mapping (5 domains), access controls checklist, availability posture, 8 prefilled procurement questionnaire answers
- Updates `/trust-center` bottom section: replaces bare contact link with the inline self-service form

## Test plan

- [ ] Visit `/trust-center` — "Get the security pack" section shows with inline form
- [ ] Submit form with name/email/company — success state shows "Open security summary" button
- [ ] Button links to `/security-pack` — all sections render correctly
- [ ] TypeScript / build passes clean

Closes #127