### PR TITLE
Fix markdown HEAD negotiation

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -69,13 +69,14 @@ function acceptsMarkdown(acceptHeader) {
 export async function onRequest(context) {
   const { request } = context
   const url = new URL(request.url)
+  const isMarkdownMethod = request.method === 'GET' || request.method === 'HEAD'
 
   if (
-    request.method === 'GET' &&
+    isMarkdownMethod &&
     acceptsMarkdown(request.headers.get('Accept')) &&
     normalisePath(url.pathname) === '/'
   ) {
-    return new Response(MARKDOWN_BODY, { headers: MARKDOWN_RESPONSE_HEADERS })
+    return new Response(request.method === 'HEAD' ? null : MARKDOWN_BODY, { headers: MARKDOWN_RESPONSE_HEADERS })
   }
 
   return context.next()

--- a/tests/content/agent-discovery.test.mjs
+++ b/tests/content/agent-discovery.test.mjs
@@ -20,7 +20,7 @@ async function loadMiddleware() {
   return import(moduleUrl)
 }
 
-function createContext(path, accept = 'text/markdown') {
+function createContext(path, accept = 'text/markdown', method = 'GET') {
   let nextCalls = 0
 
   return {
@@ -28,6 +28,7 @@ function createContext(path, accept = 'text/markdown') {
       return nextCalls
     },
     request: new Request(`https://neutralai.co.uk${path}`, {
+      method,
       headers: {
         Accept: accept,
       },
@@ -105,6 +106,14 @@ test('markdown negotiation fallback only handles the homepage when markdown is a
 
   assert.equal(rejectedMarkdownContext.nextCalls, 1)
   assert.equal(await rejectedMarkdownResponse.text(), 'next')
+
+  const headContext = createContext('/', 'text/markdown', 'HEAD')
+  const headResponse = await onRequest(headContext)
+
+  assert.equal(headContext.nextCalls, 0)
+  assert.equal(headResponse.headers.get('Content-Type'), 'text/markdown; charset=utf-8')
+  assert.equal(headResponse.headers.get('Cache-Control'), 'no-store')
+  assert.equal(await headResponse.text(), '')
 })
 
 test('api catalog is a linkset with public API and website discovery links', () => {


### PR DESCRIPTION
## Problem

Follow-up to #157. After production deploy, `GET -H 'Accept: text/markdown' /` returned the markdown fallback, but `HEAD -H 'Accept: text/markdown' /` still exposed HTML headers. The runbook uses `curl -sSI`, so HEAD should negotiate the same markdown headers without a body.

## What Changed

- Allow the markdown fallback to handle `HEAD` as well as `GET` for `/`.
- Return no body for HEAD responses while preserving the same markdown headers.
- Add runtime middleware coverage for HEAD negotiation.

## Validation

- [x] `node --test tests/content/agent-discovery.test.mjs`
- [x] `npm run lint`
- [x] `npm run build`

## Risks / Follow-ups

- This only changes the homepage markdown fallback. Other routes still pass through to their normal HTML, as intended by #157.
