### PR TITLE
Add UK compliance hub with verified regulator guidance and gated checklist

### DIFF
--- a/app/compliance/ChecklistLeadForm.tsx
+++ b/app/compliance/ChecklistLeadForm.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { FormEvent, useRef, useState } from 'react'
+import { CheckCircle2, Download, Loader2 } from 'lucide-react'
+import { siteConfig } from '../site'
+import { getLeadAttribution, trackAnalyticsEvent } from '../lib/analytics'
+import { getReferralSnapshot, referralSnapshotToFieldMap } from '../lib/referral'
+
+const GOOGLE_SHEETS_EXEC_PATH_REGEX = /^\/macros\/s\/[a-z0-9_-]+\/exec\/?$/i
+
+function resolveEndpoint(raw: string): string | null {
+  if (!raw) return null
+  try {
+    const parsed = new URL(raw)
+    if (parsed.protocol !== 'https:' || parsed.hostname !== 'script.google.com') return null
+    if (parsed.username || parsed.password || parsed.search || parsed.hash) return null
+    if (!GOOGLE_SHEETS_EXEC_PATH_REGEX.test(parsed.pathname)) return null
+    return parsed.toString()
+  } catch {
+    return null
+  }
+}
+
+type Status = 'idle' | 'submitting' | 'success' | 'error'
+
+export default function ChecklistLeadForm() {
+  const endpoint = resolveEndpoint(siteConfig.leadCapture.googleSheetsEndpoint)
+  const [status, setStatus] = useState<Status>('idle')
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [company, setCompany] = useState('')
+  const [role, setRole] = useState('')
+  const [honeypot, setHoneypot] = useState('')
+  const formStartedRef = useRef(false)
+
+  function handleFormFocus() {
+    if (!formStartedRef.current) {
+      formStartedRef.current = true
+      trackAnalyticsEvent('form_started', { form_id: 'compliance_checklist' })
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="rounded-2xl border border-accent-success/30 bg-accent-success/10 p-6 text-center">
+        <CheckCircle2 className="mx-auto h-8 w-8 text-accent-success" />
+        <p className="mt-3 text-base font-semibold text-white">Checklist ready</p>
+        <p className="mt-1 text-sm text-slate-300">
+          Open the checklist below — it prints cleanly if you prefer to work through it on paper.
+        </p>
+        <a
+          href="/compliance/checklist"
+          className="btn btn-cta mt-5 inline-flex items-center gap-2"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Download className="h-4 w-4" />
+          Open the checklist
+        </a>
+      </div>
+    )
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault()
+    if (honeypot.trim()) return
+
+    if (!name.trim() || !email.trim() || !company.trim()) return
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) return
+
+    setStatus('submitting')
+
+    const payload: Record<string, string> = {
+      full_name: name.trim(),
+      email: email.trim(),
+      company_name: company.trim(),
+      company_website: '',
+      role: role.trim(),
+      website_intent: 'website_checklist_download',
+      lead_source: 'compliance_hub_checklist',
+      message: 'AI confidentiality checklist download request',
+      website_page_url: typeof window !== 'undefined' ? window.location.href : '',
+    }
+
+    Object.entries(getLeadAttribution()).forEach(([key, value]) => {
+      payload[key] = String(value)
+    })
+
+    const referralSnapshot = getReferralSnapshot()
+    if (referralSnapshot) {
+      Object.entries(referralSnapshotToFieldMap(referralSnapshot)).forEach(([key, value]) => {
+        payload[key] = value
+      })
+    }
+
+    try {
+      if (endpoint) {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        if (!response.ok) {
+          setStatus('error')
+          trackAnalyticsEvent('form_error', { form_id: 'compliance_checklist' })
+          return
+        }
+      }
+      trackAnalyticsEvent('lead_submitted', { form_id: 'compliance_checklist' })
+      trackAnalyticsEvent('checklist_downloaded', { form_id: 'compliance_checklist' })
+      setStatus('success')
+    } catch {
+      setStatus('error')
+      trackAnalyticsEvent('form_error', { form_id: 'compliance_checklist' })
+    }
+  }
+
+  const inputClass =
+    'w-full rounded-xl border border-white/10 bg-background px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none text-sm'
+
+  return (
+    <form onSubmit={handleSubmit} onFocus={handleFormFocus} className="grid gap-4">
+      <input
+        name="company_website"
+        value={honeypot}
+        onChange={(e) => setHoneypot(e.target.value)}
+        className="hidden"
+        tabIndex={-1}
+        aria-hidden="true"
+        autoComplete="off"
+      />
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="block">
+          <span className="sr-only">Full name</span>
+          <input
+            type="text"
+            placeholder="Full name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            className={inputClass}
+            autoComplete="name"
+          />
+        </label>
+        <label className="block">
+          <span className="sr-only">Work email</span>
+          <input
+            type="email"
+            placeholder="Work email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className={inputClass}
+            autoComplete="email"
+          />
+        </label>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="block">
+          <span className="sr-only">Firm or company</span>
+          <input
+            type="text"
+            placeholder="Firm or company"
+            value={company}
+            onChange={(e) => setCompany(e.target.value)}
+            required
+            className={inputClass}
+            autoComplete="organization"
+          />
+        </label>
+        <label className="block">
+          <span className="sr-only">Role</span>
+          <input
+            type="text"
+            placeholder="Role (e.g. COLP, DPO, IT lead)"
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            className={inputClass}
+            autoComplete="organization-title"
+          />
+        </label>
+      </div>
+
+      {status === 'error' && (
+        <p className="text-sm text-red-400">Something went wrong — please try again or email {siteConfig.contactEmail}.</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="btn btn-cta flex items-center justify-center gap-2"
+      >
+        {status === 'submitting' ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Preparing checklist…
+          </>
+        ) : (
+          <>
+            <Download className="h-4 w-4" />
+            Get the checklist
+          </>
+        )}
+      </button>
+      <p className="text-xs leading-5 text-slate-500">
+        We use your details to send the checklist and occasional relevant guidance. No spam, unsubscribe any time.
+      </p>
+    </form>
+  )
+}

--- a/app/compliance/GuidancePage.tsx
+++ b/app/compliance/GuidancePage.tsx
@@ -1,0 +1,171 @@
+import Link from 'next/link'
+import { ArrowLeft, ArrowRight, BookOpenCheck, ExternalLink, ShieldCheck } from 'lucide-react'
+import { contactLinks } from '../site'
+import type { GuidanceEntry } from './content'
+
+// Static, developer-authored JSON-LD only (no user input). The < escape keeps
+// any literal "<" in content from terminating the script tag (XSS hardening).
+function toJsonLd(data: object): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c')
+}
+
+function faqStructuredData(entry: GuidanceEntry) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: entry.faq.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  }
+}
+
+export default function GuidancePage({ entry }: { entry: GuidanceEntry }) {
+  return (
+    <main className="min-h-screen pt-24">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: toJsonLd(faqStructuredData(entry)) }}
+      />
+
+      <section className="section">
+        <div className="container-custom max-w-4xl">
+          <Link
+            href="/compliance"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-primary-light hover:text-primary"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            UK compliance hub
+          </Link>
+
+          <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
+            <BookOpenCheck className="h-3.5 w-3.5" />
+            {entry.publisher}
+          </div>
+          <h1 className="mt-5 font-heading text-4xl font-bold md:text-5xl">{entry.pageTitle}</h1>
+
+          <div className="mt-5 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-slate-400">
+            <span>
+              Guidance: <span className="text-slate-200">{entry.title}</span>
+            </span>
+            <span>Published {entry.firstPublished}</span>
+            {entry.lastUpdated && <span>Updated {entry.lastUpdated}</span>}
+            <a
+              href={entry.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 font-semibold text-primary-light hover:text-primary"
+            >
+              Read the original
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </div>
+
+          <div className="mt-8 rounded-[24px] border border-primary/20 bg-primary/[0.07] p-6">
+            <p className="text-base leading-8 text-slate-200">{entry.directAnswer}</p>
+          </div>
+
+          <h2 className="mt-12 font-heading text-3xl font-bold">What the guidance says</h2>
+          <div className="mt-6 space-y-4">
+            {entry.whatItSays.map((item) => (
+              <div key={item.point} className="rounded-2xl border border-white/10 bg-background/80 p-5">
+                <p className="text-sm leading-7 text-slate-200">{item.point}</p>
+                {item.quote && (
+                  <blockquote className="mt-3 border-l-2 border-primary/50 pl-4 text-sm italic leading-7 text-slate-300">
+                    “{item.quote}”
+                    <span className="mt-1 block text-xs not-italic text-slate-500">— {entry.publisher}</span>
+                  </blockquote>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <h2 className="mt-12 font-heading text-3xl font-bold">What this means for your firm</h2>
+          <ul className="mt-6 space-y-3">
+            {entry.whatItMeans.map((item) => (
+              <li key={item} className="flex items-start gap-3 text-sm leading-7 text-slate-300">
+                <ShieldCheck className="mt-1 h-4 w-4 flex-shrink-0 text-primary-light" />
+                {item}
+              </li>
+            ))}
+          </ul>
+
+          <h2 className="mt-12 font-heading text-3xl font-bold">Mapping the guidance to technical controls</h2>
+          <p className="mt-3 text-sm leading-7 text-slate-400">
+            How each expectation in this guidance maps to a NeutralAI control. The full cross-regulator table lives on
+            the{' '}
+            <Link href="/compliance/uk-guidance-map" className="font-semibold text-primary-light hover:text-primary">
+              UK guidance map
+            </Link>
+            .
+          </p>
+          <div className="mt-6 overflow-hidden rounded-[24px] border border-white/10 bg-background/80">
+            <div className="grid border-b border-white/10 bg-white/[0.04] text-sm font-semibold text-slate-200 md:grid-cols-[1fr_0.7fr_1fr]">
+              <div className="px-5 py-4">Guidance expectation</div>
+              <div className="px-5 py-4">NeutralAI control</div>
+              <div className="px-5 py-4">How it works</div>
+            </div>
+            {entry.controlMapping.map((row) => (
+              <div key={row.expectation} className="grid border-b border-white/10 last:border-b-0 md:grid-cols-[1fr_0.7fr_1fr]">
+                <div className="px-5 py-4 text-sm leading-6 text-slate-300">{row.expectation}</div>
+                <div className="px-5 py-4 text-sm font-semibold leading-6 text-white">{row.control}</div>
+                <div className="px-5 py-4 text-sm leading-6 text-slate-400">{row.how}</div>
+              </div>
+            ))}
+          </div>
+
+          <h2 className="mt-12 font-heading text-3xl font-bold">Common questions</h2>
+          <div className="mt-6 space-y-4">
+            {entry.faq.map((item) => (
+              <div key={item.question} className="rounded-2xl border border-white/10 bg-background/80 p-5">
+                <h3 className="font-heading text-lg font-semibold text-white">{item.question}</h3>
+                <p className="mt-2 text-sm leading-7 text-slate-300">{item.answer}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-12 rounded-[24px] border border-white/10 bg-white/[0.04] p-5 text-xs leading-6 text-slate-500">
+            This page summarises third-party guidance for convenience and is not legal advice. Summaries can go stale —
+            always read the original at the source link above before relying on it. Last reviewed:{' '}
+            {entry.lastReviewed}.
+          </div>
+
+          <div className="mt-10 grid gap-4 md:grid-cols-2">
+            <div className="rounded-[24px] border border-primary/20 bg-primary/10 p-6">
+              <h3 className="font-heading text-xl font-semibold text-white">Review your own AI exposure</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                The AI Confidentiality Checklist walks through usage discovery, exposure, policy, controls, and
+                evidence.
+              </p>
+              <Link
+                href="/compliance#checklist"
+                className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-primary-light hover:text-primary"
+              >
+                Get the checklist
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+            <div className="rounded-[24px] border border-white/10 bg-background/80 p-6">
+              <h3 className="font-heading text-xl font-semibold text-white">Talk it through</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                Bring one low-risk workflow and we will show where masking and audit evidence fit — 20 minutes, no
+                commitment.
+              </p>
+              <Link
+                href={contactLinks.demo}
+                className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-primary-light hover:text-primary"
+              >
+                Book a risk review
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/compliance/bar-council-generative-ai/page.tsx
+++ b/app/compliance/bar-council-generative-ai/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import GuidancePage from '../GuidancePage'
+import { guidanceEntries } from '../content'
+import { siteConfig } from '../../site'
+
+const entry = guidanceEntries.find((item) => item.slug === 'bar-council-generative-ai')!
+
+export const metadata: Metadata = {
+  title: "Bar Council ChatGPT and LLM Considerations, Explained",
+  description: "The Bar Council's considerations for using ChatGPT and LLM-based tools: extreme vigilance with privileged information and no personal data in prompts.",
+  alternates: {
+    canonical: '/compliance/bar-council-generative-ai',
+  },
+  openGraph: {
+    title: "Bar Council ChatGPT and LLM Considerations, Explained",
+    description: "The Bar Council's considerations for using ChatGPT and LLM-based tools: extreme vigilance with privileged information and no personal data in prompts.",
+    url: `${siteConfig.url}/compliance/bar-council-generative-ai`,
+  },
+}
+
+export default function BarCouncilGenerativeAiPage() {
+  return <GuidancePage entry={entry} />
+}

--- a/app/compliance/checklist/page.tsx
+++ b/app/compliance/checklist/page.tsx
@@ -1,0 +1,215 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ClipboardCheck, ShieldCheck } from 'lucide-react'
+import { contactLinks } from '../../site'
+
+export const metadata: Metadata = {
+  title: 'AI Confidentiality Checklist for Law Firms',
+  description:
+    'A practical checklist for law firms reviewing AI use, client-data exposure, technical masking controls, and audit evidence.',
+  // Gated lead-magnet asset: reached via the /compliance hub form, kept out of search.
+  robots: { index: false, follow: false },
+}
+
+type ChecklistSection = {
+  title: string
+  intro: string
+  questions: string[]
+  aside?: { label: string; text: string }
+}
+
+const sections: ChecklistSection[] = [
+  {
+    title: '1. AI usage discovery',
+    intro: 'Before improving AI controls, the firm needs to know where AI is already being used.',
+    questions: [
+      'Do we know which AI tools people are using for legal work?',
+      'Do we know whether staff use ChatGPT, Claude, Copilot, Gemini, or other tools with client-related material?',
+      'Is AI use approved, banned, informal, or handled team by team?',
+      'Do partners, associates, paralegals, and support staff follow the same AI process?',
+      'Do we have a named owner for AI usage policy and review?',
+    ],
+  },
+  {
+    title: '2. Client-data exposure',
+    intro: 'Legal documents often contain information the model does not need to see.',
+    questions: [
+      'Could client names be included in AI prompts or uploaded documents?',
+      'Could addresses, phone numbers, email addresses, or personal identifiers be included?',
+      'Could contracts, matter notes, financial values, case facts, or settlement details be included?',
+      'Could privileged or confidential context be copied into AI tools?',
+      'Do we have a process for deciding what information should be removed before AI use?',
+    ],
+    aside: {
+      label: 'Practical test',
+      text: 'Take one sample legal document or matter note. Highlight every detail that an external AI model does not need in order to perform the task.',
+    },
+  },
+  {
+    title: '3. Policy and consent',
+    intro: 'Policy is useful, but it should be specific enough for daily work.',
+    questions: [
+      'Do we have an AI policy that explains what client data must not be shared?',
+      'Does the policy cover documents, prompts, summaries, emails, and attachments?',
+      'Does the policy explain approved tools versus unapproved tools?',
+      'Do users know when client consent, partner approval, or further review may be needed?',
+      'Do we review AI use when opening new matters or adopting new tools?',
+    ],
+    aside: {
+      label: 'Watch-out',
+      text: 'If the policy depends only on users remembering what not to paste, the firm may still have a technical control gap.',
+    },
+  },
+  {
+    title: '4. Technical controls',
+    intro: 'The strongest AI workflow usually combines policy with a technical privacy step.',
+    questions: [
+      'Is sensitive information masked or redacted before AI use?',
+      'Are client names, contact details, matter IDs, financial values, and document references detected before model exposure?',
+      'Are approved AI tools enforced technically, or only suggested in policy?',
+      'Can users run a safe sample document through an approved privacy workflow?',
+      'Can the firm distinguish between raw client content and audit-safe metadata?',
+    ],
+    aside: {
+      label: 'Example safer workflow',
+      text: 'Document or prompt → sensitive data detected → client-identifiable details masked → masked version sent for AI review → audit-friendly record kept.',
+    },
+  },
+  {
+    title: '5. Audit evidence',
+    intro:
+      'If a client, insurer, regulator, or internal reviewer asks how AI was controlled, the firm should be able to show evidence without exposing raw client content again.',
+    questions: [
+      'Can we show that a masking or redaction control ran before AI use?',
+      'Can we show which categories were detected, such as names, emails, addresses, matter IDs, or financial values?',
+      'Can we show the policy applied, timestamp, user or team, destination, and status?',
+      'Can we produce an audit summary without copying raw client data into the report?',
+      'Can partners, DPOs, IT, or compliance owners review AI usage at team level?',
+    ],
+  },
+  {
+    title: '6. Incident readiness',
+    intro: 'If client data is exposed through AI, the first questions will be practical.',
+    questions: [
+      'Do we know who investigates an AI-related data exposure concern?',
+      'Do we know what evidence should be collected in the first 24 hours?',
+      'Can we identify whether a prompt or document was masked before AI use?',
+      'Can we tell whether the issue was user error, tool misuse, policy failure, or missing technical control?',
+      'Do we have a review path for repeat issues or high-risk workflows?',
+    ],
+    aside: {
+      label: 'Prompt for internal discussion',
+      text: 'If a client asked whether their information was used in AI, who could answer and what evidence would they use?',
+    },
+  },
+]
+
+const scoring = [
+  { range: '0–5', interpretation: 'You may already have a defined AI control path, but review whether evidence is easy to produce.' },
+  { range: '6–12', interpretation: 'There may be gaps between policy, daily behaviour, and technical controls.' },
+  { range: '13+', interpretation: 'The firm may be relying heavily on user discipline without enough visibility or evidence.' },
+] as const
+
+export default function ComplianceChecklistPage() {
+  return (
+    <main className="min-h-screen pt-24">
+      <section className="section">
+        <div className="container-custom max-w-4xl">
+          <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
+            <ClipboardCheck className="h-3.5 w-3.5" />
+            Checklist
+          </div>
+          <h1 className="mt-5 font-heading text-4xl font-bold md:text-6xl">
+            AI Confidentiality Checklist for Law Firms
+          </h1>
+          <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-300">
+            Use this checklist before your firm uses AI on client documents, prompts, matter notes, contracts, emails,
+            or research material. It helps partners, operations teams, DPOs, compliance owners, and legal technology
+            leads answer one practical question: are we using AI on client work safely, and do we have evidence of the
+            controls we apply?
+          </p>
+          <p className="mt-4 rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-sm leading-6 text-slate-400">
+            This checklist is not legal advice and does not prove compliance. It is a practical starting point for
+            reviewing AI confidentiality risk, technical controls, and audit evidence. Mark each question yes, no, or
+            not sure.
+          </p>
+
+          <div className="mt-12 space-y-10">
+            {sections.map((section) => (
+              <div key={section.title} className="rounded-[24px] border border-white/10 bg-background/80 p-6 md:p-8">
+                <h2 className="font-heading text-2xl font-semibold text-white">{section.title}</h2>
+                <p className="mt-2 text-sm leading-6 text-slate-400">{section.intro}</p>
+                <ul className="mt-5 space-y-3">
+                  {section.questions.map((question) => (
+                    <li key={question} className="flex items-start gap-3 text-sm leading-6 text-slate-200">
+                      <span
+                        aria-hidden="true"
+                        className="mt-1 h-4 w-4 flex-shrink-0 rounded border border-white/25 bg-white/5"
+                      />
+                      {question}
+                    </li>
+                  ))}
+                </ul>
+                {section.aside && (
+                  <div className="mt-5 rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary-light">
+                      {section.aside.label}
+                    </p>
+                    <p className="mt-1 text-sm leading-6 text-slate-300">{section.aside.text}</p>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-12 rounded-[24px] border border-white/10 bg-background/80 p-6 md:p-8">
+            <h2 className="font-heading text-2xl font-semibold text-white">Score your current position</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-400">
+              Count how many questions were answered no or not sure.
+            </p>
+            <div className="mt-5 overflow-hidden rounded-2xl border border-white/10">
+              {scoring.map((row) => (
+                <div key={row.range} className="grid border-b border-white/10 last:border-b-0 md:grid-cols-[0.2fr_1fr]">
+                  <div className="px-5 py-4 font-heading text-lg font-semibold text-white">{row.range}</div>
+                  <div className="px-5 py-4 text-sm leading-6 text-slate-300">{row.interpretation}</div>
+                </div>
+              ))}
+            </div>
+            <p className="mt-4 text-xs leading-5 text-slate-500">
+              This scoring is not a compliance assessment. It is a conversation starter for internal review.
+            </p>
+          </div>
+
+          <div className="mt-12 rounded-[24px] border border-primary/20 bg-primary/10 p-6 md:p-8">
+            <div className="flex items-start gap-4">
+              <ShieldCheck className="mt-1 h-6 w-6 flex-shrink-0 text-primary-light" />
+              <div>
+                <h2 className="font-heading text-2xl font-semibold text-white">Where NeutralAI fits</h2>
+                <p className="mt-2 text-sm leading-7 text-slate-200">
+                  NeutralAI helps law firms use AI on legal documents with less client-identifiable data exposed to the
+                  model, and with audit-friendly evidence of the control applied: sensitive fields are detected and
+                  masked before the prompt leaves the browser, and the record of that control is kept without turning
+                  raw client content into another reporting risk. It is not a guarantee of compliance or privilege
+                  protection, and it does not replace legal review.
+                </p>
+                <p className="mt-4 text-sm leading-7 text-slate-200">
+                  If you want to review one workflow, start small: bring one low-risk legal workflow — contract review,
+                  matter summaries, discovery triage — and we will walk through where masking, audit evidence, and
+                  deployment controls would fit.
+                </p>
+                <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+                  <Link href={contactLinks.demo} className="btn btn-cta px-6 py-3 text-sm">
+                    Book a 20-minute risk review
+                  </Link>
+                  <Link href="/compliance" className="btn btn-secondary px-6 py-3 text-sm">
+                    Back to the compliance hub
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/compliance/content.ts
+++ b/app/compliance/content.ts
@@ -1,0 +1,641 @@
+// Data source of truth for the /compliance hub.
+// Every date, quote, and URL below is verified against the internal claims
+// register (pazarlama/claims-register.md) and fetched primary sources on the
+// lastReviewed date. Quotes are verbatim from the cited documents — do not
+// paraphrase inside `quote` fields; put paraphrase in `point`/`line` fields.
+
+export type GuidanceEntry = {
+  slug: string
+  shortName: string
+  publisher: string
+  pageTitle: string
+  title: string
+  firstPublished: string
+  lastUpdated?: string
+  sourceUrl: string
+  lastReviewed: string
+  oneLineSummary: string
+  directAnswer: string
+  whatItSays: { point: string; quote?: string }[]
+  whatItMeans: string[]
+  controlMapping: { expectation: string; control: string; how: string }[]
+  faq: { question: string; answer: string }[]
+}
+
+export type ControlMapRow = {
+  control: string
+  description: string
+  guidanceLines: { shortName: string; slug: string; line: string }[]
+}
+
+const LAST_REVIEWED = '17 July 2026'
+
+export const guidanceEntries: GuidanceEntry[] = [
+  {
+    slug: 'law-society-generative-ai',
+    shortName: 'Law Society',
+    publisher: 'The Law Society of England and Wales',
+    pageTitle: 'Law Society generative AI guidance, explained for busy firms',
+    title: 'Generative AI – the essentials',
+    firstPublished: '17 November 2023',
+    lastUpdated: 'June 2026',
+    sourceUrl: 'https://www.lawsociety.org.uk/topics/ai-and-lawtech/generative-ai-the-essentials',
+    lastReviewed: LAST_REVIEWED,
+    oneLineSummary:
+      'No confidential data into public generative AI tools; use fictional data for testing — the baseline for solicitors.',
+    directAnswer:
+      'The Law Society’s "Generative AI – the essentials" guide (first published November 2023, updated June 2026) tells solicitors they can use generative AI — but confidential data should not go into free, online generative AI services, and testing or template-building should always use fictional data rather than real client information. In practice that means firms need either an enterprise AI contract with retention guarantees, a technical control that removes client identifiers before prompts leave the firm, or both. The guide treats AI adoption as manageable risk — the emphasis is on confidentiality, competence, and supervision, not on avoiding AI.',
+    whatItSays: [
+      {
+        point:
+          'For free, online generative AI services — where the firm has no operational relationship with the vendor — the instruction on confidential data is unambiguous.',
+        quote: 'do not put any confidential data into the tool',
+      },
+      {
+        point:
+          'Client confidential and personal data should not be used to test or build templates with generative AI — the guide says to create and use fictional data instead.',
+      },
+      {
+        point:
+          'Firms should understand what the AI provider does with input data — training use, retention, and access — before approving a tool, and weigh any sharing of client data with an AI business carefully.',
+      },
+      {
+        point:
+          'The June 2026 update added recent developments including a case in which two solicitors were referred to the SRA after AI-generated false information reached a court.',
+      },
+    ],
+    whatItMeans: [
+      'A written AI policy alone does not satisfy the guidance if staff can still paste client names into free chatbots — the control needs to reach the point of use.',
+      'Tool approval should be based on the provider’s data terms (retention, training, access), not on popularity.',
+      'If client identifiers are masked before a prompt leaves the firm, the confidentiality question changes materially: the public tool never receives the identifying content.',
+      'Consent conversations get easier when you can show clients exactly what does and does not reach an AI provider.',
+    ],
+    controlMapping: [
+      {
+        expectation: 'No identifiable client data into public AI tools',
+        control: 'Mask before send',
+        how: 'Client names, addresses, NI/NHS numbers, and case references are detected and replaced with placeholders in the browser, before the prompt reaches the AI provider.',
+      },
+      {
+        expectation: 'Understand and limit what the provider retains',
+        control: 'Reversible vault (15-min TTL)',
+        how: 'Real values never leave the firm; masked tokens are restored locally after the response returns, and vault entries expire in minutes by default.',
+      },
+      {
+        expectation: 'Supervision and accountability for AI use',
+        control: 'Audit trail',
+        how: 'Every masking event is logged with policy, timestamp, and category counts — evidence of the control without storing raw client content.',
+      },
+    ],
+    faq: [
+      {
+        question: 'Does the Law Society ban solicitors from using ChatGPT?',
+        answer:
+          'No. The guidance permits generative AI use but expects firms to protect client confidentiality — identifiable client data should not go into public AI tools without safeguards and informed consent. The practical question is how the firm enforces that in daily work.',
+      },
+      {
+        question: 'Is masking client data before AI use enough to satisfy the guidance?',
+        answer:
+          'Masking materially reduces what an AI provider receives, which is central to the confidentiality concern. It is a strong technical control, not a compliance guarantee — firms still need policy, training, and appropriate provider terms.',
+      },
+      {
+        question: 'How current is this guidance?',
+        answer:
+          'It is actively maintained: first published in November 2023, with updates in 2024, May and October 2025, and June 2026. The June 2026 revision added recent regulatory developments and case references. The core position on confidential data and public AI tools has been consistent throughout — always check the original page for the current text.',
+      },
+    ],
+  },
+  {
+    slug: 'sra-ai-risk-outlook',
+    shortName: 'SRA',
+    publisher: 'Solicitors Regulation Authority',
+    pageTitle: 'What the SRA actually says about AI in law firms',
+    title: 'Risk Outlook report: the use of artificial intelligence in the legal market',
+    firstPublished: '20 November 2023',
+    sourceUrl: 'https://www.sra.org.uk/sra/research-publications/artificial-intelligence-legal-market/',
+    lastReviewed: LAST_REVIEWED,
+    oneLineSummary:
+      'The regulator frames AI adoption itself as expected — the risk is adopting it without controls, or not adopting it at all.',
+    directAnswer:
+      'The SRA’s Risk Outlook report on AI in the legal market (November 2023) is notable for what it does not say: it does not tell firms to avoid AI. It reports that, reportedly, three quarters of the largest solicitors’ firms were already using AI, and frames the risk as failing to adopt safely rather than adopting at all. For smaller firms the message is uncomfortable in the other direction: the technology gap is real, and the safe-adoption expectations (confidentiality, accuracy, accountability) apply at every firm size.',
+    whatItSays: [
+      {
+        point:
+          'AI adoption in the legal market is already mainstream at the top end — the report cites that, reportedly, three quarters of the largest firms were using AI by late 2023.',
+        quote: 'three quarters of the largest solicitors’ firms were using AI, nearly twice the number from just three years ago',
+      },
+      {
+        point: 'Not adopting AI is itself framed as a competitive and client-service risk.',
+        quote: 'The risk to firms might not come from adopting AI, but from failing to do so.',
+      },
+      {
+        point: 'The regulator’s posture is enablement with conditions: AI must operate within the law, and firms remain accountable.',
+        quote: 'We want to help firms and consumers safely gain the benefits that AI can bring.',
+      },
+    ],
+    whatItMeans: [
+      'The SRA is not a reason to ban AI — it is a reason to be able to show your AI use is controlled.',
+      'Confidentiality and accountability expectations apply regardless of firm size; "we are too small to need controls" is not a position the report supports.',
+      'The firms that benefit are the ones that can adopt quickly because their control story is already in place.',
+      'Separate SRA compliance tips on AI and technology (updated February 2026) reinforce responsible adoption — check the SRA site for the current text.',
+    ],
+    controlMapping: [
+      {
+        expectation: 'Adopt AI safely rather than abstain',
+        control: 'Mask before send',
+        how: 'Staff keep using AI tools for productivity; the control removes client-identifiable data from prompts automatically, so adoption does not depend on perfect user discipline.',
+      },
+      {
+        expectation: 'Remain accountable for AI use',
+        control: 'Audit trail',
+        how: 'Category-level masking logs show what was protected, when, and under which policy — the evidence layer for supervision and file reviews.',
+      },
+      {
+        expectation: 'Operate within the law across tools',
+        control: 'Policy + whitelist',
+        how: 'Tenant policies and whitelisted terms apply the same masking rules across every supported AI site, rather than per-tool ad hoc decisions.',
+      },
+    ],
+    faq: [
+      {
+        question: 'Does the SRA require law firms to use AI?',
+        answer:
+          'No. The Risk Outlook report observes that most large firms already use AI and frames non-adoption as a potential competitive risk — but it requires nothing. Its practical weight is in the safe-adoption expectations it sets for firms that do use AI.',
+      },
+      {
+        question: 'Is the 75% adoption statistic current?',
+        answer:
+          'The figure comes from the SRA’s November 2023 report, which itself qualifies it as "reportedly". Treat it as a dated, directional signal about large-firm adoption, not a live market measurement.',
+      },
+      {
+        question: 'What does "safe adoption" look like for a small firm?',
+        answer:
+          'A defined policy, an approved-tools list, a technical control that stops client identifiers reaching public AI tools, and evidence that the control ran. That combination is achievable without a security team.',
+      },
+    ],
+  },
+  {
+    slug: 'bar-council-generative-ai',
+    shortName: 'Bar Council',
+    publisher: 'The Bar Council of England and Wales',
+    pageTitle: 'The Bar Council on ChatGPT and LLMs: what barristers should know',
+    title: 'Considerations when using ChatGPT and generative AI software based on large language models',
+    firstPublished: '30 January 2024',
+    lastUpdated: '25 November 2025',
+    sourceUrl:
+      'https://www.barcouncilethics.co.uk/documents/considerations-when-using-chatgpt-and-generative-ai-software-based-on-large-language-models/',
+    lastReviewed: LAST_REVIEWED,
+    oneLineSummary:
+      'Extreme vigilance with privileged or confidential information in LLMs; never input personal data into prompts.',
+    directAnswer:
+      'The Bar Council’s considerations document on ChatGPT and LLM-based tools (January 2024, reviewed November 2025) does not prohibit generative AI — it sets out how to use it without breaching core duties. The sharpest lines are about data: be extremely vigilant about sharing legally privileged or confidential information with an LLM system, and do not input personal data into prompts. The November 2025 review added the Ayinde fabricated-citations judgments, connecting careless AI use directly to court sanctions. Note: the document describes itself as assistance, not formal BSB guidance.',
+    whatItSays: [
+      {
+        point: 'Privileged and confidential information requires extreme caution with LLM systems.',
+        quote:
+          'Be extremely vigilant about sharing with a generative LLM system any legally privileged or confidential information',
+      },
+      {
+        point: 'What goes into a system may not stay there — inputs can become training data and resurface.',
+        quote:
+          'anything that a user types into the system may be used to train the software and might find itself repeated verbatim in future results',
+      },
+      {
+        point:
+          'Personal data should not be entered into prompts at all; the document suggests synthetic data as a way to avoid UK GDPR breach.',
+      },
+      {
+        point:
+          'The November 2025 review added the Ayinde v Haringey judgments on fabricated AI citations — the courts are now part of this story, not a hypothetical.',
+      },
+    ],
+    whatItMeans: [
+      'For chambers and barristers, the input side (what reaches the model) is treated as seriously as the output side (hallucinated citations).',
+      '"Vigilance" as a human-only control fails under deadline pressure — a technical mask-before-send step makes the vigilant path the default path.',
+      'The synthetic-data suggestion maps directly to masking: structurally faithful placeholders preserve the legal question while removing the identifying content.',
+      'This is an assistance document, not binding BSB guidance — but it is what a disciplinary tribunal would expect a barrister to have read.',
+    ],
+    controlMapping: [
+      {
+        expectation: 'Extreme vigilance with privileged/confidential information',
+        control: 'Mask before send',
+        how: 'Identifying and confidential specifics are removed from the prompt automatically — vigilance becomes a system property instead of a memory test.',
+      },
+      {
+        expectation: 'Never input personal data into prompts',
+        control: 'UK entity detection',
+        how: 'Names, addresses, NI and NHS numbers, court references, and other UK identifiers are detected and replaced before the text leaves the browser.',
+      },
+      {
+        expectation: 'Prefer synthetic stand-ins over real data',
+        control: 'Reversible tokenisation',
+        how: 'Placeholders like <PERSON_7K9X> act as consistent synthetic stand-ins; the real values are restored only in your environment after the response returns.',
+      },
+    ],
+    faq: [
+      {
+        question: 'Is the Bar Council document binding on barristers?',
+        answer:
+          'No — it explicitly states it is not formal guidance for BSB Handbook purposes. It is an assistance document from the Bar Council’s IT Panel. In practice, it sets the expectations a regulator or tribunal would assume a careful barrister knows.',
+      },
+      {
+        question: 'Can barristers use ChatGPT for drafting at all?',
+        answer:
+          'Yes, the document contemplates legitimate use. The constraints are on what goes in (no privileged, confidential, or personal data) and on verifying what comes out (the Ayinde judgments on fabricated citations are now cited in the November 2025 review).',
+      },
+      {
+        question: 'How does masking relate to the "synthetic data" suggestion?',
+        answer:
+          'Masking automates it: real identifiers are replaced with structurally faithful placeholders before the prompt leaves your machine, which is exactly the synthetic stand-in pattern the document suggests — without asking the barrister to build synthetic examples by hand.',
+      },
+    ],
+  },
+  {
+    slug: 'judiciary-ai-guidance',
+    shortName: 'Judiciary',
+    publisher: 'Courts and Tribunals Judiciary',
+    pageTitle: 'The judiciary’s AI guidance: the clearest line in UK legal AI',
+    title: 'Artificial Intelligence (AI) — Guidance for Judicial Office Holders',
+    firstPublished: '12 December 2023',
+    lastUpdated: '31 October 2025',
+    sourceUrl:
+      'https://www.judiciary.uk/guidance-and-resources/artificial-intelligence-ai-judicial-guidance-october-2025/',
+    lastReviewed: LAST_REVIEWED,
+    oneLineSummary:
+      'Anything entered into a public AI chatbot "should be seen as being published to all the world."',
+    directAnswer:
+      'The judiciary’s AI guidance for judicial office holders (December 2023, updated October 2025) contains the single clearest sentence in UK legal AI: any information you input into a public AI chatbot "should be seen as being published to all the world." Judges are told not to enter anything that is not already public. The October 2025 update also added warnings about white text and hidden prompts embedded in documents. If that is the standard the bench applies to itself, it is a reasonable benchmark for anyone handling confidential material.',
+    whatItSays: [
+      {
+        point: 'The confidentiality rule is absolute for public chatbots.',
+        quote: 'Do not enter any information into a public AI chatbot that is not already in the public domain.',
+      },
+      {
+        point: 'Inputs are treated as irreversible publication.',
+        quote: 'Any information that you input into a public AI chatbot should be seen as being published to all the world.',
+      },
+      {
+        point:
+          'The October 2025 version added a glossary entry for "white text" and warns about hidden prompts concealed in documents — visible to the system but not the human reader.',
+      },
+      {
+        point:
+          'Coverage is broad: all judicial office holders plus clerks, judicial assistants, and legal advisers under the Lady Chief Justice and Senior President of Tribunals.',
+      },
+    ],
+    whatItMeans: [
+      'The "published to all the world" framing is the same reasoning the Upper Tribunal applied in Munir v SSHD when a representative pasted client letters into ChatGPT — this is now a consistent judicial position.',
+      'If a matter may end up before a judge, assume the judge holds this view of what pasting into a chatbot means.',
+      'The white-text warning matters for document uploads: what a human reviewer sees is not necessarily what the model receives.',
+      'The operational answer is the same as everywhere else in this hub: make sure non-public information physically cannot reach the public tool.',
+    ],
+    controlMapping: [
+      {
+        expectation: 'Nothing non-public into public AI chatbots',
+        control: 'Mask before send',
+        how: 'Client-identifiable and confidential specifics are replaced before submission, so the public tool receives only de-identified content.',
+      },
+      {
+        expectation: 'Treat inputs as irreversible publication',
+        control: 'Reversible vault (15-min TTL)',
+        how: 'Because real values never leave the firm, there is nothing to "recall" from the provider — restoration happens locally, and vault entries expire by default.',
+      },
+      {
+        expectation: 'Beware hidden content in documents',
+        control: 'Document scan gate',
+        how: 'Uploads are scanned before submission, on the same masked path as typed prompts — reducing the gap between what a human sees and what the model receives.',
+      },
+    ],
+    faq: [
+      {
+        question: 'Does the judiciary’s guidance apply to law firms?',
+        answer:
+          'Not directly — it binds judicial office holders and their support staff. Its wider value is as a benchmark: it shows how the bench itself characterises entering information into public AI tools, which informed the Upper Tribunal’s reasoning in Munir v SSHD.',
+      },
+      {
+        question: 'What is the "white text" warning about?',
+        answer:
+          'Hidden prompts or concealed text can be embedded in a document so the system reads instructions a human reviewer cannot see. The October 2025 update added this to the guidance glossary — it is a document-upload risk, not just a chat risk.',
+      },
+      {
+        question: 'What changed between the 2023 and 2025 versions?',
+        answer:
+          'The core confidentiality position is unchanged. The chain is December 2023 → April 2025 → October 2025, with the latest version adding the white-text/hidden-prompt warnings and updated definitions. Read the current version at the source link.',
+      },
+    ],
+  },
+  {
+    slug: 'ico-generative-ai',
+    shortName: 'ICO',
+    publisher: 'Information Commissioner’s Office',
+    pageTitle: 'The ICO’s position on generative AI and personal data',
+    title: 'Response to the consultation series on generative AI',
+    firstPublished: '12 December 2024',
+    lastUpdated: 'March 2026 (strategy update)',
+    sourceUrl:
+      'https://ico.org.uk/about-the-ico/what-we-do/our-work-on-artificial-intelligence/response-to-the-consultation-series-on-generative-ai/',
+    lastReviewed: LAST_REVIEWED,
+    oneLineSummary:
+      'The ICO has moved from consultation to enforcement posture on generative AI — with a statutory AI code in the pipeline.',
+    directAnswer:
+      'The ICO ran a five-part consultation on generative AI and data protection through 2024 and published its response in December 2024, holding firm on purpose limitation, accuracy, and controllership. Its AI and biometrics strategy (June 2025) went further: the direction is a statutory code of practice for AI and automated decision-making, now in development following the Data (Use and Access) Act. The regulator has said plainly it will use formal powers where personal information is used recklessly. For firms, UK GDPR applies to AI prompts today — there is no AI exemption.',
+    whatItSays: [
+      {
+        point: 'Transparency expectations for generative AI developers are explicit and immediate.',
+        quote: 'As a first step, we expect generative AI developers to significantly improve their approach to transparency.',
+      },
+      {
+        point: 'The enforcement posture is stated, not implied.',
+        quote:
+          'we will not hesitate to use our formal powers to safeguard people’s rights if organisations are using personal information recklessly',
+      },
+      {
+        point:
+          'The June 2025 AI and biometrics strategy sets four priorities, including a statutory code of practice for AI and automated decision-making — in development following the DUAA.',
+      },
+      {
+        point:
+          'The consultation response held the ICO’s positions on purpose limitation, accuracy, and controllership for generative AI development and deployment.',
+      },
+    ],
+    whatItMeans: [
+      'Personal data in AI prompts is a data protection question under UK GDPR now — waiting for the statutory code is not a strategy.',
+      'A firm that can show a masking control ran before AI use has a materially better answer to "how do you protect personal data in AI workflows?" than one relying on policy alone.',
+      'Data minimisation is the principle doing the work: send the model only what it needs, which for most legal and financial tasks excludes real identifiers.',
+      'The statutory AI/ADM code will raise evidence expectations — audit trails built now become the compliance surface later.',
+    ],
+    controlMapping: [
+      {
+        expectation: 'Data minimisation in AI processing',
+        control: 'Mask before send',
+        how: 'Identifiers are stripped from prompts by default, so the AI provider processes de-identified content — minimisation applied at the exact point of exposure.',
+      },
+      {
+        expectation: 'Demonstrable accountability (UK GDPR Art. 5(2))',
+        control: 'Audit trail + DPIA evidence pack',
+        how: 'Masking events are logged by category and policy, and can be exported as a signed evidence pack that slots into a DPIA or an ICO enquiry response.',
+      },
+      {
+        expectation: 'Lawful, controlled data flows to processors',
+        control: 'BYOK + on-prem deployment',
+        how: 'Firms that need tighter control can run the gateway in their own environment and use their own LLM contracts and keys, keeping the processing chain theirs.',
+      },
+    ],
+    faq: [
+      {
+        question: 'Is there an ICO fine for pasting client data into ChatGPT?',
+        answer:
+          'Not yet, as at the last review of this page. The ICO’s first fine against a law firm (DPP Law, April 2025, £60,000) was about basic security failures, not AI use. The regulator’s stated posture on reckless personal-data use suggests the gap is opportunity, not safety.',
+      },
+      {
+        question: 'Does UK GDPR apply to AI prompts?',
+        answer:
+          'Yes. If a prompt contains personal data, entering it into an AI tool is processing — lawful basis, minimisation, and accountability apply. There is no AI exemption in UK data protection law.',
+      },
+      {
+        question: 'What is the statutory AI code and when is it coming?',
+        answer:
+          'Following the Data (Use and Access) Act 2025, the government and ICO are developing a statutory code of practice covering AI and automated decision-making. Timing is not fixed; the ICO’s March 2026 strategy update describes it as in development. Build evidence habits now rather than retrofitting.',
+      },
+    ],
+  },
+  {
+    slug: 'data-use-and-access-act',
+    shortName: 'DUAA 2025',
+    publisher: 'UK Parliament (legislation.gov.uk)',
+    pageTitle: 'No UK AI Act — so what actually binds you? The DUAA, explained',
+    title: 'Data (Use and Access) Act 2025 (c. 18)',
+    firstPublished: '19 June 2025 (Royal Assent)',
+    lastUpdated: 'Main data-protection provisions in force 5 February 2026',
+    sourceUrl: 'https://www.legislation.gov.uk/ukpga/2025/18',
+    lastReviewed: LAST_REVIEWED,
+    oneLineSummary:
+      'The UK’s data reform act: ADM rules relaxed but conditioned, complaints procedures mandatory, ICO AI code incoming.',
+    directAnswer:
+      'The UK has no AI Act — but the Data (Use and Access) Act 2025 changes the data protection rules that govern AI use. Royal Assent came on 19 June 2025; the main data-protection provisions, including the automated decision-making changes (section 80), commenced on 5 February 2026, and the mandatory data-subject complaints procedure follows on 19 June 2026. The ADM reform expands when organisations can make significant automated decisions, in exchange for safeguards. For firms using AI on personal data, the compliance frame is DUAA-amended UK GDPR — not a hypothetical AI law.',
+    whatItSays: [
+      {
+        point: 'The ADM reform is a trade: more room for automated decisions, with safeguards attached.',
+        quote:
+          'This section expands the circumstances in which an organisation can make significant decisions based solely on its automated processing of personal information',
+      },
+      {
+        point: 'The "solely automated" test turns on meaningful human involvement.',
+        quote: 'a decision is based solely on automated processing if there is no meaningful human involvement in taking it',
+      },
+      {
+        point:
+          'Commencement is staged: main data-protection provisions and the ADM changes (s.80, Sch.6) in force 5 February 2026; the data-subject complaints procedure requirement (s.103, Sch.10) from 19 June 2026.',
+      },
+      {
+        point: 'The Act paves the way for the ICO’s statutory code of practice on AI and automated decision-making.',
+      },
+    ],
+    whatItMeans: [
+      'When someone says "there’s no AI regulation in the UK", the accurate answer is: the DUAA-amended UK GDPR regime is the AI regulation for personal data, and its provisions are in force now.',
+      'The meaningful-human-involvement test makes documentation of AI workflows matter — you need to be able to show where humans sit in the loop.',
+      'From June 2026, firms need a proper complaints procedure for data subjects — AI-related complaints will arrive through it.',
+      'The safest way to keep AI workflows out of the hardest ADM questions is to keep personal identifiers out of the automated processing in the first place.',
+    ],
+    controlMapping: [
+      {
+        expectation: 'Lawful processing under DUAA-amended UK GDPR',
+        control: 'Mask before send',
+        how: 'Removing identifiers before AI processing reduces the personal-data footprint of the workflow — the strongest form of data minimisation.',
+      },
+      {
+        expectation: 'Evidence for the meaningful-human-involvement test',
+        control: 'Audit trail',
+        how: 'Logged masking and routing events document how the AI step fits into the wider workflow, supporting the human-involvement narrative.',
+      },
+      {
+        expectation: 'Answering data-subject complaints (from June 2026)',
+        control: 'DPIA evidence pack',
+        how: 'Exportable, signed summaries of what was masked and when give a concrete artefact for complaint responses and ICO correspondence.',
+      },
+    ],
+    faq: [
+      {
+        question: 'Is the DUAA fully in force?',
+        answer:
+          'No — commencement is staged. The main data-protection provisions, including the ADM changes, commenced on 5 February 2026 (Commencement No. 6 Regulations, SI 2026/82). The mandatory complaints-procedure requirement follows on 19 June 2026. Say "main provisions in force", not "fully in force".',
+      },
+      {
+        question: 'Does the DUAA replace UK GDPR?',
+        answer:
+          'No. It amends UK GDPR and the Data Protection Act 2018. Your existing data protection obligations continue, with modified rules in areas like automated decision-making, recognised legitimate interests, and complaints handling.',
+      },
+      {
+        question: 'What should a firm using AI do about the ADM changes?',
+        answer:
+          'Map where AI makes or shapes significant decisions about individuals, document where meaningful human involvement sits, and reduce the personal data entering those workflows. If identifiers are masked before processing, many workflows simply carry less ADM exposure.',
+      },
+    ],
+  },
+  {
+    slug: 'fca-ai-approach',
+    shortName: 'FCA',
+    publisher: 'Financial Conduct Authority',
+    pageTitle: 'The FCA’s AI approach: no new rulebook, existing rules apply',
+    title: 'AI and the FCA: our approach',
+    firstPublished: 'AI Update, 22 April 2024',
+    lastUpdated: 'Approach page updated 13 February 2026',
+    sourceUrl: 'https://www.fca.org.uk/firms/innovation/ai-approach',
+    lastReviewed: LAST_REVIEWED,
+    oneLineSummary:
+      'No AI-specific rulebook: Consumer Duty and SM&CR already cover AI use — accountability sits with named senior managers.',
+    directAnswer:
+      'The FCA has deliberately not written an AI rulebook. Its position, set out in the April 2024 AI Update and restated on its current approach page, is that existing frameworks — the Consumer Duty, the Senior Managers and Certification Regime, and existing data and operational-resilience rules — already apply to AI. That is not a lighter regime; it is a heavier one for individuals, because SM&CR means a named senior manager is accountable for AI-driven outcomes, and the Consumer Duty asks whether AI use delivers good customer outcomes. The FCA’s AI Live Testing programme runs alongside, supporting firms deploying AI — its second cohort was announced in April 2026.',
+    whatItSays: [
+      {
+        point: 'The position is explicit on the FCA’s current approach page.',
+        quote:
+          'We do not plan to introduce extra regulations for AI. Instead, we’ll rely on existing frameworks, which mitigate many of the risks associated with AI.',
+      },
+      {
+        point: 'The April 2024 AI Update reasons that AI risks are rarely unique to AI.',
+        quote:
+          'Many risks related to AI are not necessarily unique to AI itself and can therefore be mitigated within existing legislative and/or regulatory frameworks.',
+      },
+      {
+        point: 'Accountability is personal: the AI Update names SM&CR as directly relevant.',
+        quote:
+          'The Senior Managers and Certification Regime (SM&CR) emphasises senior management accountability and is relevant to the safe and responsible use of AI.',
+      },
+      {
+        point:
+          'The AI Live Testing programme (part of the FCA’s AI Lab) supports firms deploying AI — cohort 2, announced 21 April 2026, includes eight firms from major banks to fintechs.',
+      },
+    ],
+    whatItMeans: [
+      'For a regulated financial firm, "can we use AI?" is the wrong question — "which senior manager owns the AI risk, and what evidence do they hold?" is the FCA-shaped question.',
+      'Customer personal data entering AI tools sits under both UK GDPR and the Consumer Duty lens — a data leak through a prompt is also a customer-outcome failure.',
+      'Evidence is the currency of SM&CR: technical controls that log what was protected before AI processing give the accountable manager something to stand on.',
+      'The absence of an AI rulebook means there is no waiting game — the obligations are already live.',
+    ],
+    controlMapping: [
+      {
+        expectation: 'Consumer Duty: good outcomes when AI touches customer data',
+        control: 'Mask before send',
+        how: 'Customer identifiers, account references, and payment details are masked before prompts reach external AI providers — reducing the exposure that turns into a customer-outcome failure.',
+      },
+      {
+        expectation: 'SM&CR: named accountability for AI use',
+        control: 'Audit trail + DPIA evidence pack',
+        how: 'Exportable logs of the control running give the accountable senior manager concrete evidence of the safeguards in place.',
+      },
+      {
+        expectation: 'Operational control over data flows',
+        control: 'BYOK + on-prem',
+        how: 'Firms can keep the gateway inside their own environment and use their own provider contracts — the data flow stays within the firm’s documented perimeter.',
+      },
+    ],
+    faq: [
+      {
+        question: 'Has the FCA banned or restricted generative AI?',
+        answer:
+          'No. The FCA has chosen not to write AI-specific rules and instead applies the existing framework — Consumer Duty, SM&CR, and existing data and resilience requirements — to AI use. Its AI Live Testing programme actively supports firms deploying AI.',
+      },
+      {
+        question: 'Who is accountable when AI goes wrong at a regulated firm?',
+        answer:
+          'Under SM&CR, a named senior manager. That is why evidence matters: the accountable individual needs to show reasonable steps, and technical controls with audit trails are exactly that kind of evidence.',
+      },
+      {
+        question: 'Does masking customer data help with FCA expectations?',
+        answer:
+          'It addresses the data-exposure slice of the risk: masking reduces what external AI providers receive, and the audit trail documents the control. It does not by itself satisfy Consumer Duty or SM&CR — those are broader regimes about outcomes and governance.',
+      },
+    ],
+  },
+]
+
+// The seven NeutralAI controls mapped across all guidance — the
+// /compliance/uk-guidance-map table. Lines paraphrase the guidance; verbatim
+// quotes live on the per-guidance pages.
+export const controlMapRows: ControlMapRow[] = [
+  {
+    control: 'Mask before send',
+    description: 'PII detected and replaced in the browser before the prompt or upload leaves the firm.',
+    guidanceLines: [
+      { shortName: 'Law Society', slug: 'law-society-generative-ai', line: 'No identifiable client data into public AI tools without safeguards.' },
+      { shortName: 'Judiciary', slug: 'judiciary-ai-guidance', line: 'Nothing non-public into a public AI chatbot — inputs are publication.' },
+      { shortName: 'Bar Council', slug: 'bar-council-generative-ai', line: 'Extreme vigilance with privileged or confidential information; no personal data in prompts.' },
+      { shortName: 'ICO', slug: 'ico-generative-ai', line: 'Data minimisation applies to AI processing under UK GDPR.' },
+    ],
+  },
+  {
+    control: 'Reversible vault (15-minute TTL)',
+    description: 'Masked tokens restore locally after the response; encrypted vault entries expire in minutes.',
+    guidanceLines: [
+      { shortName: 'Judiciary', slug: 'judiciary-ai-guidance', line: 'Inputs are irreversible publication — so real values must never be the input.' },
+      { shortName: 'Bar Council', slug: 'bar-council-generative-ai', line: 'Inputs may be retained, used for training, and repeated verbatim later.' },
+      { shortName: 'Law Society', slug: 'law-society-generative-ai', line: 'Understand what the provider retains — or ensure it retains nothing identifying.' },
+    ],
+  },
+  {
+    control: 'Audit trail',
+    description: 'Category-level masking events logged with policy and timestamp — no raw PII in the log.',
+    guidanceLines: [
+      { shortName: 'ICO', slug: 'ico-generative-ai', line: 'Accountability: demonstrate compliance, not just assert it.' },
+      { shortName: 'FCA', slug: 'fca-ai-approach', line: 'SM&CR: the accountable senior manager needs evidence of reasonable steps.' },
+      { shortName: 'SRA', slug: 'sra-ai-risk-outlook', line: 'Firms remain accountable for AI use — supervision needs a record.' },
+      { shortName: 'DUAA 2025', slug: 'data-use-and-access-act', line: 'Document where human involvement sits in automated workflows.' },
+    ],
+  },
+  {
+    control: 'Whitelist & tenant policy',
+    description: 'Firm-approved terms and per-tenant masking policy applied consistently across every AI tool.',
+    guidanceLines: [
+      { shortName: 'Law Society', slug: 'law-society-generative-ai', line: 'Approve tools deliberately; apply the same confidentiality rules everywhere.' },
+      { shortName: 'SRA', slug: 'sra-ai-risk-outlook', line: 'Safe adoption is a firm-level posture, not a per-tool improvisation.' },
+    ],
+  },
+  {
+    control: 'BYOK',
+    description: 'Growth/Enterprise tenants use their own LLM provider keys and contracts.',
+    guidanceLines: [
+      { shortName: 'ICO', slug: 'ico-generative-ai', line: 'Controllership: keep the processing chain under your own contracts.' },
+      { shortName: 'FCA', slug: 'fca-ai-approach', line: 'Operational control over data flows within the firm’s documented perimeter.' },
+    ],
+  },
+  {
+    control: 'On-prem / private deployment',
+    description: 'The gateway can run inside the firm’s own environment or VPC.',
+    guidanceLines: [
+      { shortName: 'Judiciary', slug: 'judiciary-ai-guidance', line: 'The guidance distinguishes public tools from systems inside a secure network.' },
+      { shortName: 'FCA', slug: 'fca-ai-approach', line: 'Resilience and control expectations favour infrastructure the firm governs.' },
+    ],
+  },
+  {
+    control: 'SSO & access control',
+    description: 'OIDC/SAML SSO, MFA posture, and role-based access for admin surfaces.',
+    guidanceLines: [
+      { shortName: 'ICO', slug: 'ico-generative-ai', line: 'Security of processing: control who can reach personal data and policy settings.' },
+      { shortName: 'SRA', slug: 'sra-ai-risk-outlook', line: 'The DPP Law fine (April 2025) turned on missing basic access controls like MFA.' },
+    ],
+  },
+]
+
+export const hubFaq = [
+  {
+    question: 'Is there a single UK regulator for AI use in professional firms?',
+    answer:
+      'No. AI use is governed through existing regimes: the ICO for data protection, the SRA and Law Society for solicitors, the Bar Council and BSB for barristers, the FCA for financial services, and the courts through rulings and judicial guidance. This hub maps each source to the technical controls that address it.',
+  },
+  {
+    question: 'Do these rules apply to a small firm without a security team?',
+    answer:
+      'Yes. Confidentiality, data protection, and accountability expectations apply at every firm size — none of the guidance carves out small firms. The practical difference is that small firms need controls that install in minutes rather than enterprise deployment projects.',
+  },
+  {
+    question: 'Has anyone actually been sanctioned for pasting client data into AI?',
+    answer:
+      'The Upper Tribunal in Munir v SSHD ([2026] UKUT 81) accepted that a legal representative pasting Home Office letters into ChatGPT was a data breach, with self-reporting to regulators. There is not yet an ICO fine specifically for AI prompt leakage — the first law-firm fine (DPP Law, April 2025) was for basic security failures.',
+  },
+  {
+    question: 'What is the fastest way to assess our exposure?',
+    answer:
+      'Work through the AI Confidentiality Checklist on this page — usage discovery, data exposure, policy, technical controls, audit evidence, and incident readiness in about 20 minutes. It is not a compliance assessment; it is a structured way to find the gaps.',
+  },
+] as const

--- a/app/compliance/data-use-and-access-act/page.tsx
+++ b/app/compliance/data-use-and-access-act/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import GuidancePage from '../GuidancePage'
+import { guidanceEntries } from '../content'
+import { siteConfig } from '../../site'
+
+const entry = guidanceEntries.find((item) => item.slug === 'data-use-and-access-act')!
+
+export const metadata: Metadata = {
+  title: "DUAA 2025: The Law That Actually Governs Your AI Use",
+  description: "No UK AI Act exists - the Data (Use and Access) Act 2025 amends the data protection rules that govern AI use, with main provisions in force since February 2026.",
+  alternates: {
+    canonical: '/compliance/data-use-and-access-act',
+  },
+  openGraph: {
+    title: "DUAA 2025: The Law That Actually Governs Your AI Use",
+    description: "No UK AI Act exists - the Data (Use and Access) Act 2025 amends the data protection rules that govern AI use, with main provisions in force since February 2026.",
+    url: `${siteConfig.url}/compliance/data-use-and-access-act`,
+  },
+}
+
+export default function DataUseAndAccessActPage() {
+  return <GuidancePage entry={entry} />
+}

--- a/app/compliance/fca-ai-approach/page.tsx
+++ b/app/compliance/fca-ai-approach/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import GuidancePage from '../GuidancePage'
+import { guidanceEntries } from '../content'
+import { siteConfig } from '../../site'
+
+const entry = guidanceEntries.find((item) => item.slug === 'fca-ai-approach')!
+
+export const metadata: Metadata = {
+  title: "The FCA's AI Approach: Existing Rules Apply",
+  description: "The FCA plans no AI-specific rulebook: Consumer Duty and SM&CR already cover AI use, and accountability sits with named senior managers.",
+  alternates: {
+    canonical: '/compliance/fca-ai-approach',
+  },
+  openGraph: {
+    title: "The FCA's AI Approach: Existing Rules Apply",
+    description: "The FCA plans no AI-specific rulebook: Consumer Duty and SM&CR already cover AI use, and accountability sits with named senior managers.",
+    url: `${siteConfig.url}/compliance/fca-ai-approach`,
+  },
+}
+
+export default function FcaAiApproachPage() {
+  return <GuidancePage entry={entry} />
+}

--- a/app/compliance/ico-generative-ai/page.tsx
+++ b/app/compliance/ico-generative-ai/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import GuidancePage from '../GuidancePage'
+import { guidanceEntries } from '../content'
+import { siteConfig } from '../../site'
+
+const entry = guidanceEntries.find((item) => item.slug === 'ico-generative-ai')!
+
+export const metadata: Metadata = {
+  title: "The ICO on Generative AI and Personal Data",
+  description: "The ICO's consultation response and AI strategy: UK GDPR applies to AI prompts today, with a statutory AI code in development.",
+  alternates: {
+    canonical: '/compliance/ico-generative-ai',
+  },
+  openGraph: {
+    title: "The ICO on Generative AI and Personal Data",
+    description: "The ICO's consultation response and AI strategy: UK GDPR applies to AI prompts today, with a statutory AI code in development.",
+    url: `${siteConfig.url}/compliance/ico-generative-ai`,
+  },
+}
+
+export default function IcoGenerativeAiPage() {
+  return <GuidancePage entry={entry} />
+}

--- a/app/compliance/judiciary-ai-guidance/page.tsx
+++ b/app/compliance/judiciary-ai-guidance/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import GuidancePage from '../GuidancePage'
+import { guidanceEntries } from '../content'
+import { siteConfig } from '../../site'
+
+const entry = guidanceEntries.find((item) => item.slug === 'judiciary-ai-guidance')!
+
+export const metadata: Metadata = {
+  title: "Judiciary AI Guidance: Published to All the World",
+  description: "The judiciary's AI guidance treats anything entered into a public AI chatbot as published to all the world - the clearest line in UK legal AI.",
+  alternates: {
+    canonical: '/compliance/judiciary-ai-guidance',
+  },
+  openGraph: {
+    title: "Judiciary AI Guidance: Published to All the World",
+    description: "The judiciary's AI guidance treats anything entered into a public AI chatbot as published to all the world - the clearest line in UK legal AI.",
+    url: `${siteConfig.url}/compliance/judiciary-ai-guidance`,
+  },
+}
+
+export default function JudiciaryAiGuidancePage() {
+  return <GuidancePage entry={entry} />
+}

--- a/app/compliance/law-society-generative-ai/page.tsx
+++ b/app/compliance/law-society-generative-ai/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import GuidancePage from '../GuidancePage'
+import { guidanceEntries } from '../content'
+import { siteConfig } from '../../site'
+
+const entry = guidanceEntries.find((item) => item.slug === 'law-society-generative-ai')!
+
+export const metadata: Metadata = {
+  title: "Law Society Generative AI Guidance for Law Firms",
+  description: "What the Law Society's 'Generative AI - the essentials' guide says about client data and public AI tools, and how firms can meet it with technical controls.",
+  alternates: {
+    canonical: '/compliance/law-society-generative-ai',
+  },
+  openGraph: {
+    title: "Law Society Generative AI Guidance for Law Firms",
+    description: "What the Law Society's 'Generative AI - the essentials' guide says about client data and public AI tools, and how firms can meet it with technical controls.",
+    url: `${siteConfig.url}/compliance/law-society-generative-ai`,
+  },
+}
+
+export default function LawSocietyGenerativeAiPage() {
+  return <GuidancePage entry={entry} />
+}

--- a/app/compliance/page.tsx
+++ b/app/compliance/page.tsx
@@ -1,0 +1,213 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, BookOpenCheck, ClipboardCheck, Map, ShieldCheck } from 'lucide-react'
+import { siteConfig, contactLinks } from '../site'
+import { guidanceEntries, hubFaq } from './content'
+import ChecklistLeadForm from './ChecklistLeadForm'
+
+export const metadata: Metadata = {
+  title: 'UK AI Compliance Hub — What Regulators Say About AI and Client Data',
+  description:
+    'What the Law Society, SRA, Bar Council, judiciary, ICO, DUAA 2025, and FCA actually say about AI and confidential data — mapped to practical technical controls.',
+  keywords: [
+    'UK AI compliance',
+    'law firm AI guidance',
+    'Law Society generative AI',
+    'SRA AI guidance',
+    'ICO generative AI',
+    'DUAA 2025',
+    'FCA AI approach',
+  ],
+  alternates: {
+    canonical: '/compliance',
+  },
+  openGraph: {
+    title: 'UK AI Compliance Hub',
+    description:
+      'Every major UK source of AI guidance for regulated firms, summarised with verbatim lines and mapped to technical controls.',
+    url: `${siteConfig.url}/compliance`,
+  },
+}
+
+// Static, developer-authored JSON-LD only (no user input). The < escape keeps
+// any literal "<" in content from terminating the script tag (XSS hardening).
+function toJsonLd(data: object): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c')
+}
+
+const faqStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: hubFaq.map((item) => ({
+    '@type': 'Question',
+    name: item.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: item.answer,
+    },
+  })),
+}
+
+export default function ComplianceHubPage() {
+  return (
+    <main className="min-h-screen pt-24">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: toJsonLd(faqStructuredData) }} />
+
+      <section className="relative overflow-hidden py-20 md:py-24">
+        <div className="absolute inset-0 grid-bg opacity-30" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(6,182,212,0.18),transparent_30%),radial-gradient(circle_at_bottom_right,rgba(249,115,22,0.16),transparent_26%)]" />
+
+        <div className="container-custom relative z-10">
+          <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
+            <BookOpenCheck className="h-3.5 w-3.5" />
+            UK compliance hub
+          </div>
+          <h1 className="mt-5 max-w-4xl font-heading text-5xl font-bold md:text-7xl">
+            The regulators have already written the rules for AI and client data
+          </h1>
+          <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-300">
+            There is no single UK AI Act — instead, the Law Society, SRA, Bar Council, the judiciary, the ICO, the Data
+            (Use and Access) Act 2025, and the FCA each set expectations for how regulated teams use AI with
+            confidential data. This hub summarises each source with verbatim lines, links to the originals, and maps
+            every expectation to a practical technical control. Each page carries the date it was last reviewed.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <a href="#guidance" className="btn btn-cta w-full px-8 py-4 text-base sm:w-auto">
+              Browse the guidance
+              <ArrowRight className="h-5 w-5" />
+            </a>
+            <Link href="/compliance/uk-guidance-map" className="btn btn-secondary w-full px-8 py-4 text-base sm:w-auto">
+              <Map className="h-5 w-5" />
+              Open the guidance map
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section id="guidance" className="section">
+        <div className="container-custom">
+          <h2 className="font-heading text-3xl font-bold md:text-5xl">The seven sources that matter</h2>
+          <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-300 md:text-base">
+            Each page: what the guidance says (verbatim), what it means for your firm, and how it maps to technical
+            controls.
+          </p>
+
+          <div className="mt-10 grid gap-4 md:grid-cols-2">
+            {guidanceEntries.map((entry) => (
+              <Link
+                key={entry.slug}
+                href={`/compliance/${entry.slug}`}
+                className="group rounded-[24px] border border-white/10 bg-background/80 p-6 transition hover:border-primary/40 hover:bg-primary/[0.06]"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">{entry.shortName}</p>
+                  <span className="text-xs text-slate-500">
+                    {entry.lastUpdated ? `Updated ${entry.lastUpdated}` : `Published ${entry.firstPublished}`}
+                  </span>
+                </div>
+                <h3 className="mt-3 font-heading text-xl font-semibold text-white group-hover:text-primary-light">
+                  {entry.title}
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-slate-400">{entry.oneLineSummary}</p>
+                <span className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-primary-light">
+                  Read the summary
+                  <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
+                </span>
+              </Link>
+            ))}
+
+            <Link
+              href="/compliance/uk-guidance-map"
+              className="group rounded-[24px] border border-primary/25 bg-primary/10 p-6 transition hover:border-primary/50"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Cross-regulator</p>
+                <Map className="h-4 w-4 text-primary-light" />
+              </div>
+              <h3 className="mt-3 font-heading text-xl font-semibold text-white">UK guidance map</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                One table: every NeutralAI control mapped to the guidance lines it addresses, across all seven sources.
+              </p>
+              <span className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-primary-light">
+                Open the map
+                <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
+              </span>
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section id="checklist" className="section">
+        <div className="container-custom">
+          <div className="rounded-[32px] border border-primary/20 bg-[linear-gradient(180deg,rgba(15,23,42,0.95),rgba(2,6,23,0.97)),radial-gradient(circle_at_top_right,rgba(34,211,238,0.18),transparent_24%)] px-6 py-10 md:px-10">
+            <div className="grid gap-10 lg:grid-cols-[1fr_0.85fr] lg:items-center">
+              <div>
+                <div className="inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
+                  <ClipboardCheck className="h-3.5 w-3.5" />
+                  Free checklist
+                </div>
+                <h2 className="mt-4 font-heading text-3xl font-bold md:text-5xl">
+                  AI Confidentiality Checklist for Law Firms
+                </h2>
+                <p className="mt-5 max-w-2xl text-sm leading-7 text-slate-300 md:text-base">
+                  Thirty practical questions across usage discovery, client-data exposure, policy, technical controls,
+                  audit evidence, and incident readiness — with a scoring guide. Built for partners, COLPs, DPOs, and
+                  IT leads who need a structured 20-minute review, not a compliance lecture.
+                </p>
+                <p className="mt-4 text-xs leading-6 text-slate-500">
+                  Not legal advice; the checklist is a practical starting point for reviewing AI confidentiality risk.
+                </p>
+              </div>
+              <div className="rounded-[24px] border border-white/12 bg-background/85 p-6">
+                <ChecklistLeadForm />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container-custom max-w-4xl">
+          <h2 className="font-heading text-3xl font-bold md:text-5xl">Common questions</h2>
+          <div className="mt-8 space-y-4">
+            {hubFaq.map((item) => (
+              <div key={item.question} className="rounded-2xl border border-white/10 bg-background/80 p-6">
+                <h3 className="font-heading text-lg font-semibold text-white">{item.question}</h3>
+                <p className="mt-2 text-sm leading-7 text-slate-300">{item.answer}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-12 rounded-[24px] border border-white/10 bg-white/[0.04] p-6">
+            <div className="flex items-start gap-4">
+              <ShieldCheck className="mt-1 h-6 w-6 flex-shrink-0 text-primary-light" />
+              <div>
+                <h3 className="font-heading text-xl font-semibold text-white">
+                  Want to see the controls behind the mapping?
+                </h3>
+                <p className="mt-2 text-sm leading-7 text-slate-300">
+                  NeutralAI masks client-identifiable data in prompts and uploads before they reach AI tools, keeps a
+                  reversible vault with a 15-minute TTL, and logs audit-friendly evidence of every control. See the
+                  published accuracy benchmark, or bring one low-risk workflow to a 20-minute review.
+                </p>
+                <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+                  <Link href="/benchmark" className="btn btn-secondary px-6 py-3 text-sm">
+                    View the benchmark
+                  </Link>
+                  <Link href={contactLinks.demo} className="btn btn-cta px-6 py-3 text-sm">
+                    Book a risk review
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <p className="mt-8 text-xs leading-6 text-slate-500">
+            This hub summarises third-party guidance for convenience and is not legal advice. Sources are linked on
+            every page — read the originals before relying on them. Last reviewed: 17 July 2026.
+          </p>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/compliance/sra-ai-risk-outlook/page.tsx
+++ b/app/compliance/sra-ai-risk-outlook/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import GuidancePage from '../GuidancePage'
+import { guidanceEntries } from '../content'
+import { siteConfig } from '../../site'
+
+const entry = guidanceEntries.find((item) => item.slug === 'sra-ai-risk-outlook')!
+
+export const metadata: Metadata = {
+  title: "SRA AI Risk Outlook, Explained",
+  description: "What the SRA's Risk Outlook report on AI in the legal market actually says: adoption is expected, the risk is adopting without controls.",
+  alternates: {
+    canonical: '/compliance/sra-ai-risk-outlook',
+  },
+  openGraph: {
+    title: "SRA AI Risk Outlook, Explained",
+    description: "What the SRA's Risk Outlook report on AI in the legal market actually says: adoption is expected, the risk is adopting without controls.",
+    url: `${siteConfig.url}/compliance/sra-ai-risk-outlook`,
+  },
+}
+
+export default function SraAiRiskOutlookPage() {
+  return <GuidancePage entry={entry} />
+}

--- a/app/compliance/uk-guidance-map/page.tsx
+++ b/app/compliance/uk-guidance-map/page.tsx
@@ -1,0 +1,94 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft, ArrowRight, Map } from 'lucide-react'
+import { siteConfig, contactLinks } from '../../site'
+import { controlMapRows } from '../content'
+
+export const metadata: Metadata = {
+  title: 'UK AI Guidance Map — Controls Mapped to Regulator Expectations',
+  description:
+    'One table mapping NeutralAI controls — mask-before-send, reversible vault, audit trail, whitelist, BYOK, on-prem, SSO — to Law Society, SRA, Bar Council, judiciary, ICO, DUAA, and FCA guidance.',
+  alternates: {
+    canonical: '/compliance/uk-guidance-map',
+  },
+  openGraph: {
+    title: 'UK AI Guidance Map',
+    description: 'Every NeutralAI control mapped to the UK guidance lines it addresses.',
+    url: `${siteConfig.url}/compliance/uk-guidance-map`,
+  },
+}
+
+export default function UkGuidanceMapPage() {
+  return (
+    <main className="min-h-screen pt-24">
+      <section className="section">
+        <div className="container-custom">
+          <Link
+            href="/compliance"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-primary-light hover:text-primary"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            UK compliance hub
+          </Link>
+
+          <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
+            <Map className="h-3.5 w-3.5" />
+            Cross-regulator map
+          </div>
+          <h1 className="mt-5 max-w-4xl font-heading text-4xl font-bold md:text-6xl">
+            Seven controls, seven sources of guidance — one map
+          </h1>
+          <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-300">
+            UK guidance on AI and confidential data converges on a small set of expectations: keep identifiable data
+            out of public tools, minimise what providers receive, stay accountable, and keep evidence. This table maps
+            each NeutralAI control to the guidance lines it addresses. Lines are paraphrased for brevity — the verbatim
+            quotes and source links live on each guidance page.
+          </p>
+
+          <div className="mt-12 space-y-6">
+            {controlMapRows.map((row) => (
+              <div key={row.control} className="overflow-hidden rounded-[24px] border border-white/10 bg-background/80">
+                <div className="border-b border-white/10 bg-white/[0.04] px-6 py-5">
+                  <h2 className="font-heading text-xl font-semibold text-white">{row.control}</h2>
+                  <p className="mt-1 text-sm leading-6 text-slate-400">{row.description}</p>
+                </div>
+                <div>
+                  {row.guidanceLines.map((line) => (
+                    <Link
+                      key={`${row.control}-${line.shortName}`}
+                      href={`/compliance/${line.slug}`}
+                      className="group grid border-b border-white/10 transition last:border-b-0 hover:bg-primary/[0.05] md:grid-cols-[0.22fr_1fr_auto]"
+                    >
+                      <div className="px-6 py-4 font-mono text-xs uppercase tracking-[0.14em] text-primary-light">
+                        {line.shortName}
+                      </div>
+                      <div className="px-6 py-4 text-sm leading-6 text-slate-300 md:px-0">{line.line}</div>
+                      <div className="hidden items-center px-6 md:flex">
+                        <ArrowRight className="h-4 w-4 text-slate-500 transition group-hover:text-primary-light" />
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-12 rounded-[24px] border border-white/10 bg-white/[0.04] p-5 text-xs leading-6 text-slate-500">
+            This map summarises third-party guidance for convenience and is not legal advice, a compliance guarantee,
+            or a claim of endorsement by any regulator. Read the originals via the source links on each guidance page.
+            Last reviewed: 17 July 2026.
+          </div>
+
+          <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+            <Link href="/compliance#checklist" className="btn btn-cta px-6 py-3 text-sm">
+              Get the AI Confidentiality Checklist
+            </Link>
+            <Link href={contactLinks.demo} className="btn btn-secondary px-6 py-3 text-sm">
+              Book a 20-minute risk review
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -37,6 +37,7 @@ const legalLinks = [
   { label: 'Terms of Service', href: '/terms' },
   { label: 'Security', href: '/security' },
   { label: 'Trust Center', href: '/trust-center' },
+  { label: 'UK Compliance Hub', href: '/compliance' },
   { label: 'About', href: '/about' },
 ] as const
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -11,6 +11,16 @@ const routes = [
   '/pricing',
   '/blog',
   '/compare',
+  // /compliance/checklist is intentionally absent: gated lead-magnet asset (noindex).
+  '/compliance',
+  '/compliance/uk-guidance-map',
+  '/compliance/law-society-generative-ai',
+  '/compliance/sra-ai-risk-outlook',
+  '/compliance/bar-council-generative-ai',
+  '/compliance/judiciary-ai-guidance',
+  '/compliance/ico-generative-ai',
+  '/compliance/data-use-and-access-act',
+  '/compliance/fca-ai-approach',
   '/contact',
   '/demo',
   '/developers',
@@ -34,13 +44,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
     url: `${siteConfig.url}${route}`,
     lastModified: route === '/benchmark'
       ? '2026-07-02'
+      : route.startsWith('/compliance')
+      ? '2026-07-17'
       : route.startsWith('/use-cases')
       ? '2026-05-12'
       : route === '/trust-center' || route === '/presidio-alternative' || route.startsWith('/insights/')
       ? '2026-05-08'
       : '2026-03-29',
     changeFrequency: route === '' ? ('weekly' as const) : ('monthly' as const),
-    priority: route === '' ? 1 : route === '/presidio-alternative' || route === '/benchmark' ? 0.85 : 0.7,
+    priority:
+      route === ''
+        ? 1
+        : route === '/presidio-alternative' || route === '/benchmark' || route === '/compliance'
+        ? 0.85
+        : 0.7,
   }))
 
   const blogRoutes = getAllPosts().map((post) => ({

--- a/app/use-cases/content.ts
+++ b/app/use-cases/content.ts
@@ -39,6 +39,11 @@ const financeFaq = [
       'No. NeutralAI provides a gateway boundary, masking policy, and audit evidence that can support financial services review conversations, but it does not guarantee regulatory approval.',
   },
   {
+    question: 'Are there FCA rules specifically about AI?',
+    answer:
+      'The FCA has said it does not plan AI-specific regulations: existing frameworks — the Consumer Duty, SM&CR, and data and resilience rules — apply to AI use. That makes evidence of controls the practical requirement, since a named senior manager is accountable for AI-driven outcomes.',
+  },
+  {
     question: 'Can financial teams keep enough context for useful AI output?',
     answer:
       'Yes. The gateway can replace sensitive values with placeholders or governed tokens while preserving the surrounding business context needed for summaries, triage, and review.',
@@ -115,7 +120,7 @@ export const financeUseCase: UseCasePageContent = {
   complianceMapping: [
     {
       label: 'FCA and PRA review',
-      body: 'Show where AI prompt traffic is controlled, which values are masked, and what audit-safe metadata proves the control ran.',
+      body: 'The FCA plans no AI-specific rulebook — Consumer Duty and SM&CR apply to AI use as-is, so a named senior manager owns the outcome. Show where AI prompt traffic is controlled, which values are masked, and what audit-safe metadata proves the control ran.',
     },
     {
       label: 'PCI-DSS scoping',

--- a/scripts/accessibility-smoke.mjs
+++ b/scripts/accessibility-smoke.mjs
@@ -41,6 +41,16 @@ const scenarios = [
     contrast: [],
   },
   {
+    name: 'compliance-hub',
+    route: '/compliance/',
+    contrast: [],
+  },
+  {
+    name: 'compliance-guidance',
+    route: '/compliance/judiciary-ai-guidance/',
+    contrast: [],
+  },
+  {
     name: 'playground',
     route: '/playground/',
     contrast: [

--- a/tests/content/landmarks.test.mjs
+++ b/tests/content/landmarks.test.mjs
@@ -30,8 +30,8 @@ function countMainLandmarks(source) {
   return matches ? matches.length : 0
 }
 
-function delegatesToUseCasePage(source) {
-  return source.includes('<UseCasePage ')
+function delegatesToSharedTemplate(source) {
+  return source.includes('<UseCasePage ') || source.includes('<GuidancePage ')
 }
 
 test('root layout delegates main landmark ownership to routes', () => {
@@ -46,6 +46,11 @@ test('root layout delegates main landmark ownership to routes', () => {
 test('shared use-case template owns a single main landmark', () => {
   const source = readFileSync(join(root, 'app/use-cases/UseCasePage.tsx'), 'utf8')
   assert.equal(countMainLandmarks(source), 1, 'UseCasePage should render one <main>')
+})
+
+test('shared guidance template owns a single main landmark', () => {
+  const source = readFileSync(join(root, 'app/compliance/GuidancePage.tsx'), 'utf8')
+  assert.equal(countMainLandmarks(source), 1, 'GuidancePage should render one <main>')
 })
 
 test('custom not-found page owns a single main landmark', () => {
@@ -66,8 +71,8 @@ test('each route page renders one main landmark directly or via shared template'
     }
 
     assert.ok(
-      count === 0 && delegatesToUseCasePage(source),
-      `${pageFile.replace(`${root}/`, '')} should render one <main> directly or delegate to UseCasePage`,
+      count === 0 && delegatesToSharedTemplate(source),
+      `${pageFile.replace(`${root}/`, '')} should render one <main> directly or delegate to a shared template (UseCasePage/GuidancePage)`,
     )
   }
 })


### PR DESCRIPTION
## Problem

Buyers researching "can law firms use ChatGPT with client data" find nothing on our site that maps UK regulator expectations to concrete controls. The 2026-07 growth research showed regulatory content is our highest-leverage citation surface (AI-referred visitors convert ~23x; quotable stats lift citation visibility 32-41%), and the AI Confidentiality Checklist existed as a doc but was not capturing leads. Closes #146.

## What Changed

- **/compliance hub**: seven UK guidance sources summarised with verbatim lines, primary-source links, and "Last reviewed" stamps — Law Society, SRA, Bar Council, Judiciary, ICO, DUAA 2025, FCA
- **/compliance/uk-guidance-map**: one table mapping each NeutralAI control (mask-before-send, reversible vault 15-min TTL, audit trail, whitelist, BYOK, on-prem, SSO) to the guidance lines it addresses
- **7 per-guidance pages** via a shared `GuidancePage` template with FAQPage JSON-LD and ~100-word direct-answer passages (GEO format)
- **Gated lead magnet**: AI Confidentiality Checklist as a noindex asset page behind a lead form (Google Sheets endpoint, attribution + referral fields, `compliance_checklist` analytics events)
- **FCA refresh** on /use-cases/financial-services (no-new-rulebook position + SM&CR accountability FAQ)
- sitemap + footer links; a11y smoke scenarios extended to the new routes; landmarks content test now recognises `GuidancePage` as a shared main-landmark template

**Claims discipline:** every date/quote verified against fetched primary sources on 2026-07-17 via a 7-agent verification pass. Two upstream corrections were caught and landed in the internal claims register: the Law Society guide was first published **Nov 2023** (May 2025 was an update), and the SRA ~75% stat is from the **Nov 2023** Risk Outlook (qualified "reportedly"). No pricing or competitor-price claims anywhere (pre-LTD gate respected).

## Validation

- [x] `npm run build` — all 10 new routes prerender statically
- [x] `npm run lint` — no issues
- [x] `npm run test:content` — landmarks suite green (5/5); 3 unrelated tests are red on main too (verified by stashing; follow-up task filed)
- [x] `npm run test:a11y-smoke` — PASS on all routes including compliance-hub + compliance-guidance