### PR TITLE
fix(homepage): replace leaked "Final CTA" internal label with benefit copy

### DIFF
--- a/app/components/home/CtaSection.tsx
+++ b/app/components/home/CtaSection.tsx
@@ -10,7 +10,7 @@ export default function CtaSection() {
 
       <div className="container-custom relative z-10">
         <div className="mx-auto max-w-4xl rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.95),rgba(2,6,23,0.97)),radial-gradient(circle_at_top_left,rgba(34,211,238,0.12),transparent_24%),radial-gradient(circle_at_top_right,rgba(249,115,22,0.18),transparent_22%)] px-6 py-10 text-center shadow-[0_32px_80px_rgba(2,8,23,0.5)] md:px-10 md:py-12">
-          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Final CTA</p>
+          <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#fdba74]">Start in minutes</p>
           <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
             Put the <span className="gradient-text-warm">control layer</span> in place before the rollout gets messy
           </h2>


### PR DESCRIPTION
## Summary

- Replaced the hard-coded internal eyebrow label `"Final CTA"` (line 13 of `app/components/home/CtaSection.tsx`) with `"Start in minutes"` — a benefit-oriented phrase that matches the section's conversion intent (Try Free / Talk to Sales).
- Grepped the entire codebase for other leaked internal labels (`TODO`, `PLACEHOLDER`, `Section N`, `Draft`, `WIP`, `FIXME`). No other user-visible internal labels were found; all other occurrences were legitimate HTML `placeholder` attributes on form inputs or product-demo copy about PII masking tokens.

**Replacement text chosen:** `Start in minutes` — concise, benefit-focused, and consistent with the low-friction onboarding message in the surrounding CTA copy.

## Build

`npm run build` passes with 0 TypeScript errors and all 53 static pages generated successfully.

Closes #136