### PR TITLE
fix(extension): drop 'Interceptor' on public pages + add no-harvesting trust attestation

### DIFF
--- a/app/install-extension/page.tsx
+++ b/app/install-extension/page.tsx
@@ -6,7 +6,7 @@ import { extensionLinks, siteConfig } from '../site'
 export const metadata: Metadata = {
   title: 'Install Browser Extension',
   description:
-    'Install NeutralAI Interceptor for Chrome or Edge, or start an enterprise rollout for managed browser deployments.',
+    'Install the NeutralAI browser extension for Chrome or Edge, or start an enterprise rollout for managed browser deployments.',
   alternates: {
     canonical: '/install-extension',
   },
@@ -57,12 +57,12 @@ export default function InstallExtensionPage() {
 
         <div className="container-custom relative z-10">
           <div className="mx-auto max-w-4xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">NeutralAI Interceptor</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">NeutralAI PII Masking</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
               Install the browser extension without guessing the rollout path
             </h1>
             <p className="mt-6 text-xl text-slate-400">
-              NeutralAI Interceptor masks sensitive prompt data before it leaves supported AI web applications. This page is the public install reference for browser store review and managed enterprise rollout.
+              The NeutralAI browser extension masks sensitive prompt data before it leaves supported AI web applications. This page is the public install reference for browser store review and managed enterprise rollout.
             </p>
           </div>
         </div>
@@ -143,7 +143,7 @@ export default function InstallExtensionPage() {
               <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">What the extension does</p>
               <h2 className="mt-4 font-heading text-3xl font-bold">Single-purpose behaviour</h2>
               <p className="mt-4 text-slate-400">
-                NeutralAI Interceptor helps users mask sensitive prompt data before it is submitted from supported AI web applications. It is designed to run on supported AI hosts, call the NeutralAI API boundary, and avoid remotely hosted executable code.
+                The NeutralAI browser extension helps users mask sensitive prompt data before it is submitted from supported AI web applications. It is designed to run on supported AI hosts, call the NeutralAI API boundary, and avoid remotely hosted executable code.
               </p>
               <div className="mt-8 rounded-2xl border border-primary/20 bg-primary/10 p-4 text-sm text-slate-200">
                 <ShieldCheck className="mb-3 h-5 w-5 text-primary-light" />

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -6,7 +6,7 @@ import { extensionLinks, siteConfig } from '../site'
 export const metadata: Metadata = {
   title: 'Privacy Policy',
   description:
-    'Public privacy policy for NeutralAI Interceptor, covering supported hosts, sign-in flow, API flow, and metadata-only telemetry posture.',
+    'Public privacy policy for the NeutralAI browser extension, covering supported hosts, sign-in flow, API flow, and metadata-only telemetry posture.',
   alternates: {
     canonical: '/privacy',
   },
@@ -42,12 +42,12 @@ export default function PrivacyPage() {
 
         <div className="container-custom relative z-10">
           <div className="mx-auto max-w-4xl text-center">
-            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">NeutralAI Interceptor</p>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">NeutralAI PII Masking</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
               Browser extension privacy policy
             </h1>
             <p className="mt-6 text-xl text-slate-400">
-              This privacy page exists for browser store review and public reference. It explains how NeutralAI Interceptor operates on supported AI web apps, what service endpoints it contacts, and what telemetry posture the product is designed to maintain.
+              This privacy page exists for browser store review and public reference. It explains how the NeutralAI browser extension operates on supported AI web apps, what service endpoints it contacts, and what telemetry posture the product is designed to maintain.
             </p>
             <p className="mt-4 text-sm text-slate-400">
               Privacy questions can be sent to{' '}
@@ -69,7 +69,7 @@ export default function PrivacyPage() {
               </div>
               <h2 className="mt-5 font-heading text-3xl font-bold">Supported AI hosts only</h2>
               <p className="mt-4 text-sm leading-6 text-slate-400">
-                NeutralAI Interceptor is intended to run only on supported AI web applications where prompt masking is applied before submission. It does not request broad host access across arbitrary browsing activity.
+                The NeutralAI browser extension is intended to run only on supported AI web applications where prompt masking is applied before submission. It does not request broad host access across arbitrary browsing activity.
               </p>
               <ul className="mt-6 grid gap-3 sm:grid-cols-2">
                 {supportedHosts.map((host) => (

--- a/app/support/browser-extension/page.tsx
+++ b/app/support/browser-extension/page.tsx
@@ -133,8 +133,9 @@ export default function BrowserExtensionSupportPage() {
                 <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Managed mode (signed in)</p>
                 <p className="mt-2 text-sm leading-6 text-slate-400">
                   Prompt text is sent over TLS to the NeutralAI gateway for stronger server-side detection and the masked
-                  result is returned. Reversible mask tokens live in an encrypted vault (AES-256-GCM) with a 15-minute TTL,
-                  then are destroyed. The audit log records the <em>entities masked</em>, not your full prompt text.
+                  result is returned. Reversible mask tokens live in an encrypted vault (AES-256-GCM) with a short TTL
+                  (15 minutes by default), then are destroyed. The audit log records the <em>entities masked</em>, not your
+                  full prompt text.
                 </p>
               </div>
             </div>

--- a/app/support/browser-extension/page.tsx
+++ b/app/support/browser-extension/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { AppWindow, ExternalLink, HardDrive, LockKeyhole, MonitorSmartphone, Radio, Shield } from 'lucide-react'
+import { AppWindow, ExternalLink, HardDrive, LockKeyhole, MonitorSmartphone, Radio, Shield, ShieldCheck } from 'lucide-react'
 import { extensionLinks, siteConfig } from '../../site'
 
 export const metadata: Metadata = {
   title: 'Browser Extension Support',
   description:
-    'Public support reference for NeutralAI Interceptor, including permission rationale, host permission scope, sign-in flow, and enterprise rollout guidance.',
+    'Public support reference for the NeutralAI browser extension, including its no-chat-harvesting attestation, permission rationale, host permission scope, sign-in flow, and enterprise rollout guidance.',
   alternates: {
     canonical: '/support/browser-extension',
   },
@@ -45,6 +45,29 @@ const permissionExplanations = [
   },
 ] as const
 
+const dataHandlingCommitments = [
+  {
+    title: 'No conversation collection',
+    detail:
+      'We do not collect, store, sell or share your conversations. Prompt text is processed to find and mask PII, then discarded.',
+  },
+  {
+    title: 'No browsing-history harvesting',
+    detail:
+      'Content scripts run only on the supported AI chat sites listed in the manifest — nowhere else. The extension has no visibility into the rest of your browsing.',
+  },
+  {
+    title: 'No ads, trackers or affiliate links',
+    detail:
+      'The extension injects nothing into pages beyond the masking behaviour, and monetises none of your activity.',
+  },
+  {
+    title: 'No remotely hosted code',
+    detail:
+      'All executable logic ships inside the reviewed extension package. Nothing is fetched and run from a remote server at runtime.',
+  },
+] as const
+
 const integrationEndpoints = [
   extensionLinks.signIn,
   extensionLinks.session,
@@ -65,10 +88,64 @@ export default function BrowserExtensionSupportPage() {
           <div className="mx-auto max-w-4xl text-center">
             <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Browser extension support</p>
             <h1 className="mt-4 font-heading text-4xl font-bold md:text-6xl">
-              Public support reference for NeutralAI Interceptor
+              Public support reference for the NeutralAI browser extension
             </h1>
             <p className="mt-6 text-xl text-slate-400">
               This is the canonical support page for browser store review, self-serve installs, and enterprise rollout conversations. It explains the extension’s limited purpose, requested permissions, and the NeutralAI-owned app and API surfaces it interacts with.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container-custom">
+          <div className="card p-8 md:p-10">
+            <div className="flex items-center gap-3">
+              <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10">
+                <ShieldCheck className="h-6 w-6 text-primary" />
+              </div>
+              <div>
+                <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Data handling &amp; trust</p>
+                <h2 className="font-heading text-3xl font-bold">What this extension does not do</h2>
+              </div>
+            </div>
+            <p className="mt-6 max-w-3xl text-sm leading-6 text-slate-400">
+              In December 2025 several &ldquo;privacy&rdquo; browser extensions were found harvesting millions of users&rsquo;
+              AI chats. Because this extension attaches to the same AI chat pages, we state its data handling plainly and keep
+              it auditable — so users, IT administrators and store reviewers can verify we are not doing that.
+            </p>
+            <div className="mt-8 grid gap-4 md:grid-cols-2">
+              {dataHandlingCommitments.map((item) => (
+                <div key={item.title} className="rounded-2xl border border-border bg-background px-5 py-5">
+                  <h3 className="font-heading text-lg font-semibold">{item.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-400">{item.detail}</p>
+                </div>
+              ))}
+            </div>
+            <div className="mt-8 grid gap-4 md:grid-cols-2">
+              <div className="rounded-2xl border border-primary/20 bg-primary/10 px-5 py-5">
+                <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Local mode (default)</p>
+                <p className="mt-2 text-sm leading-6 text-slate-200">
+                  Detection and masking run entirely in your browser. Nothing is sent to NeutralAI servers.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-border bg-background px-5 py-5">
+                <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Managed mode (signed in)</p>
+                <p className="mt-2 text-sm leading-6 text-slate-400">
+                  Prompt text is sent over TLS to the NeutralAI gateway for stronger server-side detection and the masked
+                  result is returned. Reversible mask tokens live in an encrypted vault (AES-256-GCM) with a 15-minute TTL,
+                  then are destroyed. The audit log records the <em>entities masked</em>, not your full prompt text.
+                </p>
+              </div>
+            </div>
+            <p className="mt-6 text-sm text-slate-400">
+              The full data-handling dossier ships with the extension source as{' '}
+              <span className="font-mono text-slate-300">browser-extension/SECURITY.md</span>, and vulnerabilities can be
+              reported via{' '}
+              <a href={siteConfig.securityTxtPath} className="text-primary-light hover:text-primary">
+                /.well-known/security.txt
+              </a>
+              .
             </p>
           </div>
         </div>
@@ -154,7 +231,7 @@ export default function BrowserExtensionSupportPage() {
               <h2 className="mt-4 font-heading text-3xl font-bold">Policy-managed deployment</h2>
               <div className="mt-4 space-y-4 text-sm leading-6 text-slate-400">
                 <p>
-                  Enterprise customers can deploy NeutralAI Interceptor with managed browser policies so the extension is force-installed, pinned, and locked to organization-controlled NeutralAI endpoints.
+                  Enterprise customers can deploy the NeutralAI browser extension with managed browser policies so the extension is force-installed, pinned, and locked to organization-controlled NeutralAI endpoints.
                 </p>
                 <p>
                   That rollout path is separate from self-serve sign-in and is the recommended approach for regulated teams or centrally managed browser fleets.

--- a/app/support/browser-extension/page.tsx
+++ b/app/support/browser-extension/page.tsx
@@ -49,12 +49,12 @@ const dataHandlingCommitments = [
   {
     title: 'No conversation collection',
     detail:
-      'We do not collect, store, sell or share your conversations. Prompt text is processed to find and mask PII, then discarded.',
+      'We never sell, share, or retain your conversations, and we run no analytics or model training on them. Prompt text is used only to detect and mask PII — in local mode without leaving your browser, in managed mode via the gateway masking call described below — then discarded.',
   },
   {
     title: 'No browsing-history harvesting',
     detail:
-      'Content scripts run only on the supported AI chat sites listed in the manifest — nowhere else. The extension has no visibility into the rest of your browsing.',
+      'Content scripts run only on the supported AI chat sites listed in the manifest — nowhere else. The extension does not read, collect, or transmit the content of your other tabs or general browsing.',
   },
   {
     title: 'No ads, trackers or affiliate links',
@@ -126,7 +126,9 @@ export default function BrowserExtensionSupportPage() {
               <div className="rounded-2xl border border-primary/20 bg-primary/10 px-5 py-5">
                 <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary-light">Local mode (default)</p>
                 <p className="mt-2 text-sm leading-6 text-slate-200">
-                  Detection and masking run entirely in your browser. Nothing is sent to NeutralAI servers.
+                  Detection and masking run entirely in your browser — your prompt text is never sent to NeutralAI
+                  servers. The extension still makes background calls for policy/config refresh and metadata telemetry,
+                  which never carry prompt content.
                 </p>
               </div>
               <div className="rounded-2xl border border-border bg-background px-5 py-5">
@@ -140,9 +142,10 @@ export default function BrowserExtensionSupportPage() {
               </div>
             </div>
             <p className="mt-6 text-sm text-slate-400">
-              The full data-handling dossier ships with the extension source as{' '}
-              <span className="font-mono text-slate-300">browser-extension/SECURITY.md</span>, and vulnerabilities can be
-              reported via{' '}
+              This page is the public statement of that posture; the same attestation ships inside the extension package
+              as{' '}
+              <span className="font-mono text-slate-300">SECURITY.md</span> for installed users and store reviewers.
+              Vulnerabilities can be reported via{' '}
               <a href={siteConfig.securityTxtPath} className="text-primary-light hover:text-primary">
                 /.well-known/security.txt
               </a>


### PR DESCRIPTION
Advances **gateway #1455** (GROWTH-EXT-01). The extension manifest was already renamed to a benefit-forward listing name, but the public website still carried the trust-negative **'NeutralAI Interceptor'** name that #1455 exists to remove — and the support page lacked the no-chat-harvesting attestation that is the whole point after the Dec-2025 Urban VPN scandal.

## Changes
- **Rename** 'NeutralAI Interceptor' → 'the NeutralAI browser extension' (prose) / 'NeutralAI PII Masking' (eyebrows) on `/privacy`, `/install-extension`, `/support/browser-extension`. **Store-listing URL slugs (`neutralai-interceptor`) left unchanged** — those are the live CWS/Edge URLs; changing them would break the links.
- **Add 'Data handling & trust'** section to `/support/browser-extension`, mirroring `browser-extension/SECURITY.md`: the Dec-2025 harvesting context, four explicit do-not commitments (no conversation collection, no browsing-history harvesting, no ads/trackers, no remote code), the local-vs-managed data-flow, and pointers to SECURITY.md + `/.well-known/security.txt`. This satisfies the ticket's 'SECURITY.md linked from … website' acceptance.

## Verification
- Live `next dev`: pages render; the new section is full-width (1176px), 6 cards, no horizontal overflow; hero H1 reads 'the NeutralAI browser extension'.
- `tsc --noEmit` clean; `eslint` clean on all three files.

## Out of scope (manual / user-owned)
Chrome Web Store display-name + screenshot upload and the 0.1.2+ store publish — those are store-console actions, not code.