### PR TITLE
Visual refresh for compliance and answers pages

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,35 @@
+# PRODUCT.md — NeutralAI Marketing Website
+
+## Register
+
+Brand (marketing site) — design IS the product here: the site must earn trust for a security product before a single feature is shown.
+
+## What this is
+
+Public marketing site for NeutralAI Gateway: a PII-masking layer for generative AI, aimed at regulated UK teams (law firms first, finance second). It sits between staff and AI tools, masking client-identifiable data before prompts leave the browser, with reversible tokenization and audit evidence.
+
+## Target users
+
+- **Sarah** — COLP/practice manager at a 10–50 person UK law firm. Non-technical, risk-literate, time-poor. Reads: Law Society Gazette, Legal IT Insider.
+- **Priya** — owner of a small DPO/GDPR consultancy (partner channel). Compliance jargon fluent; recommends tools to clients.
+- **Mark** — MSP owner serving law firms. Technical, procurement-aware.
+- Secondary: developers evaluating the API/SDK (/developers, playground).
+
+## Brand personality
+
+Calm engineer in the cockpit: "specs, not hype". Stoic, precise, evidence-led. The voice makes strong claims only when a benchmark, ruling, or primary source backs them — and links it. Trust is the product; drama is the enemy. But calm ≠ flat: the site should feel like a well-lit control room, not a PDF.
+
+## Anti-references (what we must NOT look like)
+
+- Generic SaaS gradient-hero template ("AI-powered platform" slop).
+- Fear-mongering security vendor (red alerts, hacker imagery, FUD).
+- Legal-industry beige (parchment, serif-solemn, stock gavel photos).
+- Wall-of-text compliance PDF — the exact failure mode of content pages: same-size grey text, no hierarchy, nothing to hold the eye.
+
+## Strategic design principles
+
+1. **Evidence as decoration.** The most interesting visual material IS the product material: masked-token transformations (`Sarah Thompson` → `<PERSON_7K9X>`), benchmark numbers, verbatim regulator quotes, dates. Style these as first-class visual objects (big, monospace, colored), not as body text.
+2. **One accent does meaning, one does action.** Cyan = product/trust/interactive identity; orange = conversion CTAs only. Purple sparingly for "intelligence". Never decorative rainbow.
+3. **Readable dark.** Body text ≥16px, slate-200/300 on dark backgrounds (4.5:1 minimum); slate-400/500 reserved for genuinely secondary metadata. If a page feels faint, the greys are wrong.
+4. **Content pages carry the same craft as the homepage.** /compliance, /answers, /blog are the pages AI assistants cite and buyers actually read — they deserve hero treatment, pull-quotes, visual rhythm, not template prose.
+5. **Motion is quiet and purposeful**: reveal, hover-lift, glow on interactive elements; respects prefers-reduced-motion.

--- a/app/answers/AnswerPage.tsx
+++ b/app/answers/AnswerPage.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
-import { ArrowLeft, ArrowRight, CheckCircle2, ExternalLink, HelpCircle } from 'lucide-react'
+import { ArrowLeft, ArrowRight, CheckCircle2, ExternalLink } from 'lucide-react'
+import MaskDemo from '../components/MaskDemo'
 import { contactLinks } from '../site'
 import type { AnswerEntry } from './content'
 
@@ -33,31 +34,49 @@ export default function AnswerPage({ entry }: { entry: AnswerEntry }) {
     <main className="min-h-screen pt-24">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: toJsonLd(faqStructuredData(entry)) }} />
 
-      <section className="section">
-        <div className="container-custom max-w-4xl">
+      <section className="relative overflow-hidden py-14 md:py-16">
+        <div className="absolute inset-0 grid-bg opacity-20" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(6,182,212,0.14),transparent_32%)]" />
+        <div className="container-custom relative z-10 max-w-4xl">
           <Link
             href="/answers"
-            className="inline-flex items-center gap-2 text-sm font-semibold text-primary-light hover:text-primary"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-primary-light transition-colors hover:text-primary"
           >
             <ArrowLeft className="h-4 w-4" />
             All questions
           </Link>
 
-          <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
-            <HelpCircle className="h-3.5 w-3.5" />
-            {entry.category}
+          <div className="mt-6 flex items-center gap-3">
+            <span className="rounded-lg bg-primary/10 px-2.5 py-1 font-mono text-xs font-semibold uppercase tracking-[0.14em] text-primary-light">
+              {entry.category}
+            </span>
+            <span className="font-mono text-xs text-slate-400">Reviewed {entry.lastReviewed}</span>
           </div>
-          <h1 className="mt-5 font-heading text-4xl font-bold md:text-5xl">{entry.question}</h1>
+          <h1 className="mt-5 font-heading text-4xl font-bold [text-wrap:balance] md:text-6xl">{entry.question}</h1>
+        </div>
+      </section>
 
-          <div className="mt-8 rounded-[24px] border border-primary/20 bg-primary/[0.07] p-6">
-            <p className="text-base leading-8 text-slate-200">{entry.directAnswer}</p>
+      <section className="pb-6">
+        <div className="container-custom max-w-4xl">
+          <div className="rounded-2xl border border-primary/25 bg-primary/[0.08] p-7 md:p-9">
+            <span className="font-mono text-xs uppercase tracking-[0.16em] text-primary-light">The short answer</span>
+            <p className="mt-4 text-lg leading-8 text-slate-100 [text-wrap:pretty] md:text-xl md:leading-9">
+              {entry.directAnswer}
+            </p>
           </div>
+        </div>
+      </section>
 
-          {entry.sections.map((section) => (
-            <div key={section.heading}>
-              <h2 className="mt-12 font-heading text-3xl font-bold">{section.heading}</h2>
+      <section className="section">
+        <div className="container-custom max-w-4xl">
+          {entry.sections.map((section, index) => (
+            <div key={section.heading} className={index > 0 ? 'mt-14' : ''}>
+              <h2 className="font-heading text-3xl font-bold [text-wrap:balance] md:text-4xl">{section.heading}</h2>
               {section.paragraphs.map((paragraph) => (
-                <p key={paragraph.slice(0, 40)} className="mt-4 text-sm leading-7 text-slate-300 md:text-base md:leading-8">
+                <p
+                  key={paragraph.slice(0, 40)}
+                  className="mt-5 max-w-[70ch] text-base leading-8 text-slate-200 [text-wrap:pretty]"
+                >
                   {paragraph}
                 </p>
               ))}
@@ -65,80 +84,99 @@ export default function AnswerPage({ entry }: { entry: AnswerEntry }) {
           ))}
 
           {entry.keyPoints && entry.keyPoints.length > 0 && (
-            <>
-              <h2 className="mt-12 font-heading text-3xl font-bold">The short version</h2>
-              <ul className="mt-6 space-y-3">
+            <div className="mt-14 rounded-2xl border border-accent-success/25 bg-accent-success/[0.06] p-7">
+              <h2 className="font-heading text-2xl font-bold text-white">The short version</h2>
+              <ul className="mt-5 space-y-4">
                 {entry.keyPoints.map((point) => (
-                  <li key={point} className="flex items-start gap-3 text-sm leading-7 text-slate-300">
-                    <CheckCircle2 className="mt-1 h-4 w-4 flex-shrink-0 text-primary-light" />
-                    {point}
+                  <li key={point} className="flex items-start gap-3">
+                    <CheckCircle2 className="mt-1 h-5 w-5 flex-shrink-0 text-accent-success" />
+                    <span className="text-base leading-8 text-slate-200">{point}</span>
                   </li>
                 ))}
               </ul>
-            </>
+            </div>
           )}
+        </div>
+      </section>
 
-          <h2 className="mt-12 font-heading text-3xl font-bold">Related questions</h2>
-          <div className="mt-6 space-y-4">
+      <section className="pb-14">
+        <div className="container-custom max-w-4xl">
+          <h2 className="font-heading text-3xl font-bold md:text-4xl">Related questions</h2>
+          <div className="mt-7 space-y-4">
             {entry.faq.map((item) => (
-              <div key={item.question} className="rounded-2xl border border-white/10 bg-background/80 p-5">
-                <h3 className="font-heading text-lg font-semibold text-white">{item.question}</h3>
-                <p className="mt-2 text-sm leading-7 text-slate-300">{item.answer}</p>
+              <div key={item.question} className="rounded-2xl border border-white/10 bg-background-secondary/50 p-6 md:p-7">
+                <h3 className="font-heading text-xl font-semibold text-white">{item.question}</h3>
+                <p className="mt-3 text-base leading-8 text-slate-300">{item.answer}</p>
               </div>
             ))}
           </div>
+        </div>
+      </section>
 
-          {entry.sources && entry.sources.length > 0 && (
-            <div className="mt-12 rounded-[24px] border border-white/10 bg-background/80 p-6">
-              <h2 className="font-heading text-xl font-semibold text-white">Sources</h2>
-              <ul className="mt-4 space-y-2">
+      {entry.sources && entry.sources.length > 0 && (
+        <section className="pb-14">
+          <div className="container-custom max-w-4xl">
+            <div className="rounded-2xl border border-white/10 bg-background-secondary/50 p-6 md:p-7">
+              <h2 className="font-mono text-xs uppercase tracking-[0.16em] text-primary-light">Sources</h2>
+              <ul className="mt-4 grid gap-3 md:grid-cols-2">
                 {entry.sources.map((source) => (
                   <li key={source.url}>
                     <a
                       href={source.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 text-sm font-semibold text-primary-light hover:text-primary"
+                      className="group inline-flex items-start gap-2 text-base font-medium leading-7 text-slate-200 transition-colors hover:text-primary-light"
                     >
+                      <ExternalLink className="mt-1.5 h-4 w-4 flex-shrink-0 text-primary-light" />
                       {source.label}
-                      <ExternalLink className="h-3.5 w-3.5" />
                     </a>
                   </li>
                 ))}
               </ul>
             </div>
-          )}
+          </div>
+        </section>
+      )}
 
-          <div className="mt-10 grid gap-4 md:grid-cols-2">
+      <section className="pb-8">
+        <div className="container-custom max-w-4xl">
+          <div className="grid gap-4 md:grid-cols-2">
             {entry.related.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}
-                className="group rounded-[24px] border border-white/10 bg-background/80 p-5 transition hover:border-primary/40"
+                className="group flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-background-secondary/50 p-5 transition hover:border-primary/40 hover:bg-primary/[0.05]"
               >
-                <p className="text-sm font-semibold text-white group-hover:text-primary-light">{item.label}</p>
-                <span className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-primary-light">
-                  Read more
-                  <ArrowRight className="h-3.5 w-3.5 transition group-hover:translate-x-0.5" />
+                <span className="text-base font-semibold leading-7 text-slate-100 group-hover:text-primary-light">
+                  {item.label}
                 </span>
+                <ArrowRight className="h-4 w-4 flex-shrink-0 text-slate-500 transition group-hover:translate-x-0.5 group-hover:text-primary-light" />
               </Link>
             ))}
           </div>
 
-          <div className="mt-12 rounded-[24px] border border-white/10 bg-white/[0.04] p-5 text-xs leading-6 text-slate-500">
+          <p className="mt-8 text-sm leading-7 text-slate-400">
             This page is general information, not legal advice. Where third-party guidance or law is summarised, read
             the originals via the source links before relying on them. Last reviewed: {entry.lastReviewed}.
-          </div>
+          </p>
+        </div>
+      </section>
 
-          <div className="mt-10 rounded-[24px] border border-primary/20 bg-primary/10 p-6">
-            <h3 className="font-heading text-xl font-semibold text-white">See the control in action</h3>
-            <p className="mt-2 text-sm leading-6 text-slate-300">
-              Paste a sample prompt into the playground and watch identifiable data get masked before it would ever
-              reach an AI provider — or bring one low-risk workflow to a 20-minute review.
+      <section className="pb-20">
+        <div className="container-custom max-w-4xl">
+          <div className="rounded-2xl border border-primary/20 bg-[linear-gradient(180deg,rgba(15,23,42,0.9),rgba(3,7,18,0.95)),radial-gradient(circle_at_top_right,rgba(34,211,238,0.16),transparent_30%)] p-7 md:p-9">
+            <h3 className="font-heading text-2xl font-bold text-white md:text-3xl">This is the control in action</h3>
+            <p className="mt-3 max-w-[65ch] text-base leading-8 text-slate-300">
+              Identifiable data is masked in the browser before the prompt ever leaves — try it yourself with a sample
+              prompt, or bring one low-risk workflow to a 20-minute review.
             </p>
-            <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+            <div className="mt-6">
+              <MaskDemo />
+            </div>
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row">
               <Link href="/playground" className="btn btn-cta px-6 py-3 text-sm">
                 Try the playground
+                <ArrowRight className="h-4 w-4" />
               </Link>
               <Link href={contactLinks.demo} className="btn btn-secondary px-6 py-3 text-sm">
                 Book a risk review

--- a/app/answers/page.tsx
+++ b/app/answers/page.tsx
@@ -55,12 +55,12 @@ export default function AnswersHubPage() {
                     <Link
                       key={entry.slug}
                       href={`/answers/${entry.slug}`}
-                      className="group rounded-[24px] border border-white/10 bg-background/80 p-6 transition hover:border-primary/40 hover:bg-primary/[0.06]"
+                      className="group rounded-2xl border border-white/10 bg-background/80 p-6 transition hover:border-primary/40 hover:bg-primary/[0.06]"
                     >
-                      <h3 className="font-heading text-xl font-semibold text-white group-hover:text-primary-light">
+                      <h3 className="font-heading text-2xl font-semibold leading-snug text-white [text-wrap:balance] group-hover:text-primary-light">
                         {entry.question}
                       </h3>
-                      <p className="mt-2 text-sm leading-6 text-slate-400 line-clamp-3">{entry.directAnswer}</p>
+                      <p className="mt-3 text-base leading-7 text-slate-300 line-clamp-3">{entry.directAnswer}</p>
                       <span className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-primary-light">
                         Read the answer
                         <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
@@ -83,7 +83,7 @@ export default function AnswersHubPage() {
                   <HelpCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-primary-light" />
                   {item.question}
                 </h3>
-                <p className="mt-2 text-sm leading-7 text-slate-300">{item.answer}</p>
+                <p className="mt-3 text-base leading-8 text-slate-300">{item.answer}</p>
               </div>
             ))}
           </div>

--- a/app/compliance/GuidancePage.tsx
+++ b/app/compliance/GuidancePage.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { ArrowLeft, ArrowRight, BookOpenCheck, ExternalLink, ShieldCheck } from 'lucide-react'
+import { ArrowLeft, ArrowRight, ExternalLink, ShieldCheck } from 'lucide-react'
 import { contactLinks } from '../site'
 import type { GuidanceEntry } from './content'
 
@@ -24,6 +24,39 @@ function faqStructuredData(entry: GuidanceEntry) {
   }
 }
 
+function FactBand({ entry }: { entry: GuidanceEntry }) {
+  const facts: { label: string; value: string }[] = [
+    { label: 'Issued by', value: entry.publisher },
+    { label: 'Published', value: entry.firstPublished },
+  ]
+  if (entry.lastUpdated) facts.push({ label: 'Updated', value: entry.lastUpdated })
+  facts.push({ label: 'We reviewed', value: entry.lastReviewed })
+
+  return (
+    <div className="mt-8 overflow-hidden rounded-2xl border border-white/10 bg-background-secondary/60">
+      <dl className="grid grid-cols-2 divide-white/10 max-md:divide-y md:grid-cols-[repeat(4,1fr)_auto] md:divide-x">
+        {facts.map((fact) => (
+          <div key={fact.label} className="px-5 py-4">
+            <dt className="font-mono text-[11px] uppercase tracking-[0.16em] text-primary-light">{fact.label}</dt>
+            <dd className="mt-1.5 text-sm font-semibold leading-5 text-slate-100">{fact.value}</dd>
+          </div>
+        ))}
+        <div className="col-span-2 flex items-center px-5 py-4 md:col-span-1">
+          <a
+            href={entry.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm font-semibold text-primary-light transition-colors hover:text-primary"
+          >
+            Read the original
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        </div>
+      </dl>
+    </div>
+  )
+}
+
 export default function GuidancePage({ entry }: { entry: GuidanceEntry }) {
   return (
     <main className="min-h-screen pt-24">
@@ -32,136 +65,181 @@ export default function GuidancePage({ entry }: { entry: GuidanceEntry }) {
         dangerouslySetInnerHTML={{ __html: toJsonLd(faqStructuredData(entry)) }}
       />
 
-      <section className="section">
-        <div className="container-custom max-w-4xl">
+      <section className="relative overflow-hidden py-14 md:py-16">
+        <div className="absolute inset-0 grid-bg opacity-20" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(6,182,212,0.14),transparent_32%)]" />
+        <div className="container-custom relative z-10 max-w-4xl">
           <Link
             href="/compliance"
-            className="inline-flex items-center gap-2 text-sm font-semibold text-primary-light hover:text-primary"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-primary-light transition-colors hover:text-primary"
           >
             <ArrowLeft className="h-4 w-4" />
             UK compliance hub
           </Link>
 
-          <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-light">
-            <BookOpenCheck className="h-3.5 w-3.5" />
-            {entry.publisher}
-          </div>
-          <h1 className="mt-5 font-heading text-4xl font-bold md:text-5xl">{entry.pageTitle}</h1>
+          <h1 className="mt-6 font-heading text-4xl font-bold [text-wrap:balance] md:text-6xl">{entry.pageTitle}</h1>
+          <p className="mt-4 text-lg leading-8 text-slate-300">{entry.title}</p>
 
-          <div className="mt-5 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-slate-400">
-            <span>
-              Guidance: <span className="text-slate-200">{entry.title}</span>
-            </span>
-            <span>Published {entry.firstPublished}</span>
-            {entry.lastUpdated && <span>Updated {entry.lastUpdated}</span>}
-            <a
-              href={entry.sourceUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 font-semibold text-primary-light hover:text-primary"
-            >
-              Read the original
-              <ExternalLink className="h-3.5 w-3.5" />
-            </a>
-          </div>
+          <FactBand entry={entry} />
+        </div>
+      </section>
 
-          <div className="mt-8 rounded-[24px] border border-primary/20 bg-primary/[0.07] p-6">
-            <p className="text-base leading-8 text-slate-200">{entry.directAnswer}</p>
+      <section className="pb-6">
+        <div className="container-custom max-w-4xl">
+          <div className="rounded-2xl border border-primary/25 bg-primary/[0.08] p-7 md:p-9">
+            <div className="flex items-center gap-3">
+              <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/15">
+                <ShieldCheck className="h-5 w-5 text-primary-light" />
+              </span>
+              <span className="font-mono text-xs uppercase tracking-[0.16em] text-primary-light">In one minute</span>
+            </div>
+            <p className="mt-5 text-lg leading-8 text-slate-100 [text-wrap:pretty] md:text-xl md:leading-9">
+              {entry.directAnswer}
+            </p>
           </div>
+        </div>
+      </section>
 
-          <h2 className="mt-12 font-heading text-3xl font-bold">What the guidance says</h2>
-          <div className="mt-6 space-y-4">
-            {entry.whatItSays.map((item) => (
-              <div key={item.point} className="rounded-2xl border border-white/10 bg-background/80 p-5">
-                <p className="text-sm leading-7 text-slate-200">{item.point}</p>
-                {item.quote && (
-                  <blockquote className="mt-3 border-l-2 border-primary/50 pl-4 text-sm italic leading-7 text-slate-300">
+      <section className="section">
+        <div className="container-custom max-w-4xl">
+          <h2 className="font-heading text-3xl font-bold md:text-4xl">What the guidance says</h2>
+          <div className="mt-8 space-y-10">
+            {entry.whatItSays.map((item) =>
+              item.quote ? (
+                <figure key={item.point} className="relative">
+                  <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute -left-3 -top-8 select-none font-heading text-[7rem] leading-none text-primary/15 md:-left-8"
+                  >
+                    “
+                  </span>
+                  <blockquote className="relative font-heading text-2xl font-semibold leading-snug text-white [text-wrap:balance] md:text-3xl">
                     “{item.quote}”
-                    <span className="mt-1 block text-xs not-italic text-slate-500">— {entry.publisher}</span>
                   </blockquote>
-                )}
-              </div>
-            ))}
+                  <figcaption className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1">
+                    <span className="font-mono text-xs uppercase tracking-[0.14em] text-primary-light">
+                      {entry.publisher}
+                    </span>
+                    <span className="text-base leading-7 text-slate-300">{item.point}</span>
+                  </figcaption>
+                </figure>
+              ) : (
+                <div key={item.point} className="rounded-2xl border border-white/10 bg-background-secondary/50 p-6">
+                  <p className="text-base leading-8 text-slate-200">{item.point}</p>
+                </div>
+              ),
+            )}
           </div>
+        </div>
+      </section>
 
-          <h2 className="mt-12 font-heading text-3xl font-bold">What this means for your firm</h2>
-          <ul className="mt-6 space-y-3">
+      <section className="pb-14">
+        <div className="container-custom max-w-4xl">
+          <h2 className="font-heading text-3xl font-bold md:text-4xl">What this means for your firm</h2>
+          <ul className="mt-7 space-y-5">
             {entry.whatItMeans.map((item) => (
-              <li key={item} className="flex items-start gap-3 text-sm leading-7 text-slate-300">
-                <ShieldCheck className="mt-1 h-4 w-4 flex-shrink-0 text-primary-light" />
-                {item}
+              <li key={item} className="flex items-start gap-4">
+                <span className="mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                  <ShieldCheck className="h-4 w-4 text-primary-light" />
+                </span>
+                <span className="text-base leading-8 text-slate-200">{item}</span>
               </li>
             ))}
           </ul>
+        </div>
+      </section>
 
-          <h2 className="mt-12 font-heading text-3xl font-bold">Mapping the guidance to technical controls</h2>
-          <p className="mt-3 text-sm leading-7 text-slate-400">
-            How each expectation in this guidance maps to a NeutralAI control. The full cross-regulator table lives on
-            the{' '}
+      <section className="pb-14">
+        <div className="container-custom max-w-4xl">
+          <h2 className="font-heading text-3xl font-bold md:text-4xl">Guidance → control, line by line</h2>
+          <p className="mt-3 max-w-2xl text-base leading-7 text-slate-300">
+            How each expectation maps to a NeutralAI control. The full cross-regulator table lives on the{' '}
             <Link href="/compliance/uk-guidance-map" className="font-semibold text-primary-light hover:text-primary">
               UK guidance map
             </Link>
             .
           </p>
-          <div className="mt-6 overflow-hidden rounded-[24px] border border-white/10 bg-background/80">
-            <div className="grid border-b border-white/10 bg-white/[0.04] text-sm font-semibold text-slate-200 md:grid-cols-[1fr_0.7fr_1fr]">
-              <div className="px-5 py-4">Guidance expectation</div>
-              <div className="px-5 py-4">NeutralAI control</div>
-              <div className="px-5 py-4">How it works</div>
-            </div>
-            {entry.controlMapping.map((row) => (
-              <div key={row.expectation} className="grid border-b border-white/10 last:border-b-0 md:grid-cols-[1fr_0.7fr_1fr]">
-                <div className="px-5 py-4 text-sm leading-6 text-slate-300">{row.expectation}</div>
-                <div className="px-5 py-4 text-sm font-semibold leading-6 text-white">{row.control}</div>
-                <div className="px-5 py-4 text-sm leading-6 text-slate-400">{row.how}</div>
+          <div className="mt-7 overflow-hidden rounded-2xl border border-white/10">
+            {entry.controlMapping.map((row, index) => (
+              <div
+                key={row.expectation}
+                className={`grid gap-x-6 gap-y-3 p-6 md:grid-cols-[1fr_1.1fr] ${
+                  index % 2 === 0 ? 'bg-background-secondary/60' : 'bg-background/60'
+                } ${index > 0 ? 'border-t border-white/10' : ''}`}
+              >
+                <div>
+                  <p className="text-base font-medium leading-7 text-slate-100">{row.expectation}</p>
+                </div>
+                <div>
+                  <span className="inline-flex items-center rounded-lg bg-primary/10 px-2.5 py-1 font-mono text-[13px] font-semibold text-primary-light">
+                    {row.control}
+                  </span>
+                  <p className="mt-2.5 text-base leading-7 text-slate-300">{row.how}</p>
+                </div>
               </div>
             ))}
           </div>
+        </div>
+      </section>
 
-          <h2 className="mt-12 font-heading text-3xl font-bold">Common questions</h2>
-          <div className="mt-6 space-y-4">
+      <section className="pb-14">
+        <div className="container-custom max-w-4xl">
+          <h2 className="font-heading text-3xl font-bold md:text-4xl">Common questions</h2>
+          <div className="mt-7 space-y-4">
             {entry.faq.map((item) => (
-              <div key={item.question} className="rounded-2xl border border-white/10 bg-background/80 p-5">
-                <h3 className="font-heading text-lg font-semibold text-white">{item.question}</h3>
-                <p className="mt-2 text-sm leading-7 text-slate-300">{item.answer}</p>
+              <div key={item.question} className="rounded-2xl border border-white/10 bg-background-secondary/50 p-6 md:p-7">
+                <h3 className="font-heading text-xl font-semibold text-white">{item.question}</h3>
+                <p className="mt-3 text-base leading-8 text-slate-300">{item.answer}</p>
               </div>
             ))}
           </div>
 
-          <div className="mt-12 rounded-[24px] border border-white/10 bg-white/[0.04] p-5 text-xs leading-6 text-slate-500">
+          <p className="mt-10 text-sm leading-7 text-slate-400">
             This page summarises third-party guidance for convenience and is not legal advice. Summaries can go stale —
-            always read the original at the source link above before relying on it. Last reviewed:{' '}
-            {entry.lastReviewed}.
-          </div>
+            always read the original at the source link above before relying on it. Last reviewed: {entry.lastReviewed}.
+          </p>
+        </div>
+      </section>
 
-          <div className="mt-10 grid gap-4 md:grid-cols-2">
-            <div className="rounded-[24px] border border-primary/20 bg-primary/10 p-6">
-              <h3 className="font-heading text-xl font-semibold text-white">Review your own AI exposure</h3>
-              <p className="mt-2 text-sm leading-6 text-slate-300">
-                The AI Confidentiality Checklist walks through usage discovery, exposure, policy, controls, and
-                evidence.
-              </p>
-              <Link
-                href="/compliance#checklist"
-                className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-primary-light hover:text-primary"
-              >
-                Get the checklist
-                <ArrowRight className="h-4 w-4" />
-              </Link>
-            </div>
-            <div className="rounded-[24px] border border-white/10 bg-background/80 p-6">
-              <h3 className="font-heading text-xl font-semibold text-white">Talk it through</h3>
-              <p className="mt-2 text-sm leading-6 text-slate-300">
-                Bring one low-risk workflow and we will show where masking and audit evidence fit — 20 minutes, no
-                commitment.
-              </p>
-              <Link
-                href={contactLinks.demo}
-                className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-primary-light hover:text-primary"
-              >
-                Book a risk review
-                <ArrowRight className="h-4 w-4" />
-              </Link>
+      <section className="pb-20">
+        <div className="container-custom max-w-4xl">
+          <div className="rounded-2xl border border-primary/20 bg-[linear-gradient(180deg,rgba(15,23,42,0.9),rgba(3,7,18,0.95)),radial-gradient(circle_at_top_right,rgba(34,211,238,0.16),transparent_30%)] p-7 md:p-9">
+            <div className="grid gap-8 md:grid-cols-[1fr_0.9fr] md:items-center">
+              <div>
+                <h3 className="font-heading text-2xl font-bold text-white md:text-3xl">
+                  See what this control looks like in practice
+                </h3>
+                <p className="mt-3 text-base leading-8 text-slate-300">
+                  The AI Confidentiality Checklist walks through usage discovery, exposure, policy, controls, and
+                  evidence in about 20 minutes — or bring one low-risk workflow to a live review.
+                </p>
+                <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+                  <Link href="/compliance#checklist" className="btn btn-cta px-6 py-3 text-sm">
+                    Get the checklist
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                  <Link href={contactLinks.demo} className="btn btn-secondary px-6 py-3 text-sm">
+                    Book a risk review
+                  </Link>
+                </div>
+              </div>
+              <div className="max-md:order-first">
+                <div className="rounded-2xl border border-white/10 bg-background/80 p-4">
+                  <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-slate-400">The control</p>
+                  <p className="mt-3 font-mono text-sm leading-7 text-slate-200">
+                    <span className="text-slate-400">detect →</span>{' '}
+                    <span className="rounded bg-primary/15 px-1.5 py-0.5 font-semibold text-primary-light">mask</span>{' '}
+                    <span className="text-slate-400">→ send →</span>{' '}
+                    <span className="rounded bg-accent-success/15 px-1.5 py-0.5 font-semibold text-accent-success">
+                      restore
+                    </span>
+                    <span className="text-slate-400"> → audit</span>
+                  </p>
+                  <p className="mt-3 text-sm leading-6 text-slate-400">
+                    Reversible vault, 15-minute TTL. The model only ever sees placeholders.
+                  </p>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/app/compliance/checklist/page.tsx
+++ b/app/compliance/checklist/page.tsx
@@ -138,10 +138,10 @@ export default function ComplianceChecklistPage() {
             {sections.map((section) => (
               <div key={section.title} className="rounded-[24px] border border-white/10 bg-background/80 p-6 md:p-8">
                 <h2 className="font-heading text-2xl font-semibold text-white">{section.title}</h2>
-                <p className="mt-2 text-sm leading-6 text-slate-400">{section.intro}</p>
+                <p className="mt-2 text-base leading-7 text-slate-300">{section.intro}</p>
                 <ul className="mt-5 space-y-3">
                   {section.questions.map((question) => (
-                    <li key={question} className="flex items-start gap-3 text-sm leading-6 text-slate-200">
+                    <li key={question} className="flex items-start gap-3 text-base leading-7 text-slate-200">
                       <span
                         aria-hidden="true"
                         className="mt-1 h-4 w-4 flex-shrink-0 rounded border border-white/25 bg-white/5"

--- a/app/compliance/content.ts
+++ b/app/compliance/content.ts
@@ -331,7 +331,7 @@ export const guidanceEntries: GuidanceEntry[] = [
     pageTitle: 'The ICO’s position on generative AI and personal data',
     title: 'Response to the consultation series on generative AI',
     firstPublished: '12 December 2024',
-    lastUpdated: 'March 2026 (strategy update)',
+    lastUpdated: 'March 2026',
     sourceUrl:
       'https://ico.org.uk/about-the-ico/what-we-do/our-work-on-artificial-intelligence/response-to-the-consultation-series-on-generative-ai/',
     lastReviewed: LAST_REVIEWED,
@@ -406,7 +406,7 @@ export const guidanceEntries: GuidanceEntry[] = [
     pageTitle: 'No UK AI Act — so what actually binds you? The DUAA, explained',
     title: 'Data (Use and Access) Act 2025 (c. 18)',
     firstPublished: '19 June 2025 (Royal Assent)',
-    lastUpdated: 'Main data-protection provisions in force 5 February 2026',
+    lastUpdated: '5 February 2026 (main provisions in force)',
     sourceUrl: 'https://www.legislation.gov.uk/ukpga/2025/18',
     lastReviewed: LAST_REVIEWED,
     oneLineSummary:

--- a/app/compliance/page.tsx
+++ b/app/compliance/page.tsx
@@ -48,6 +48,13 @@ const faqStructuredData = {
   })),
 }
 
+function monogram(shortName: string): string {
+  if (shortName.replace(/[^A-Za-z]/g, '').length <= 4) return shortName.split(' ')[0].toUpperCase()
+  const words = shortName.split(' ').filter(Boolean)
+  if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase()
+  return shortName.slice(0, 3).toUpperCase()
+}
+
 export default function ComplianceHubPage() {
   return (
     <main className="min-h-screen pt-24">
@@ -97,18 +104,20 @@ export default function ComplianceHubPage() {
               <Link
                 key={entry.slug}
                 href={`/compliance/${entry.slug}`}
-                className="group rounded-[24px] border border-white/10 bg-background/80 p-6 transition hover:border-primary/40 hover:bg-primary/[0.06]"
+                className="group rounded-2xl border border-white/10 bg-background/80 p-6 transition hover:border-primary/40 hover:bg-primary/[0.06]"
               >
-                <div className="flex items-center justify-between gap-3">
-                  <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">{entry.shortName}</p>
-                  <span className="text-xs text-slate-500">
-                    {entry.lastUpdated ? `Updated ${entry.lastUpdated}` : `Published ${entry.firstPublished}`}
+                <div className="flex items-start justify-between gap-3">
+                  <span className="flex h-12 min-w-12 items-center justify-center rounded-xl border border-primary/25 bg-primary/10 px-2 font-mono text-sm font-bold tracking-wide text-primary-light">
+                    {monogram(entry.shortName)}
+                  </span>
+                  <span className="rounded-md bg-white/5 px-2 py-1 font-mono text-[11px] text-slate-300">
+                    {entry.lastUpdated ? `Updated ${entry.lastUpdated}` : entry.firstPublished}
                   </span>
                 </div>
-                <h3 className="mt-3 font-heading text-xl font-semibold text-white group-hover:text-primary-light">
+                <h3 className="mt-4 font-heading text-xl font-semibold leading-snug text-white group-hover:text-primary-light">
                   {entry.title}
                 </h3>
-                <p className="mt-2 text-sm leading-6 text-slate-400">{entry.oneLineSummary}</p>
+                <p className="mt-2.5 text-base leading-7 text-slate-300">{entry.oneLineSummary}</p>
                 <span className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-primary-light">
                   Read the summary
                   <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
@@ -118,14 +127,16 @@ export default function ComplianceHubPage() {
 
             <Link
               href="/compliance/uk-guidance-map"
-              className="group rounded-[24px] border border-primary/25 bg-primary/10 p-6 transition hover:border-primary/50"
+              className="group rounded-2xl border border-primary/25 bg-primary/10 p-6 transition hover:border-primary/50"
             >
-              <div className="flex items-center justify-between gap-3">
-                <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Cross-regulator</p>
-                <Map className="h-4 w-4 text-primary-light" />
+              <div className="flex items-start justify-between gap-3">
+                <span className="flex h-12 w-12 items-center justify-center rounded-xl border border-primary/30 bg-primary/15">
+                  <Map className="h-5 w-5 text-primary-light" />
+                </span>
+                <span className="rounded-md bg-white/5 px-2 py-1 font-mono text-[11px] text-slate-300">7 sources</span>
               </div>
-              <h3 className="mt-3 font-heading text-xl font-semibold text-white">UK guidance map</h3>
-              <p className="mt-2 text-sm leading-6 text-slate-300">
+              <h3 className="mt-4 font-heading text-xl font-semibold leading-snug text-white">UK guidance map</h3>
+              <p className="mt-2.5 text-base leading-7 text-slate-200">
                 One table: every NeutralAI control mapped to the guidance lines it addresses, across all seven sources.
               </p>
               <span className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-primary-light">
@@ -173,7 +184,7 @@ export default function ComplianceHubPage() {
             {hubFaq.map((item) => (
               <div key={item.question} className="rounded-2xl border border-white/10 bg-background/80 p-6">
                 <h3 className="font-heading text-lg font-semibold text-white">{item.question}</h3>
-                <p className="mt-2 text-sm leading-7 text-slate-300">{item.answer}</p>
+                <p className="mt-3 text-base leading-8 text-slate-300">{item.answer}</p>
               </div>
             ))}
           </div>

--- a/app/compliance/uk-guidance-map/page.tsx
+++ b/app/compliance/uk-guidance-map/page.tsx
@@ -50,7 +50,7 @@ export default function UkGuidanceMapPage() {
               <div key={row.control} className="overflow-hidden rounded-[24px] border border-white/10 bg-background/80">
                 <div className="border-b border-white/10 bg-white/[0.04] px-6 py-5">
                   <h2 className="font-heading text-xl font-semibold text-white">{row.control}</h2>
-                  <p className="mt-1 text-sm leading-6 text-slate-400">{row.description}</p>
+                  <p className="mt-1.5 text-base leading-7 text-slate-300">{row.description}</p>
                 </div>
                 <div>
                   {row.guidanceLines.map((line) => (
@@ -62,7 +62,7 @@ export default function UkGuidanceMapPage() {
                       <div className="px-6 py-4 font-mono text-xs uppercase tracking-[0.14em] text-primary-light">
                         {line.shortName}
                       </div>
-                      <div className="px-6 py-4 text-sm leading-6 text-slate-300 md:px-0">{line.line}</div>
+                      <div className="px-6 py-4 text-base leading-7 text-slate-200 md:px-0">{line.line}</div>
                       <div className="hidden items-center px-6 md:flex">
                         <ArrowRight className="h-4 w-4 text-slate-500 transition group-hover:text-primary-light" />
                       </div>

--- a/app/components/MaskDemo.tsx
+++ b/app/components/MaskDemo.tsx
@@ -1,0 +1,37 @@
+import { ArrowRight } from 'lucide-react'
+
+// "Evidence as decoration": the product's core transformation rendered as a
+// visual object. Static markup — no runtime cost, safe for static export.
+export default function MaskDemo() {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-primary/25 bg-[#050b18]">
+      <div className="flex items-center justify-between border-b border-white/10 px-4 py-2.5">
+        <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-slate-400">prompt → model</span>
+        <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-accent-success">
+          <span className="h-1.5 w-1.5 rounded-full bg-accent-success" aria-hidden="true" />
+          masked before send
+        </span>
+      </div>
+      <div className="grid gap-0 font-mono text-[13px] leading-6 md:grid-cols-[1fr_auto_1fr]">
+        <div className="px-4 py-4 text-slate-300">
+          <span className="block text-[11px] uppercase tracking-[0.14em] text-slate-500">You type</span>
+          <p className="mt-2">
+            Advise <mark className="rounded bg-white/10 px-1 py-0.5 text-white">Sarah Thompson</mark>, NI{' '}
+            <mark className="rounded bg-white/10 px-1 py-0.5 text-white">AB123456C</mark>, on the settlement offer.
+          </p>
+        </div>
+        <div className="hidden items-center px-1 md:flex" aria-hidden="true">
+          <ArrowRight className="h-4 w-4 text-primary-light" />
+        </div>
+        <div className="border-t border-white/10 px-4 py-4 text-slate-300 md:border-l md:border-t-0">
+          <span className="block text-[11px] uppercase tracking-[0.14em] text-slate-500">The model receives</span>
+          <p className="mt-2">
+            Advise <mark className="rounded bg-primary/15 px-1 py-0.5 font-semibold text-primary-light">&lt;PERSON_7K9X&gt;</mark>,
+            NI <mark className="rounded bg-primary/15 px-1 py-0.5 font-semibold text-primary-light">&lt;NI_8W1R&gt;</mark>, on
+            the settlement offer.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/home/PlanBadges.tsx
+++ b/app/components/home/PlanBadges.tsx
@@ -1,0 +1,36 @@
+import { KeyRound, ShieldCheck } from 'lucide-react'
+
+const BYOK_PLANS = ['Business', 'Enterprise'] as const
+const SSO_PLANS = ['Enterprise'] as const
+const SSO_ROADMAP_PLANS = ['Business'] as const
+
+export default function PlanBadges({ planName }: { planName: string }) {
+  const hasByok = (BYOK_PLANS as readonly string[]).includes(planName)
+  const hasSso = (SSO_PLANS as readonly string[]).includes(planName)
+  const hasSsoRoadmap = (SSO_ROADMAP_PLANS as readonly string[]).includes(planName)
+
+  if (!hasByok && !hasSso && !hasSsoRoadmap) return null
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-2">
+      {hasByok && (
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-400/20 bg-amber-400/10 px-3 py-1 text-xs font-medium text-amber-300">
+          <KeyRound className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+          BYOK available
+        </span>
+      )}
+      {hasSso && (
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/20 bg-violet-400/10 px-3 py-1 text-xs font-medium text-violet-300">
+          <ShieldCheck className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+          SSO required
+        </span>
+      )}
+      {hasSsoRoadmap && (
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/15 bg-violet-400/[0.07] px-3 py-1 text-xs font-medium text-violet-300/70">
+          <ShieldCheck className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+          SSO export path
+        </span>
+      )}
+    </div>
+  )
+}

--- a/app/components/home/PricingComparisonTable.tsx
+++ b/app/components/home/PricingComparisonTable.tsx
@@ -1,0 +1,58 @@
+const comparisonTiers = ['Free', 'Developer', 'Starter', 'Team', 'Business', 'Enterprise'] as const
+
+// Direct process.env reference so the price figures below drop out of the bundle
+// entirely while pricing publication is gated (see app/data/homepage.ts).
+const comparisonRows: ReadonlyArray<readonly [string, string, string, string, string, string, string]> =
+  process.env.NEXT_PUBLIC_SHOW_PRICING === 'true'
+    ? [
+        ['Masking requests', '1k', '10K', '10K', '100K', '500K', 'Custom'],
+        ['Managed AI credit', '£1 trial', 'Bring your own LLM', '£3', '£10', '£25', 'Custom'],
+        ['Provider spend model', 'Managed sandbox', 'BYO LLM (shield-only)', 'Managed eval', 'BYOK recommended', 'BYOK expected', 'Customer-owned'],
+        ['API key management', 'Basic', 'Shield API/SDK only', 'Basic', 'Team', 'Full lifecycle', 'Scoped controls'],
+        ['SSO / SIEM path', 'No', 'No', 'No', 'Roadmap', 'Export path', 'Required'],
+      ]
+    : []
+
+export default function PricingComparisonTable() {
+  return (
+    <>
+      {/* Desktop: full comparison grid */}
+      <div className="mt-8 hidden overflow-hidden rounded-[28px] border border-white/10 bg-white/[0.04] lg:block">
+        <div className="grid grid-cols-7 border-b border-white/10 text-sm text-slate-300">
+          <div className="px-4 py-3 font-semibold text-slate-100">Capability</div>
+          {comparisonTiers.map((tier) => (
+            <div key={tier} className="px-4 py-3 font-semibold text-slate-100">{tier}</div>
+          ))}
+        </div>
+        {comparisonRows.map(([label, ...values]) => (
+          <div key={label} className="grid grid-cols-7 border-b border-white/10 text-sm text-slate-300 last:border-b-0">
+            <div className="px-4 py-3 text-slate-100">{label}</div>
+            {values.map((value, i) => (
+              <div key={comparisonTiers[i]} className="px-4 py-3">{value}</div>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Mobile/tablet: one card per plan, listing all its capabilities — no horizontal scroll */}
+      <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:hidden">
+        {comparisonTiers.map((tier, tierIdx) => (
+          <div key={tier} className="rounded-[24px] border border-white/10 bg-white/[0.04] p-5">
+            <h4 className="font-heading text-base font-semibold text-primary-light">{tier}</h4>
+            <dl className="mt-3 space-y-2">
+              {comparisonRows.map(([label, ...values]) => (
+                <div
+                  key={label}
+                  className="flex items-baseline justify-between gap-4 border-b border-white/5 pb-2 last:border-b-0 last:pb-0"
+                >
+                  <dt className="text-sm text-slate-400">{label}</dt>
+                  <dd className="text-right text-sm font-medium text-slate-200">{values[tierIdx]}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/app/components/home/PricingFaq.tsx
+++ b/app/components/home/PricingFaq.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { ChevronDown } from 'lucide-react'
+import { pricingFaqs } from '../../data/homepage'
+
+function FaqAccordionItem({ question, answer }: { question: string; answer: string }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="rounded-[20px] border border-white/10 bg-background/75">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
+      >
+        <span className="font-heading text-base font-semibold text-slate-100">{question}</span>
+        <ChevronDown
+          className={`h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+          aria-hidden="true"
+        />
+      </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="answer"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            className="overflow-hidden"
+          >
+            <p className="px-5 pb-5 text-sm leading-6 text-slate-400">{answer}</p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}
+
+export default function PricingFaq() {
+  return (
+    <div className="mt-10">
+      <h3 className="font-heading text-2xl font-semibold">Frequently asked questions</h3>
+      <div className="mt-5 grid gap-3 lg:grid-cols-2">
+        {pricingFaqs.map((item) => (
+          <FaqAccordionItem key={item.question} question={item.question} answer={item.answer} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/components/home/PricingSection.tsx
+++ b/app/components/home/PricingSection.tsx
@@ -1,95 +1,14 @@
 'use client'
 
 import { useState } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
-import { CheckCircle2, ChevronDown, KeyRound, ShieldCheck } from 'lucide-react'
-import { advancedPricingPlans, pricingFaqs, primaryPricingPlans } from '../../data/homepage'
+import { motion } from 'framer-motion'
+import { CheckCircle2 } from 'lucide-react'
+import { advancedPricingPlans, primaryPricingPlans } from '../../data/homepage'
 import { contactLinks, siteConfig } from '../../site'
 import SectionIntro from './SectionIntro'
-
-const BYOK_PLANS = ['Business', 'Enterprise'] as const
-const SSO_PLANS = ['Enterprise'] as const
-const SSO_ROADMAP_PLANS = ['Business'] as const
-
-const comparisonTiers = ['Free', 'Developer', 'Starter', 'Team', 'Business', 'Enterprise'] as const
-
-// Direct process.env reference so the price figures below drop out of the bundle
-// entirely while pricing publication is gated (see app/data/homepage.ts).
-const comparisonRows: ReadonlyArray<readonly [string, string, string, string, string, string, string]> =
-  process.env.NEXT_PUBLIC_SHOW_PRICING === 'true'
-    ? [
-        ['Masking requests', '1k', '10K', '10K', '100K', '500K', 'Custom'],
-        ['Managed AI credit', '£1 trial', 'Bring your own LLM', '£3', '£10', '£25', 'Custom'],
-        ['Provider spend model', 'Managed sandbox', 'BYO LLM (shield-only)', 'Managed eval', 'BYOK recommended', 'BYOK expected', 'Customer-owned'],
-        ['API key management', 'Basic', 'Shield API/SDK only', 'Basic', 'Team', 'Full lifecycle', 'Scoped controls'],
-        ['SSO / SIEM path', 'No', 'No', 'No', 'Roadmap', 'Export path', 'Required'],
-      ]
-    : []
-
-function PlanBadges({ planName }: { planName: string }) {
-  const hasByok = (BYOK_PLANS as readonly string[]).includes(planName)
-  const hasSso = (SSO_PLANS as readonly string[]).includes(planName)
-  const hasSsoRoadmap = (SSO_ROADMAP_PLANS as readonly string[]).includes(planName)
-
-  if (!hasByok && !hasSso && !hasSsoRoadmap) return null
-
-  return (
-    <div className="mt-3 flex flex-wrap gap-2">
-      {hasByok && (
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-400/20 bg-amber-400/10 px-3 py-1 text-xs font-medium text-amber-300">
-          <KeyRound className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
-          BYOK available
-        </span>
-      )}
-      {hasSso && (
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/20 bg-violet-400/10 px-3 py-1 text-xs font-medium text-violet-300">
-          <ShieldCheck className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
-          SSO required
-        </span>
-      )}
-      {hasSsoRoadmap && (
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/15 bg-violet-400/[0.07] px-3 py-1 text-xs font-medium text-violet-300/70">
-          <ShieldCheck className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
-          SSO export path
-        </span>
-      )}
-    </div>
-  )
-}
-
-function FaqAccordionItem({ question, answer }: { question: string; answer: string }) {
-  const [open, setOpen] = useState(false)
-  return (
-    <div className="rounded-[20px] border border-white/10 bg-background/75">
-      <button
-        type="button"
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-      >
-        <span className="font-heading text-base font-semibold text-slate-100">{question}</span>
-        <ChevronDown
-          className={`h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
-          aria-hidden="true"
-        />
-      </button>
-      <AnimatePresence initial={false}>
-        {open && (
-          <motion.div
-            key="answer"
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.2, ease: 'easeInOut' }}
-            className="overflow-hidden"
-          >
-            <p className="px-5 pb-5 text-sm leading-6 text-slate-400">{answer}</p>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
-  )
-}
+import PlanBadges from './PlanBadges'
+import PricingComparisonTable from './PricingComparisonTable'
+import PricingFaq from './PricingFaq'
 
 export default function PricingSection() {
   const [annualBilling, setAnnualBilling] = useState(false)
@@ -293,52 +212,9 @@ export default function PricingSection() {
           ))}
         </div>
 
-        {/* Desktop: full comparison grid */}
-        <div className="mt-8 hidden overflow-hidden rounded-[28px] border border-white/10 bg-white/[0.04] lg:block">
-          <div className="grid grid-cols-7 border-b border-white/10 text-sm text-slate-300">
-            <div className="px-4 py-3 font-semibold text-slate-100">Capability</div>
-            {comparisonTiers.map((tier) => (
-              <div key={tier} className="px-4 py-3 font-semibold text-slate-100">{tier}</div>
-            ))}
-          </div>
-          {comparisonRows.map(([label, ...values]) => (
-            <div key={label} className="grid grid-cols-7 border-b border-white/10 text-sm text-slate-300 last:border-b-0">
-              <div className="px-4 py-3 text-slate-100">{label}</div>
-              {values.map((value, i) => (
-                <div key={comparisonTiers[i]} className="px-4 py-3">{value}</div>
-              ))}
-            </div>
-          ))}
-        </div>
+        <PricingComparisonTable />
 
-        {/* Mobile/tablet: one card per plan, listing all its capabilities — no horizontal scroll */}
-        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:hidden">
-          {comparisonTiers.map((tier, tierIdx) => (
-            <div key={tier} className="rounded-[24px] border border-white/10 bg-white/[0.04] p-5">
-              <h4 className="font-heading text-base font-semibold text-primary-light">{tier}</h4>
-              <dl className="mt-3 space-y-2">
-                {comparisonRows.map(([label, ...values]) => (
-                  <div
-                    key={label}
-                    className="flex items-baseline justify-between gap-4 border-b border-white/5 pb-2 last:border-b-0 last:pb-0"
-                  >
-                    <dt className="text-sm text-slate-400">{label}</dt>
-                    <dd className="text-right text-sm font-medium text-slate-200">{values[tierIdx]}</dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
-          ))}
-        </div>
-
-        <div className="mt-10">
-          <h3 className="font-heading text-2xl font-semibold">Frequently asked questions</h3>
-          <div className="mt-5 grid gap-3 lg:grid-cols-2">
-            {pricingFaqs.map((item) => (
-              <FaqAccordionItem key={item.question} question={item.question} answer={item.answer} />
-            ))}
-          </div>
-        </div>
+        <PricingFaq />
       </div>
     </section>
   )

--- a/app/components/home/ProductVisual.tsx
+++ b/app/components/home/ProductVisual.tsx
@@ -1,123 +1,26 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { motion, useReducedMotion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { ShieldCheck, FileCheck2 } from 'lucide-react'
-import {
-  rawPromptCharCount,
-  rawPromptLines,
-  renderPromptLines,
-  sanitizedPromptCharCount,
-  sanitizedPromptLines,
-} from './promptAnimation'
-
-type Phase = 'typingRaw' | 'highlightRaw' | 'sending' | 'typingSanitized' | 'audit' | 'pauseSanitized'
+import { rawPromptLines, renderPromptLines, sanitizedPromptLines } from './promptAnimation'
+import { useProductVisualPhase } from './useProductVisualPhase'
 
 export default function ProductVisual() {
-  const [phase, setPhase] = useState<Phase>('typingRaw')
-  const [rawTypedChars, setRawTypedChars] = useState(0)
-  const [sanitizedTypedChars, setSanitizedTypedChars] = useState(0)
-  const shouldReduceMotion = useReducedMotion()
-  const phaseOrder = ['Detect', 'Mask', 'Route', 'Audit'] as const
-
-  useEffect(() => {
-    if (shouldReduceMotion) {
-      return
-    }
-
-    const typingSpeedMs = 34
-    let timer: ReturnType<typeof setTimeout> | undefined
-
-    if (phase === 'typingRaw') {
-      if (rawTypedChars < rawPromptCharCount) {
-        timer = setTimeout(() => {
-          setRawTypedChars((current) => current + 1)
-        }, typingSpeedMs)
-      } else {
-        timer = setTimeout(() => {
-          setPhase('highlightRaw')
-        }, 550)
-      }
-    }
-
-    if (phase === 'highlightRaw') {
-      timer = setTimeout(() => {
-        setPhase('sending')
-      }, 650)
-    }
-
-    if (phase === 'sending') {
-      timer = setTimeout(() => {
-        setPhase('typingSanitized')
-      }, 1550)
-    }
-
-    if (phase === 'typingSanitized') {
-      if (sanitizedTypedChars < sanitizedPromptCharCount) {
-        timer = setTimeout(() => {
-          setSanitizedTypedChars((current) => current + 1)
-        }, typingSpeedMs)
-      } else {
-        timer = setTimeout(() => {
-          setPhase('audit')
-        }, 700)
-      }
-    }
-
-    if (phase === 'audit') {
-      timer = setTimeout(() => {
-        setPhase('pauseSanitized')
-      }, 1700)
-    }
-
-    if (phase === 'pauseSanitized') {
-      timer = setTimeout(() => {
-        setRawTypedChars(0)
-        setSanitizedTypedChars(0)
-        setPhase('typingRaw')
-      }, 1100)
-    }
-
-    return () => {
-      if (timer) {
-        clearTimeout(timer)
-      }
-    }
-  }, [phase, rawTypedChars, sanitizedTypedChars, shouldReduceMotion])
-
-  const displayPhase = shouldReduceMotion ? 'pauseSanitized' : phase
-  const displayRawTypedChars = shouldReduceMotion ? rawPromptCharCount : rawTypedChars
-  const displaySanitizedTypedChars = shouldReduceMotion
-    ? sanitizedPromptCharCount
-    : sanitizedTypedChars
-  const rawHighlightVisible =
-    shouldReduceMotion || (displayPhase !== 'typingRaw' && displayRawTypedChars === rawPromptCharCount)
-  const showFlights = !shouldReduceMotion && displayPhase === 'sending'
-  const rawPanelActive =
-    !shouldReduceMotion &&
-    (displayPhase === 'typingRaw' || displayPhase === 'highlightRaw' || displayPhase === 'sending')
-  const sanitizedPanelActive =
-    !shouldReduceMotion &&
-    (displayPhase === 'typingSanitized' || displayPhase === 'audit' || displayPhase === 'pauseSanitized')
-  const auditVisible =
-    shouldReduceMotion || displayPhase === 'audit' || displayPhase === 'pauseSanitized'
-  const beamDotAnimate = shouldReduceMotion
-    ? { x: 0, opacity: 0.2 }
-    : showFlights
-      ? { x: ['-64%', '64%'], opacity: [0.35, 1, 0.35] }
-      : { x: '-64%', opacity: 0.2 }
-  const beamDotTransition = shouldReduceMotion
-    ? { duration: 0 }
-    : { duration: 1.1, repeat: showFlights ? Infinity : 0, ease: 'easeInOut' as const }
-  const activePhaseIndex = shouldReduceMotion
-    ? 3
-    : phase === 'typingRaw' || phase === 'highlightRaw'
-      ? 0
-      : phase === 'sending'
-        ? 1
-        : phase === 'typingSanitized'
-          ? 2
-          : 3
+  const {
+    shouldReduceMotion,
+    phaseOrder,
+    activePhaseIndex,
+    displayPhase,
+    displayRawTypedChars,
+    displaySanitizedTypedChars,
+    rawHighlightVisible,
+    showFlights,
+    rawPanelActive,
+    sanitizedPanelActive,
+    auditVisible,
+    beamDotAnimate,
+    beamDotTransition,
+  } = useProductVisualPhase()
 
   return (
     <div className="signal-simple-shell rounded-[28px] p-3 sm:p-4 md:p-6 xl:p-7">

--- a/app/components/home/useProductVisualPhase.ts
+++ b/app/components/home/useProductVisualPhase.ts
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react'
+import { useReducedMotion } from 'framer-motion'
+import { rawPromptCharCount, sanitizedPromptCharCount } from './promptAnimation'
+
+type Phase = 'typingRaw' | 'highlightRaw' | 'sending' | 'typingSanitized' | 'audit' | 'pauseSanitized'
+
+export function useProductVisualPhase() {
+  const [phase, setPhase] = useState<Phase>('typingRaw')
+  const [rawTypedChars, setRawTypedChars] = useState(0)
+  const [sanitizedTypedChars, setSanitizedTypedChars] = useState(0)
+  const shouldReduceMotion = useReducedMotion()
+  const phaseOrder = ['Detect', 'Mask', 'Route', 'Audit'] as const
+
+  useEffect(() => {
+    if (shouldReduceMotion) {
+      return
+    }
+
+    const typingSpeedMs = 34
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    if (phase === 'typingRaw') {
+      if (rawTypedChars < rawPromptCharCount) {
+        timer = setTimeout(() => {
+          setRawTypedChars((current) => current + 1)
+        }, typingSpeedMs)
+      } else {
+        timer = setTimeout(() => {
+          setPhase('highlightRaw')
+        }, 550)
+      }
+    }
+
+    if (phase === 'highlightRaw') {
+      timer = setTimeout(() => {
+        setPhase('sending')
+      }, 650)
+    }
+
+    if (phase === 'sending') {
+      timer = setTimeout(() => {
+        setPhase('typingSanitized')
+      }, 1550)
+    }
+
+    if (phase === 'typingSanitized') {
+      if (sanitizedTypedChars < sanitizedPromptCharCount) {
+        timer = setTimeout(() => {
+          setSanitizedTypedChars((current) => current + 1)
+        }, typingSpeedMs)
+      } else {
+        timer = setTimeout(() => {
+          setPhase('audit')
+        }, 700)
+      }
+    }
+
+    if (phase === 'audit') {
+      timer = setTimeout(() => {
+        setPhase('pauseSanitized')
+      }, 1700)
+    }
+
+    if (phase === 'pauseSanitized') {
+      timer = setTimeout(() => {
+        setRawTypedChars(0)
+        setSanitizedTypedChars(0)
+        setPhase('typingRaw')
+      }, 1100)
+    }
+
+    return () => {
+      if (timer) {
+        clearTimeout(timer)
+      }
+    }
+  }, [phase, rawTypedChars, sanitizedTypedChars, shouldReduceMotion])
+
+  const displayPhase = shouldReduceMotion ? 'pauseSanitized' : phase
+  const displayRawTypedChars = shouldReduceMotion ? rawPromptCharCount : rawTypedChars
+  const displaySanitizedTypedChars = shouldReduceMotion
+    ? sanitizedPromptCharCount
+    : sanitizedTypedChars
+  const rawHighlightVisible =
+    shouldReduceMotion || (displayPhase !== 'typingRaw' && displayRawTypedChars === rawPromptCharCount)
+  const showFlights = !shouldReduceMotion && displayPhase === 'sending'
+  const rawPanelActive =
+    !shouldReduceMotion &&
+    (displayPhase === 'typingRaw' || displayPhase === 'highlightRaw' || displayPhase === 'sending')
+  const sanitizedPanelActive =
+    !shouldReduceMotion &&
+    (displayPhase === 'typingSanitized' || displayPhase === 'audit' || displayPhase === 'pauseSanitized')
+  const auditVisible =
+    shouldReduceMotion || displayPhase === 'audit' || displayPhase === 'pauseSanitized'
+  const beamDotAnimate = shouldReduceMotion
+    ? { x: 0, opacity: 0.2 }
+    : showFlights
+      ? { x: ['-64%', '64%'], opacity: [0.35, 1, 0.35] }
+      : { x: '-64%', opacity: 0.2 }
+  const beamDotTransition = shouldReduceMotion
+    ? { duration: 0 }
+    : { duration: 1.1, repeat: showFlights ? Infinity : 0, ease: 'easeInOut' as const }
+  const activePhaseIndex = shouldReduceMotion
+    ? 3
+    : phase === 'typingRaw' || phase === 'highlightRaw'
+      ? 0
+      : phase === 'sending'
+        ? 1
+        : phase === 'typingSanitized'
+          ? 2
+          : 3
+
+  return {
+    shouldReduceMotion,
+    phaseOrder,
+    activePhaseIndex,
+    displayPhase,
+    displayRawTypedChars,
+    displaySanitizedTypedChars,
+    rawHighlightVisible,
+    showFlights,
+    rawPanelActive,
+    sanitizedPanelActive,
+    auditVisible,
+    beamDotAnimate,
+    beamDotTransition,
+  }
+}

--- a/tests/content/contact-form.test.mjs
+++ b/tests/content/contact-form.test.mjs
@@ -60,7 +60,7 @@ test('contact page keeps secondary email route and routes high-intent form inten
   assert.match(siteSource, /securityReview: '\/contact\?intent=security-review'/)
   assert.match(contactSource, /normalizeIntent/)
   assert.match(leadFormSource, /Lead form endpoint is not configured in this environment yet\./)
-  assert.match(thanksSource, /We&apos;ll get back to you within 1 business day/)
+  assert.match(thanksSource, /We&apos;ll get back to you within 24 hours/)
   assert.match(contactSource, /Prefer email\? Reach us at/)
   assert.match(contactSource, /contactLinks\.salesMailto/)
   assert.match(contactSource, /Other routes/)

--- a/tests/content/conversion-funnel-qa.test.mjs
+++ b/tests/content/conversion-funnel-qa.test.mjs
@@ -40,7 +40,7 @@ test('homepage, pricing, and extension flows emit CTA analytics metadata', () =>
   const pricingSource = readSource('app/components/home/PricingSection.tsx')
   const installSource = readSource('app/install-extension/page.tsx')
 
-  assert.match(heroSource, /data-analytics-event="CTA Click"/)
+  assert.match(heroSource, /data-analytics-event="cta_click"/)
   assert.match(heroSource, /data-analytics-label="Try Free"/)
   assert.match(heroSource, /data-analytics-label="Book Demo"/)
   assert.match(heroSource, /data-analytics-label="Install Browser Extension"/)
@@ -53,7 +53,7 @@ test('homepage, pricing, and extension flows emit CTA analytics metadata', () =>
   assert.match(pricingSource, /data-analytics-label=\{`\$\{plan\.name\} \$\{plan\.cta\}`\}/)
 
   assert.match(installSource, /data-analytics-placement="install_extension_options"/)
-  assert.match(installSource, /data-analytics-event="CTA Click"/)
+  assert.match(installSource, /data-analytics-event="cta_click"/)
   assert.match(installSource, /target="_blank"/)
   assert.match(installSource, /rel="noopener noreferrer"/)
 })


### PR DESCRIPTION
## Problem

User feedback on the new /compliance and /answers pages: visually boring — same font throughout, mostly small faint grey text, no imagery or attention anchors to pull a reader through. Part of #147 quality follow-up.

## What Changed

- **Regulator quotes become the visual centrepiece**: large Space Grotesk pull-quotes with an oversized quote glyph and mono attribution — the verbatim lines are the star content and now look like it
- **Fact band**: the faint one-line meta replaced by a high-contrast, mono-labelled band (Issued by / Published / Updated / We reviewed / Read the original)
- **MaskDemo component**: a before→after masked-prompt strip (`Sarah Thompson` → `<PERSON_7K9X>`) — the product's own transformation used as page imagery on answer CTAs
- **Control mapping** restyled as zebra rows with cyan mono control chips; **key points** as a green-check panel; **hub cards** get regulator monogram tiles and mono date chips
- **Readability**: body copy raised from `text-sm slate-400` to `text-base slate-200/300` across guidance pages, answers, the guidance map, and the checklist
- PRODUCT.md added to anchor future design work

## Validation

- [x] `npm run build` — 73/73 pages prerender
- [x] `npm run lint` — clean
- [x] landmarks content tests — 6/6
- [x] `npm run test:a11y-smoke` — PASS on all scenarios including the redesigned routes (contrast + keyboard)
- [x] Section-level Playwright screenshots reviewed for hero, quotes, mapping, FAQ, CTA, and hub cards