### PR TITLE
feat(analytics): fire conversion events on lead forms + normalize CTA event names

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -171,7 +171,7 @@ export default function ComparePage() {
               <Link
                 href={siteConfig.signupUrl}
                 className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto"
-                data-analytics-event="CTA Click"
+                data-analytics-event="cta_click"
                 data-analytics-label="Try Free"
                 data-analytics-placement="compare_hero"
               >
@@ -181,7 +181,7 @@ export default function ComparePage() {
               <Link
                 href="/contact"
                 className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto"
-                data-analytics-event="CTA Click"
+                data-analytics-event="cta_click"
                 data-analytics-label="Talk to Sales"
                 data-analytics-placement="compare_hero"
               >
@@ -286,7 +286,7 @@ export default function ComparePage() {
             <Link
               href="/blog/neutralai-vs-private-ai-vs-nightfall-pii-detection-benchmark-2026"
               className="btn btn-secondary inline-flex items-center gap-2 px-6 py-3 text-sm"
-              data-analytics-event="CTA Click"
+              data-analytics-event="cta_click"
               data-analytics-label="Read Benchmark Post"
               data-analytics-placement="compare_detection"
             >

--- a/app/components/GoogleSheetsLeadForm.tsx
+++ b/app/components/GoogleSheetsLeadForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { FormEvent, useMemo, useRef, useState } from 'react'
-import { getLeadAttribution } from '../lib/analytics'
+import { getLeadAttribution, trackAnalyticsEvent } from '../lib/analytics'
 import { getReferralSnapshot, referralSnapshotToFieldMap } from '../lib/referral'
 import { siteConfig } from '../site'
 
@@ -137,6 +137,7 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
   const [errors, setErrors] = useState<FieldErrors>({})
   const [touched, setTouched] = useState<Partial<Record<keyof FormState, boolean>>>({})
   const formRef = useRef<HTMLFormElement>(null)
+  const formStartedRef = useRef(false)
 
   const isSubmitting = status === 'submitting'
 
@@ -153,6 +154,13 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
   }
 
   const submissionEndpoint = endpoint
+
+  function handleFormFocus() {
+    if (!formStartedRef.current) {
+      formStartedRef.current = true
+      trackAnalyticsEvent('form_started', { form_id: 'lead_contact', lead_source: leadSource, intent })
+    }
+  }
 
   function markTouched(field: keyof FormState) {
     setTouched((prev) => ({ ...prev, [field]: true }))
@@ -227,14 +235,16 @@ export default function GoogleSheetsLeadForm({ intent, leadSource }: { intent: s
         throw new Error('submit_failed')
       }
 
+      trackAnalyticsEvent('lead_submitted', { form_id: 'lead_contact', lead_source: leadSource, intent })
       window.location.assign('/contact/thanks/')
     } catch {
       setStatus('failed')
+      trackAnalyticsEvent('form_error', { form_id: 'lead_contact', lead_source: leadSource, intent })
     }
   }
 
   return (
-    <form ref={formRef} className="space-y-4" onSubmit={handleSubmit} noValidate aria-label="Contact request form">
+    <form ref={formRef} className="space-y-4" onSubmit={handleSubmit} onFocus={handleFormFocus} noValidate aria-label="Contact request form">
       <div className="grid gap-4 md:grid-cols-2">
         {/* Full name */}
         <div className="space-y-1 text-sm">

--- a/app/components/SecurityPackForm.tsx
+++ b/app/components/SecurityPackForm.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { FormEvent, useState } from 'react'
+import { FormEvent, useRef, useState } from 'react'
 import { CheckCircle2, Download, Loader2 } from 'lucide-react'
 import { siteConfig } from '../site'
-import { getLeadAttribution } from '../lib/analytics'
+import { getLeadAttribution, trackAnalyticsEvent } from '../lib/analytics'
 import { getReferralSnapshot, referralSnapshotToFieldMap } from '../lib/referral'
 
 const GOOGLE_SHEETS_EXEC_PATH_REGEX = /^\/macros\/s\/[a-z0-9_-]+\/exec\/?$/i
@@ -30,6 +30,14 @@ export default function SecurityPackForm() {
   const [email, setEmail] = useState('')
   const [company, setCompany] = useState('')
   const [honeypot, setHoneypot] = useState('')
+  const formStartedRef = useRef(false)
+
+  function handleFormFocus() {
+    if (!formStartedRef.current) {
+      formStartedRef.current = true
+      trackAnalyticsEvent('form_started', { form_id: 'security_pack' })
+    }
+  }
 
   if (status === 'success') {
     return (
@@ -92,12 +100,16 @@ export default function SecurityPackForm() {
         })
         if (!response.ok) {
           setStatus('error')
+          trackAnalyticsEvent('form_error', { form_id: 'security_pack' })
           return
         }
       }
+      trackAnalyticsEvent('lead_submitted', { form_id: 'security_pack' })
+      trackAnalyticsEvent('security_pack_downloaded', { form_id: 'security_pack' })
       setStatus('success')
     } catch {
       setStatus('error')
+      trackAnalyticsEvent('form_error', { form_id: 'security_pack' })
     }
   }
 
@@ -105,7 +117,7 @@ export default function SecurityPackForm() {
     'w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none text-sm'
 
   return (
-    <form onSubmit={handleSubmit} className="grid gap-4">
+    <form onSubmit={handleSubmit} onFocus={handleFormFocus} className="grid gap-4">
       <input
         name="company_website"
         value={honeypot}

--- a/app/components/home/LiveMaskingDemo.tsx
+++ b/app/components/home/LiveMaskingDemo.tsx
@@ -226,7 +226,7 @@ export default function LiveMaskingDemo() {
               <a
                 href="/playground"
                 className="btn btn-cta whitespace-nowrap"
-                data-analytics-event="CTA Click"
+                data-analytics-event="cta_click"
                 data-analytics-label="Try Full Playground"
                 data-analytics-placement="homepage_live_demo"
               >
@@ -236,7 +236,7 @@ export default function LiveMaskingDemo() {
               <a
                 href={contactLinks.demo}
                 className="btn btn-secondary whitespace-nowrap"
-                data-analytics-event="CTA Click"
+                data-analytics-event="cta_click"
                 data-analytics-label="Book Demo"
                 data-analytics-placement="homepage_live_demo"
               >
@@ -399,7 +399,7 @@ export default function LiveMaskingDemo() {
             <a
               href="/playground"
               className="text-primary-light underline-offset-2 hover:underline"
-              data-analytics-event="CTA Click"
+              data-analytics-event="cta_click"
               data-analytics-label="Try Full Playground (disclaimer)"
               data-analytics-placement="homepage_live_demo_footer"
             >

--- a/app/components/home/ProductSurface.tsx
+++ b/app/components/home/ProductSurface.tsx
@@ -53,7 +53,7 @@ export default function ProductSurface() {
                   <a
                     href={siteConfig.signupUrl}
                     className="btn btn-cta w-full sm:w-auto"
-                    data-analytics-event="CTA Click"
+                    data-analytics-event="cta_click"
                     data-analytics-label="Try Free"
                     data-analytics-placement="homepage_product_surface"
                   >
@@ -62,7 +62,7 @@ export default function ProductSurface() {
                   <a
                     href="/install-extension"
                     className="btn btn-secondary w-full sm:w-auto"
-                    data-analytics-event="CTA Click"
+                    data-analytics-event="cta_click"
                     data-analytics-label="Install Browser Extension"
                     data-analytics-placement="homepage_product_surface"
                   >

--- a/app/components/home/WhyItMatters.tsx
+++ b/app/components/home/WhyItMatters.tsx
@@ -28,7 +28,7 @@ export default function WhyItMatters() {
                 <a
                   href="/use-cases/legal"
                   className="mt-4 inline-flex items-center text-sm font-semibold text-primary-light transition hover:text-primary"
-                  data-analytics-event="CTA Click"
+                  data-analytics-event="cta_click"
                   data-analytics-label="Legal Use Case"
                   data-analytics-placement="homepage_problem_legal"
                 >

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -65,7 +65,7 @@ export default function DemoPage() {
               <Link
                 href={siteConfig.signupUrl}
                 className="btn btn-cta justify-center px-8 py-4"
-                data-analytics-event="CTA Click"
+                data-analytics-event="cta_click"
                 data-analytics-label="Try Free"
                 data-analytics-placement="demo_hero"
               >
@@ -75,7 +75,7 @@ export default function DemoPage() {
               <Link
                 href={contactLinks.demo}
                 className="btn btn-secondary justify-center px-8 py-4"
-                data-analytics-event="CTA Click"
+                data-analytics-event="cta_click"
                 data-analytics-label="Book Live Demo"
                 data-analytics-placement="demo_hero"
               >
@@ -134,7 +134,7 @@ export default function DemoPage() {
                     <Link
                       href="/playground"
                       className="btn btn-cta justify-center px-7 py-4"
-                      data-analytics-event="CTA Click"
+                      data-analytics-event="cta_click"
                       data-analytics-label="Try Playground"
                       data-analytics-placement="demo_video_fallback"
                     >
@@ -143,7 +143,7 @@ export default function DemoPage() {
                     <Link
                       href={contactLinks.demo}
                       className="btn btn-secondary justify-center px-7 py-4"
-                      data-analytics-event="CTA Click"
+                      data-analytics-event="cta_click"
                       data-analytics-label="Book Live Demo"
                       data-analytics-placement="demo_video_fallback"
                     >
@@ -188,7 +188,7 @@ export default function DemoPage() {
                   <Link
                     href={siteConfig.signupUrl}
                     className="btn btn-cta justify-center px-7 py-4"
-                    data-analytics-event="CTA Click"
+                    data-analytics-event="cta_click"
                     data-analytics-label="Try Free"
                     data-analytics-placement="demo_bottom_cta"
                   >
@@ -197,7 +197,7 @@ export default function DemoPage() {
                   <Link
                     href={contactLinks.enterprise}
                     className="btn btn-secondary justify-center px-7 py-4"
-                    data-analytics-event="CTA Click"
+                    data-analytics-event="cta_click"
                     data-analytics-label="Talk to Sales"
                     data-analytics-placement="demo_bottom_cta"
                   >

--- a/app/developers/page.tsx
+++ b/app/developers/page.tsx
@@ -146,7 +146,7 @@ export default function DevelopersPage() {
                 <Link
                   href={siteConfig.signupUrl}
                   className="btn btn-cta w-full px-6 py-4 sm:w-auto"
-                  data-analytics-event="CTA Click"
+                  data-analytics-event="cta_click"
                   data-analytics-label="Get your free API key"
                   data-analytics-placement="developers_hero"
                 >

--- a/app/install-extension/page.tsx
+++ b/app/install-extension/page.tsx
@@ -95,7 +95,7 @@ export default function InstallExtensionPage() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="block"
-                    data-analytics-event="CTA Click"
+                    data-analytics-event="cta_click"
                     data-analytics-label={option.label}
                     data-analytics-placement="install_extension_options"
                   >
@@ -109,7 +109,7 @@ export default function InstallExtensionPage() {
                   key={option.title}
                   href={option.href}
                   className="block"
-                  data-analytics-event="CTA Click"
+                  data-analytics-event="cta_click"
                   data-analytics-label={option.label}
                   data-analytics-placement="install_extension_options"
                 >

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -456,7 +456,7 @@ export default function PlaygroundPage() {
                 <Link
                   href={siteConfig.signupUrl}
                   className="btn btn-secondary justify-center px-8 py-4"
-                  data-analytics-event="CTA Click"
+                  data-analytics-event="cta_click"
                   data-analytics-label="Get your free API key"
                   data-analytics-placement="playground_hero"
                 >
@@ -695,7 +695,7 @@ export default function PlaygroundPage() {
               <Link
                 href={siteConfig.signupUrl}
                 className="btn btn-cta justify-center px-8 py-4"
-                data-analytics-event="CTA Click"
+                data-analytics-event="cta_click"
                 data-analytics-label="Get your free API key"
                 data-analytics-placement="playground_bottom_cta"
               >
@@ -705,7 +705,7 @@ export default function PlaygroundPage() {
               <Link
                 href="/contact"
                 className="btn btn-secondary justify-center px-8 py-4"
-                data-analytics-event="CTA Click"
+                data-analytics-event="cta_click"
                 data-analytics-label="Talk to Sales"
                 data-analytics-placement="playground_bottom_cta"
               >


### PR DESCRIPTION
## Summary
- Fire `form_started`, `lead_submitted`, `form_error` from `GoogleSheetsLeadForm` (contact page)
- Fire `form_started`, `lead_submitted`, `form_error`, `security_pack_downloaded` from `SecurityPackForm` (trust center)
- Normalize all `data-analytics-event="CTA Click"` → `"cta_click"` across 8 files (demo, playground, compare, developers, install-extension, WhyItMatters, LiveMaskingDemo, ProductSurface)

All CTA events now use consistent snake_case with `{ placement, cta_id, label }` properties via AnalyticsProvider.

Closes #135

[ci fullstack]