### PR TITLE
fix(extension): Chrome store link → renamed listing slug (#1455)

### DIFF
--- a/app/site.ts
+++ b/app/site.ts
@@ -31,8 +31,14 @@ export const siteConfig = {
   supportEmail: 'support@neutralai.co.uk',
   salesEmail: 'sales@neutralai.co.uk',
   securityTxtPath: '/.well-known/security.txt',
+  // CWS resolves the listing by extension ID; the slug is cosmetic. The store
+  // display name was renamed (#1455), so the canonical slug is now
+  // `neutralai-pii-masking-for` — the old `neutralai-interceptor` URL still
+  // redirected, but it visibly carried the trust-negative name we removed.
   chromeExtensionUrl:
-    'https://chromewebstore.google.com/detail/neutralai-interceptor/gpdjigfhopjabaodmnombeoldieoobnh',
+    'https://chromewebstore.google.com/detail/neutralai-pii-masking-for/gpdjigfhopjabaodmnombeoldieoobnh',
+  // Edge listing is still in review; its slug hasn't been regenerated yet, so it
+  // stays on the old path until the renamed Edge listing goes live.
   edgeExtensionUrl:
     'https://microsoftedge.microsoft.com/addons/detail/neutralai-interceptor/agdhbinchoiapijeicfgdmkoekolefkg',
 } as const


### PR DESCRIPTION
The Chrome Web Store listing is now **live under the new name** (`NeutralAI PII Masking …`, v0.1.6), so its canonical slug changed `neutralai-interceptor` → `neutralai-pii-masking-for`.

CWS resolves by extension ID, so the old URL still 302-redirects (verified — not a 404), but the install link on the site visibly carried the trust-negative **'interceptor'** name that #1455 exists to remove. Point `chromeExtensionUrl` at the new slug so the link matches the new name end-to-end.

- **Edge unchanged:** still in review, slug not regenerated yet — left on the old path until the renamed Edge listing goes live.
- Verified the new URL returns 302 (resolves), same extension ID.

Relates to gateway #1455.