### PR TITLE
Add agent readiness discovery metadata

### DIFF
--- a/.codex/workflows/post-ticket-red-team-check.md
+++ b/.codex/workflows/post-ticket-red-team-check.md
@@ -1,0 +1,40 @@
+# NeutralAI Website Post-Ticket Red-Team Check
+
+Use this prompt with an independent reviewer before opening a PR.
+
+## Mode
+
+- Review only the diff vs `origin/main`.
+- Think adversarially: try to break, manipulate, or misuse the change.
+- Do not trust the implementation author's assumptions.
+- Keep output short, actionable, and ordered by severity.
+
+## Objective
+
+Find blockers before review:
+
+1. Security or privacy regressions.
+2. Public claim overstatement or unsupported product capability claims.
+3. Trust-boundary confusion, secret exposure, unsafe headers, or unsafe external links.
+4. Missing tests for the changed behavior.
+5. Operational regressions in static export, edge headers, redirects, robots, sitemap, or well-known discovery files.
+
+## Required Focus
+
+- Secrets, tokens, credentials, private URLs, and internal-only metadata.
+- Public marketing or compliance claims that are not supported by current product evidence.
+- CSP/header changes, `Link` headers, `Content-Signal`, robots, sitemap, and `.well-known` resources.
+- Unsafe JavaScript/React/Next.js patterns such as raw HTML sinks, dynamic script execution, open redirects, or client-exposed secrets.
+- Accessibility, conversion, and visual regressions when UI files are touched.
+
+## Finding Format
+
+For each issue:
+
+- Severity: Critical / Important / Minor
+- Location: file and line
+- Evidence: exact snippet or behavior
+- Impact: what could go wrong
+- Fix: smallest safe change
+
+If there are no Critical or Important issues, say that explicitly and list residual risks.

--- a/docs/ai/OPEN_QUESTIONS.md
+++ b/docs/ai/OPEN_QUESTIONS.md
@@ -22,6 +22,7 @@ Use this file for unknowns. Do not guess silently.
 - Resolved on 2026-05-15 in `docs/deployment-static-runbook.md`: generated `out/` is build-only output and should not be committed.
 - Resolved on 2026-05-15 in `docs/deployment-static-runbook.md`: owner/on-call assignment requirements for host-level redirect/header configuration are now captured as explicit closure checklist items, while the actual private-ops assignment execution remains tracked under Platform/Infra in issue [#78](https://github.com/nazifsohtaoglu/neutralai-website/issues/78) and `docs/ai/LAUNCH_READINESS_LEDGER.md`.
 - Should Playwright artifacts be ignored/cleaned, or are they used as review evidence?
+- For Agent-Ready follow-up after issue #153: should NeutralAI publish a real MCP server card, WebMCP surface, OAuth/OIDC metadata, DNS-AID records, or agentic commerce protocol metadata? Do not add those discovery claims until the owning service and production endpoint exist.
 
 ## Testing / CI
 

--- a/docs/ai/PR_RULES.md
+++ b/docs/ai/PR_RULES.md
@@ -50,4 +50,5 @@ What visitor, content, or maintenance problem does this solve?
 - Confirm no unrelated user changes were included.
 - Run targeted verification from `docs/ai/TESTING_AND_COMMANDS.md`.
 - Run `./scripts/codex-security-pre-review.sh` and resolve blocking findings.
+- Run an independent red-team review using `.codex/workflows/post-ticket-red-team-check.md` or equivalent subagent prompt, then resolve Critical/Important findings before opening the PR.
 - Mention tests that were not run and why.

--- a/docs/ai/TICKET_WORKFLOW.md
+++ b/docs/ai/TICKET_WORKFLOW.md
@@ -35,7 +35,8 @@ For non-trivial work, write a short plan:
 3. Make the smallest focused change.
 4. Update content tests if CTA/copy expectations change.
 5. Run targeted verification.
-6. Summarize residual risk.
+6. Run an independent red-team review before PR.
+7. Summarize residual risk.
 
 ### Blog Visual Workflow
 
@@ -57,6 +58,7 @@ For blog articles or content hub work:
 - Do not mix unrelated redesign work into narrow tickets.
 - Preserve user changes in the worktree.
 - Never include secrets or credentials in code, docs, tests, logs, or PR text.
+- Before PR, dispatch an independent red-team reviewer using `.codex/workflows/post-ticket-red-team-check.md` or equivalent context. Treat Critical and Important findings as blockers.
 
 ## 4. Verification
 
@@ -76,5 +78,6 @@ A ticket is ready when:
 - the requested route/component/content change is complete
 - targeted checks have run or the reason is documented
 - `./scripts/codex-security-pre-review.sh` has run and blocking findings are addressed
+- independent red-team review has run and Critical/Important findings are addressed or explicitly rejected with evidence
 - mobile/desktop visual risk has been considered for UI work
 - PR notes include summary, validation, risks, and follow-ups

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,42 @@
+{
+  "version": "0.2.0",
+  "publisher": {
+    "name": "NeutralAI",
+    "url": "https://neutralai.co.uk"
+  },
+  "updated": "2026-07-04",
+  "skills": [
+    {
+      "id": "neutralai-public-content",
+      "name": "NeutralAI public content discovery",
+      "description": "Find NeutralAI product, security, pricing, developer, and technical article content for retrieval, citation, and evaluation.",
+      "url": "https://neutralai.co.uk/.well-known/agent-skills/neutralai-public-content/SKILL.md",
+      "type": "text/markdown",
+      "audience": [
+        "ai-search",
+        "research-agent",
+        "buyer-research-agent"
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "id": "llms",
+      "url": "https://neutralai.co.uk/llms.txt",
+      "type": "text/plain",
+      "description": "LLM-readable summary and route map for the public website."
+    },
+    {
+      "id": "sitemap",
+      "url": "https://neutralai.co.uk/sitemap.xml",
+      "type": "application/xml",
+      "description": "Canonical route inventory for crawlers."
+    },
+    {
+      "id": "api-catalog",
+      "url": "https://neutralai.co.uk/.well-known/api-catalog",
+      "type": "application/linkset+json",
+      "description": "Public API and documentation discovery linkset."
+    }
+  ]
+}

--- a/public/.well-known/agent-skills/neutralai-public-content/SKILL.md
+++ b/public/.well-known/agent-skills/neutralai-public-content/SKILL.md
@@ -1,0 +1,31 @@
+# NeutralAI Public Content Discovery
+
+Use this skill when an agent needs to understand, cite, or compare NeutralAI Gateway from public website content.
+
+## What NeutralAI Is
+
+NeutralAI Gateway is a PII and sensitive-data control layer for regulated AI workflows. It sits between user prompts, documents, browser usage, or backend integrations and downstream LLM providers. Its public messaging focuses on masking sensitive data before it reaches external models, preserving auditability, and supporting regulated UK/EU teams.
+
+## High-Value Entry Points
+
+- Product overview: https://neutralai.co.uk/
+- Developers: https://neutralai.co.uk/developers
+- How it works: https://neutralai.co.uk/how-it-works
+- Security: https://neutralai.co.uk/security
+- Trust center: https://neutralai.co.uk/trust-center
+- Pricing: https://neutralai.co.uk/pricing
+- Blog: https://neutralai.co.uk/blog
+- LLM guide: https://neutralai.co.uk/llms.txt
+- Sitemap: https://neutralai.co.uk/sitemap.xml
+
+## Use Guidance
+
+- Prefer `llms.txt` and `sitemap.xml` before broad HTML crawling.
+- Cite the canonical page URL for claims.
+- Do not infer certifications, customer names, uptime commitments, or legal/compliance status beyond the public page text.
+- Treat developer examples as integration guidance, not evidence that a customer has deployed the product.
+- Use the API catalog only for public API and documentation discovery.
+
+## Content Use Signal
+
+NeutralAI public website content is available for search, retrieval, citation, and grounding. AI training is not granted by the site-level content signal.

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,50 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://api.neutralai.co.uk",
+      "service-doc": [
+        {
+          "href": "https://neutralai.co.uk/developers",
+          "type": "text/html",
+          "title": "NeutralAI developer documentation"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://api.neutralai.co.uk/health",
+          "type": "application/json",
+          "title": "API health"
+        }
+      ],
+      "describedby": [
+        {
+          "href": "https://neutralai.co.uk/.well-known/auth.md",
+          "type": "text/markdown",
+          "title": "Authentication model"
+        }
+      ]
+    },
+    {
+      "anchor": "https://neutralai.co.uk",
+      "service-doc": [
+        {
+          "href": "https://neutralai.co.uk/llms.txt",
+          "type": "text/plain",
+          "title": "LLM-readable site guide"
+        },
+        {
+          "href": "https://neutralai.co.uk/sitemap.xml",
+          "type": "application/xml",
+          "title": "Public sitemap"
+        }
+      ],
+      "service-desc": [
+        {
+          "href": "https://neutralai.co.uk/.well-known/agent-skills/index.json",
+          "type": "application/json",
+          "title": "Agent skills index"
+        }
+      ]
+    }
+  ]
+}

--- a/public/.well-known/auth.md
+++ b/public/.well-known/auth.md
@@ -1,0 +1,23 @@
+# NeutralAI Authentication
+
+NeutralAI public website content is available without authentication.
+
+NeutralAI Gateway API access uses scoped API keys sent from server-side integrations. Do not place API keys in browsers, mobile clients, public repositories, client-visible logs, or analytics events.
+
+## API Key Header
+
+```http
+x-api-key: nai_live_your_key
+```
+
+Public API examples and SDK guidance are documented at:
+
+- https://neutralai.co.uk/developers
+
+## OAuth and OIDC
+
+NeutralAI does not publish this marketing website as an OAuth or OIDC provider. If OAuth/OIDC metadata is added for a public API or application surface, it should be published from the owning service domain and reviewed separately before launch.
+
+## Agent Access
+
+Agents may read public website content, `llms.txt`, and the sitemap for search, retrieval, citation, and grounding. Training use is not granted by the site-level content signal.

--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,28 @@
 /*
+  Link: </llms.txt>; rel="alternate"; type="text/plain"; title="NeutralAI LLM guide"
+  Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"
+  Link: </.well-known/agent-skills/index.json>; rel="service-desc"; type="application/json"; title="NeutralAI agent skills index"
+  Link: </.well-known/auth.md>; rel="help"; type="text/markdown"; title="NeutralAI API authentication"
+  Content-Signal: search=yes, ai-input=yes, ai-train=no, use=reference
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY
   Permissions-Policy: geolocation=(), microphone=(), camera=()
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://api.neutralai.co.uk https://cloudflareinsights.com https://us.i.posthog.com https://eu.i.posthog.com https://script.google.com https://script.googleusercontent.com; frame-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+
+/.well-known/api-catalog
+  Content-Type: application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"
+  Cache-Control: public, max-age=3600
+
+/.well-known/agent-skills/index.json
+  Content-Type: application/json; charset=utf-8
+  Cache-Control: public, max-age=3600
+
+/.well-known/auth.md
+  Content-Type: text/markdown; charset=utf-8
+  Cache-Control: public, max-age=3600
+
+/.well-known/agent-skills/neutralai-public-content/SKILL.md
+  Content-Type: text/markdown; charset=utf-8
+  Cache-Control: public, max-age=3600

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -28,6 +28,13 @@ NeutralAI targets UK/EU regulated organisations: financial services, legal, heal
 - [Developers](https://neutralai.co.uk/developers): REST API reference, Python SDK, Node SDK, browser extension integration
 - [Install extension](https://neutralai.co.uk/install-extension): Chrome and Edge setup guide
 
+## Agent discovery
+
+- [API catalog](https://neutralai.co.uk/.well-known/api-catalog): linkset for the public API domain, developer documentation, the public health endpoint, and website discovery resources
+- [Agent skills index](https://neutralai.co.uk/.well-known/agent-skills/index.json): machine-readable index for public content discovery
+- [Agent content skill](https://neutralai.co.uk/.well-known/agent-skills/neutralai-public-content/SKILL.md): guidance for agents reading and citing NeutralAI public content
+- [Authentication note](https://neutralai.co.uk/.well-known/auth.md): API-key usage guidance and OAuth/OIDC scope note
+
 ## Technical articles (blog)
 
 - [Why PII masking matters for enterprise AI adoption](https://neutralai.co.uk/blog/why-pii-masking-matters-for-enterprise-ai-adoption)

--- a/tests/content/agent-discovery.test.mjs
+++ b/tests/content/agent-discovery.test.mjs
@@ -1,0 +1,83 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+
+function readSource(path) {
+  return readFileSync(join(root, path), 'utf8')
+}
+
+function readJson(path) {
+  return JSON.parse(readSource(path))
+}
+
+test('site-wide headers advertise agent discovery resources', () => {
+  const headers = readSource('public/_headers')
+
+  assert.match(headers, /Link: <\/llms\.txt>; rel="alternate"; type="text\/plain"/)
+  assert.match(headers, /Link: <\/\.well-known\/api-catalog>; rel="api-catalog"; type="application\/linkset\+json"/)
+  assert.match(headers, /Link: <\/\.well-known\/agent-skills\/index\.json>; rel="service-desc"; type="application\/json"/)
+  assert.match(headers, /Link: <\/\.well-known\/auth\.md>; rel="help"; type="text\/markdown"/)
+  assert.match(headers, /Content-Signal: search=yes, ai-input=yes, ai-train=no, use=reference/)
+})
+
+test('api catalog is a linkset with public API and website discovery links', () => {
+  const catalog = readJson('public/.well-known/api-catalog')
+
+  assert.ok(Array.isArray(catalog.linkset))
+  assert.equal(catalog.linkset[0].anchor, 'https://api.neutralai.co.uk')
+  assert.match(JSON.stringify(catalog), /https:\/\/neutralai\.co\.uk\/developers/)
+  assert.match(JSON.stringify(catalog), /https:\/\/api\.neutralai\.co\.uk\/health/)
+  assert.match(JSON.stringify(catalog), /https:\/\/neutralai\.co\.uk\/\.well-known\/auth\.md/)
+  assert.doesNotMatch(JSON.stringify(catalog), /https:\/\/api\.neutralai\.co\.uk\/ready/)
+  assert.doesNotMatch(JSON.stringify(catalog), /https:\/\/api\.neutralai\.co\.uk\/docs/)
+})
+
+test('agent skills index points agents to truthful public content resources', () => {
+  const index = readJson('public/.well-known/agent-skills/index.json')
+
+  assert.equal(index.publisher.name, 'NeutralAI')
+  assert.equal(index.version, '0.2.0')
+  assert.equal(index.skills[0].id, 'neutralai-public-content')
+  assert.match(index.skills[0].url, /\/\.well-known\/agent-skills\/neutralai-public-content\/SKILL\.md$/)
+  assert.ok(index.resources.some((resource) => resource.id === 'llms'))
+  assert.ok(index.resources.some((resource) => resource.id === 'sitemap'))
+  assert.ok(index.resources.some((resource) => resource.id === 'api-catalog'))
+})
+
+test('agent auth document does not claim unsupported OAuth provider behavior', () => {
+  const auth = readSource('public/.well-known/auth.md')
+
+  assert.match(auth, /NeutralAI public website content is available without authentication/)
+  assert.match(auth, /x-api-key: nai_live_your_key/)
+  assert.match(auth, /does not publish this marketing website as an OAuth or OIDC provider/)
+  assert.doesNotMatch(auth, /api\.neutralai\.co\.uk\/docs/)
+})
+
+test('agent discovery avoids unsupported protocol and operational metadata claims', () => {
+  const discoveryFiles = [
+    readSource('public/.well-known/api-catalog'),
+    readSource('public/.well-known/auth.md'),
+    readSource('public/.well-known/agent-skills/index.json'),
+    readSource('public/.well-known/agent-skills/neutralai-public-content/SKILL.md'),
+    readSource('public/llms.txt'),
+  ].join('\n')
+
+  assert.doesNotMatch(discoveryFiles, /api\.neutralai\.co\.uk\/ready/)
+  assert.doesNotMatch(discoveryFiles, /api\.neutralai\.co\.uk\/docs/)
+  assert.doesNotMatch(discoveryFiles, /mcp\/server-card|webmcp|a2a|x402|oauth-authorization-server/i)
+})
+
+test('ticket workflow requires an independent red-team review before PR', () => {
+  const ticketWorkflow = readSource('docs/ai/TICKET_WORKFLOW.md')
+  const prRules = readSource('docs/ai/PR_RULES.md')
+  const redTeamPrompt = readSource('.codex/workflows/post-ticket-red-team-check.md')
+
+  assert.match(ticketWorkflow, /independent red-team review/)
+  assert.match(ticketWorkflow, /\.codex\/workflows\/post-ticket-red-team-check\.md/)
+  assert.match(prRules, /Run an independent red-team review/)
+  assert.match(redTeamPrompt, /Think adversarially/)
+  assert.match(redTeamPrompt, /Public claim overstatement/)
+})


### PR DESCRIPTION
## Problem

Cloudflare's Agent-Ready scan showed that NeutralAI had low agent discovery coverage after AI crawler access was fixed in #152. Agents could read `robots.txt`, sitemap, and `llms.txt`, but the site did not advertise machine-readable discovery resources through headers or `.well-known` metadata.

Closes #153.

## What Changed

- Added site-wide agent discovery headers for `llms.txt`, RFC 9727 API catalog, agent skills, auth guidance, and content-use signals.
- Published static `.well-known` resources for API catalog discovery, public-content agent skills, and API-key auth guidance without claiming unsupported MCP, OAuth, WebMCP, A2A, or commerce protocol support.
- Extended `llms.txt` with the new agent discovery resources.
- Added content tests for discovery headers, linkset shape, unsupported protocol guardrails, and no public exposure of `/ready` or private `/docs` API URLs.
- Added a reusable red-team review prompt and updated ticket/PR workflow docs so every future ticket requires an independent red-team review before PR.

## Red-Team Review

- Ran an independent red-team subagent review before PR.
- Important finding addressed: removed `https://api.neutralai.co.uk/ready` from public discovery because it exposes component-level operational readiness details.
- Important finding addressed: removed `https://api.neutralai.co.uk/docs` from public discovery because the live endpoint is not a public unauthenticated API reference.
- Added negative tests to keep those boundaries from regressing.

## Validation

- [x] `node --test tests/content/agent-discovery.test.mjs` passed.
- [x] `npm run lint` passed.
- [x] `npm run build` passed.
- [x] `git diff --check` passed.
- [x] Independent red-team review completed; Critical/Important findings addressed.
- [ ] `npm run test:content` has 3 pre-existing unrelated failures: contact thank-you copy expects `1 business day`, CTA analytics test expects `CTA Click` while code uses `cta_click`, and `PricingSection.tsx` exceeds the existing line-count guard.
- [ ] `./scripts/codex-security-pre-review.sh` could not complete because the local Codex CLI vendor binary was removed/quarantined by macOS and now returns `ENOENT`.

## Risks / Follow-ups

- DNS-AID, MCP server cards, WebMCP, A2A, OAuth/OIDC, and agentic commerce metadata remain intentionally out of scope until the owning production service exists.
- If a public unauthenticated OpenAPI spec is later approved, add it to the API catalog in a separate ticket.
