### PR TITLE
feat(pricing): add Developer (£9, shield-only) tier to marketing pricing

### DIFF
--- a/app/components/home/PricingSection.tsx
+++ b/app/components/home/PricingSection.tsx
@@ -10,14 +10,14 @@ const BYOK_PLANS = ['Business', 'Enterprise'] as const
 const SSO_PLANS = ['Enterprise'] as const
 const SSO_ROADMAP_PLANS = ['Business'] as const
 
-const comparisonTiers = ['Free', 'Starter', 'Team', 'Business', 'Enterprise'] as const
+const comparisonTiers = ['Free', 'Developer', 'Starter', 'Team', 'Business', 'Enterprise'] as const
 
-const comparisonRows: ReadonlyArray<readonly [string, string, string, string, string, string]> = [
-  ['Masking requests', '1k', '10K', '100K', '500K', 'Custom'],
-  ['Managed AI credit', '£1 trial', '£3', '£10', '£25', 'Custom'],
-  ['Provider spend model', 'Managed sandbox', 'Managed eval', 'BYOK recommended', 'BYOK expected', 'Customer-owned'],
-  ['API key management', 'Basic', 'Basic', 'Team', 'Full lifecycle', 'Scoped controls'],
-  ['SSO / SIEM path', 'No', 'No', 'Roadmap', 'Export path', 'Required'],
+const comparisonRows: ReadonlyArray<readonly [string, string, string, string, string, string, string]> = [
+  ['Masking requests', '1k', '500K', '10K', '100K', '500K', 'Custom'],
+  ['Managed AI credit', '£1 trial', 'Bring your own LLM', '£3', '£10', '£25', 'Custom'],
+  ['Provider spend model', 'Managed sandbox', 'BYO LLM (shield-only)', 'Managed eval', 'BYOK recommended', 'BYOK expected', 'Customer-owned'],
+  ['API key management', 'Basic', 'Shield API/SDK only', 'Basic', 'Team', 'Full lifecycle', 'Scoped controls'],
+  ['SSO / SIEM path', 'No', 'No', 'No', 'Roadmap', 'Export path', 'Required'],
 ]
 
 function PlanBadges({ planName }: { planName: string }) {
@@ -266,14 +266,14 @@ export default function PricingSection() {
 
         {/* Desktop: full comparison grid */}
         <div className="mt-8 hidden overflow-hidden rounded-[28px] border border-white/10 bg-white/[0.04] lg:block">
-          <div className="grid grid-cols-6 border-b border-white/10 text-sm text-slate-300">
+          <div className="grid grid-cols-7 border-b border-white/10 text-sm text-slate-300">
             <div className="px-4 py-3 font-semibold text-slate-100">Capability</div>
             {comparisonTiers.map((tier) => (
               <div key={tier} className="px-4 py-3 font-semibold text-slate-100">{tier}</div>
             ))}
           </div>
           {comparisonRows.map(([label, ...values]) => (
-            <div key={label} className="grid grid-cols-6 border-b border-white/10 text-sm text-slate-300 last:border-b-0">
+            <div key={label} className="grid grid-cols-7 border-b border-white/10 text-sm text-slate-300 last:border-b-0">
               <div className="px-4 py-3 text-slate-100">{label}</div>
               {values.map((value, i) => (
                 <div key={comparisonTiers[i]} className="px-4 py-3">{value}</div>

--- a/app/components/home/PricingSection.tsx
+++ b/app/components/home/PricingSection.tsx
@@ -132,7 +132,7 @@ export default function PricingSection() {
           All listed GBP prices are excluding VAT. VAT may apply based on billing country and entity status.
         </p>
 
-        <div className="mx-auto mt-10 grid max-w-6xl gap-6 lg:grid-cols-3">
+        <div className="mx-auto mt-10 grid max-w-6xl gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-4">
           {primaryPricingPlans.map((plan, index) => (
             <motion.div
               key={plan.name}

--- a/app/data/homepage.ts
+++ b/app/data/homepage.ts
@@ -105,6 +105,28 @@ export const pricingPlans = [
     featured: false,
   },
   {
+    name: 'Developer',
+    eyebrow: 'API / SDK only',
+    summary: 'Shield-only masking API and SDK access for developers who bring their own LLM.',
+    monthlyPrice: '£9',
+    annualPrice: '£7.20',
+    annualBilled: '£86.40 billed yearly, excluding VAT',
+    priceNote: 'per month, excluding VAT',
+    usage: '500K masking requests per month',
+    managedAiCredit: 'Bring your own LLM',
+    modelUsage: 'Your own LLM — we never touch the call',
+    features: [
+      '500K monthly masking requests',
+      'Shield mask/unmask API and SDK access',
+      'Bring your own LLM — we never touch the call',
+      'No managed proxy, chat UI, or browser extension',
+      '20% annual billing discount',
+    ],
+    href: 'https://app.neutralai.co.uk/auth/signin?intent=signup&plan=developer&src=website_get_developer&callbackUrl=%2Fbilling',
+    cta: 'Get API access',
+    featured: false,
+  },
+  {
     name: 'Starter',
     eyebrow: 'Start controlled',
     summary: 'Low-friction paid plan for founders and small regulated teams.',
@@ -192,7 +214,7 @@ export const pricingPlans = [
   },
 ] as const
 
-export const primaryPricingPlans = pricingPlans.filter((plan) => ['Free', 'Starter', 'Team'].includes(plan.name))
+export const primaryPricingPlans = pricingPlans.filter((plan) => ['Free', 'Developer', 'Starter', 'Team'].includes(plan.name))
 export const advancedPricingPlans = pricingPlans.filter((plan) => ['Business', 'Enterprise'].includes(plan.name))
 
 export const pricingFaqs = [


### PR DESCRIPTION
## Ticket

Closes #156

Adds the £9/mo Developer (shield-only) billing tier to the marketing pricing page (neutralai.co.uk/pricing), matching the tier already live on the app pricing page. Pricing is hardcoded in this repo (no catalog API), so both hardcoded sources were updated.

## Changes

- `app/data/homepage.ts` — added a `Developer` entry to `pricingPlans`, positioned between `Free` and `Starter`, matching the exact field shape of the other entries. Also added to `primaryPricingPlans` so it renders as a visible card (previously an unlisted/data-only tier would never appear on the page).
- `app/components/home/PricingSection.tsx` — `comparisonTiers` now includes `Developer` after `Free`; `comparisonRows` tuple type widened from 6 to 7 elements (label + 6 tiers) with an accurate Developer value in every row; both `grid-cols-6` occurrences in the desktop comparison table became `grid-cols-7`. The mobile comparison cards map over `comparisonTiers` directly, so they scale automatically — no other hardcoded tier-count assumptions found in the repo.

## Developer tier facts

- £9/mo GBP, annual £7.20/mo (£86.40/yr, 20% discount — same pattern as other tiers)
- Shield-only, API/SDK access: developers call the mask/unmask API/SDK and bring their own LLM — NeutralAI never touches the LLM call
- 500K masking requests/month
- Excludes managed proxy, chat UI, and browser extension
- CTA: "Get API access" → `https://app.neutralai.co.uk/auth/signin?intent=signup&plan=developer&src=website_get_developer&callbackUrl=%2Fbilling`

No prohibited claims used ("we never see your PII", "guaranteed compliance", "preserves privilege" do not appear). Only the approved claim "we never touch your LLM call" / bring-your-own-LLM framing is used.

## Test plan

- [x] `npm run build` — compiles cleanly; the widened 7-tuple type checks correctly
- [x] `npm run lint` — no issues
- [x] `npm run test:content` — 88/91 pass. The 3 failures (`contact-form.test.mjs`, `conversion-funnel-qa.test.mjs` CTA analytics, `homepage-decomposition.test.mjs` 250-line limit on `PricingSection.tsx`) are pre-existing and reproduce identically on the base branch before this change (verified via `git stash`); this PR's diff to `PricingSection.tsx` is a net 0 line-count change (9 insertions / 9 deletions), so it does not newly trigger the line-count test.