### PR TITLE
fix(pricing): developer masking-requests 500K -> 10K (ladder consistency)

### DIFF
--- a/app/components/home/PricingSection.tsx
+++ b/app/components/home/PricingSection.tsx
@@ -13,7 +13,7 @@ const SSO_ROADMAP_PLANS = ['Business'] as const
 const comparisonTiers = ['Free', 'Developer', 'Starter', 'Team', 'Business', 'Enterprise'] as const
 
 const comparisonRows: ReadonlyArray<readonly [string, string, string, string, string, string, string]> = [
-  ['Masking requests', '1k', '500K', '10K', '100K', '500K', 'Custom'],
+  ['Masking requests', '1k', '10K', '10K', '100K', '500K', 'Custom'],
   ['Managed AI credit', '£1 trial', 'Bring your own LLM', '£3', '£10', '£25', 'Custom'],
   ['Provider spend model', 'Managed sandbox', 'BYO LLM (shield-only)', 'Managed eval', 'BYOK recommended', 'BYOK expected', 'Customer-owned'],
   ['API key management', 'Basic', 'Shield API/SDK only', 'Basic', 'Team', 'Full lifecycle', 'Scoped controls'],

--- a/app/data/homepage.ts
+++ b/app/data/homepage.ts
@@ -112,11 +112,11 @@ export const pricingPlans = [
     annualPrice: '£7.20',
     annualBilled: '£86.40 billed yearly, excluding VAT',
     priceNote: 'per month, excluding VAT',
-    usage: '500K masking requests per month',
+    usage: '10K masking requests per month',
     managedAiCredit: 'Bring your own LLM',
     modelUsage: 'Your own LLM — we never touch the call',
     features: [
-      '500K monthly masking requests',
+      '10K monthly masking requests',
       'Shield mask/unmask API and SDK access',
       'Bring your own LLM — we never touch the call',
       'No managed proxy, chat UI, or browser extension',


### PR DESCRIPTION
## Ticket
Fixes the £9 Developer card showing **500K masking requests** — equal to Business (£299) and more than Starter (£29, 10K) / Team (£99, 100K). Token->request unit mix-up (its 500k TOKEN cap was displayed as 500K requests).

Corrected the Developer figure to **10K** (honest conversion of 500k tokens; matches Starter's volume — the fence vs Starter is API-only / bring-your-own-LLM, not volume). Business/Starter/Team untouched.

Changed:
- `app/data/homepage.ts` — Developer `usage` + feature: 500K -> 10K
- `app/components/home/PricingSection.tsx` — comparison row Developer cell (index 2): 500K -> 10K; Business (index 5) stays 500K

Companion to gateway PR #1496 (same fix in the catalog facts + contract). Cloudflare Pages preview build verifies the type-safe render.
